### PR TITLE
fix: update copyright license and fix failing checkstyle tasks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: 'junit-report'
-          path: ./driver-proxy/build/reports/tests/test/
+          path: ./wrapper/build/reports/tests/test/
           retention-days: 3
 
       - name: 'Archive Coverage Report'
@@ -47,7 +47,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: 'coverage-report'
-          path: ./driver-proxy/build/reports/jacoco/test/
+          path: ./wrapper/build/reports/jacoco/test/
           retention-days: 3
 
   aurora-postgres-integration-tests:
@@ -98,7 +98,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: 'junit-report'
-          path: ./driver-proxy/build/reports/tests/
+          path: ./wrapper/build/reports/tests/
           retention-days: 5
 
   standard-postgres-integration-tests:
@@ -125,5 +125,5 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: 'junit-report'
-          path: ./driver-proxy/build/reports/tests/
+          path: ./wrapper/build/reports/tests/
           retention-days: 5

--- a/config/checkstyle/amazon.header
+++ b/config/checkstyle/amazon.header
@@ -1,17 +1,15 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */

--- a/config/checkstyle/google_checks.xml
+++ b/config/checkstyle/google_checks.xml
@@ -16,7 +16,7 @@
     Authors: Max Vetrenko, Ruslan Diachenko, Roman Ivanov.
  -->
 
-<module name = "Checker">
+<module name="Checker">
     <property name="charset" value="UTF-8"/>
 
     <property name="severity" value="warning"/>
@@ -47,6 +47,11 @@
     </module>
 
     <module name="SuppressWarningsFilter"/>
+
+    <module name="Header">
+        <property name="headerFile" value="${config_loc}/amazon.header"/>
+        <property name="fileExtensions" value="java"/>
+    </module>
 
     <module name="TreeWalker">
         <module name="SuppressWarningsHolder"/>
@@ -261,14 +266,6 @@
             <property name="lineWrappingIndentation" value="4"/>
             <property name="arrayInitIndent" value="2"/>
         </module>
-<!--        <module name="AbbreviationAsWordInName">-->
-<!--            <property name="ignoreFinal" value="false"/>-->
-<!--            <property name="allowedAbbreviationLength" value="0"/>-->
-<!--            <property name="tokens"-->
-<!--                      value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, ANNOTATION_DEF, ANNOTATION_FIELD_DEF,-->
-<!--                    PARAMETER_DEF, VARIABLE_DEF, METHOD_DEF, PATTERN_VARIABLE_DEF, RECORD_DEF,-->
-<!--                    RECORD_COMPONENT_DEF"/>-->
-<!--        </module>-->
         <module name="NoWhitespaceBeforeCaseDefaultColon"/>
         <module name="OverloadMethodsDeclarationOrder"/>
         <module name="VariableDeclarationUsageDistance"/>
@@ -336,20 +333,6 @@
             <property name="allowedAnnotations" value="Override, Test"/>
             <property name="tokens" value="METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF"/>
         </module>
-<!--        <module name="MissingJavadocMethod">-->
-<!--            <property name="scope" value="public"/>-->
-<!--            <property name="minLineCount" value="2"/>-->
-<!--            <property name="allowedAnnotations" value="Override, Test"/>-->
-<!--            <property name="tokens" value="METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF,-->
-<!--                                   COMPACT_CTOR_DEF"/>-->
-<!--        </module>-->
-<!--        <module name="MissingJavadocType">-->
-<!--            <property name="scope" value="protected"/>-->
-<!--            <property name="tokens"-->
-<!--                      value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF,-->
-<!--                      RECORD_DEF, ANNOTATION_DEF"/>-->
-<!--            <property name="excludeScope" value="nothing"/>-->
-<!--        </module>-->
         <module name="MethodName">
             <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9_]*$"/>
             <message key="name.invalidPattern"
@@ -368,9 +351,5 @@
                       default="checkstyle-xpath-suppressions.xml" />
             <property name="optional" value="true"/>
         </module>
-    </module>
-    <module name="Header">
-        <property name="headerFile" value="config/checkstyle/amazon.header"/>
-        <property name="fileExtensions" value="java"/>
     </module>
 </module>

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/ConnectionPlugin.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/ConnectionPlugin.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/ConnectionPluginFactory.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/ConnectionPluginFactory.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/ConnectionPluginManager.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/ConnectionPluginManager.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/ConnectionPropertyNames.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/ConnectionPropertyNames.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/ConnectionProvider.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/ConnectionProvider.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/DataSourceConnectionProvider.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/DataSourceConnectionProvider.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/Driver.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/Driver.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/DriverConnectionProvider.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/DriverConnectionProvider.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/HostAvailability.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/HostAvailability.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/HostListProvider.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/HostListProvider.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/HostListProviderService.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/HostListProviderService.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/HostRole.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/HostRole.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/HostSpec.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/HostSpec.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/JdbcCallable.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/JdbcCallable.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/JdbcRunnable.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/JdbcRunnable.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/NodeChangeOptions.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/NodeChangeOptions.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/OldConnectionSuggestedAction.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/OldConnectionSuggestedAction.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/PluginManagerService.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/PluginManagerService.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/PluginService.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/PluginService.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/PluginServiceImpl.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/PluginServiceImpl.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/PropertyDefinition.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/PropertyDefinition.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/ProxyDriverProperty.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/ProxyDriverProperty.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/cleanup/CanReleaseResources.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/cleanup/CanReleaseResources.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.cleanup;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/ds/ProxyDriverDataSource.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/ds/ProxyDriverDataSource.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.ds;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/hostlistprovider/AuroraHostListProvider.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/hostlistprovider/AuroraHostListProvider.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.hostlistprovider;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/hostlistprovider/ConnectionStringHostListProvider.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/hostlistprovider/ConnectionStringHostListProvider.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.hostlistprovider;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/hostlistprovider/DynamicHostListProvider.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/hostlistprovider/DynamicHostListProvider.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.hostlistprovider;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/hostlistprovider/StaticHostListProvider.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/hostlistprovider/StaticHostListProvider.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.hostlistprovider;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/plugin/AbstractConnectionPlugin.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/plugin/AbstractConnectionPlugin.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.plugin;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/plugin/AuroraHostListConnectionPlugin.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/plugin/AuroraHostListConnectionPlugin.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.plugin;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/plugin/AuroraHostListConnectionPluginFactory.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/plugin/AuroraHostListConnectionPluginFactory.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.plugin;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/plugin/DataCacheConnectionPlugin.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/plugin/DataCacheConnectionPlugin.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.plugin;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/plugin/DataCacheConnectionPluginFactory.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/plugin/DataCacheConnectionPluginFactory.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.plugin;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/plugin/DefaultConnectionPlugin.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/plugin/DefaultConnectionPlugin.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.plugin;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/plugin/ExecutionTimeConnectionPlugin.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/plugin/ExecutionTimeConnectionPlugin.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.plugin;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/plugin/ExecutionTimeConnectionPluginFactory.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/plugin/ExecutionTimeConnectionPluginFactory.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.plugin;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/plugin/IamAuthConnectionPlugin.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/plugin/IamAuthConnectionPlugin.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.plugin;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/plugin/IamAuthConnectionPluginFactory.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/plugin/IamAuthConnectionPluginFactory.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.plugin;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/plugin/LogQueryConnectionPlugin.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/plugin/LogQueryConnectionPlugin.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.plugin;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/plugin/LogQueryConnectionPluginFactory.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/plugin/LogQueryConnectionPluginFactory.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.plugin;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/plugin/efm/ExecutorServiceInitializer.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/plugin/efm/ExecutorServiceInitializer.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.plugin.efm;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/plugin/efm/HostMonitoringConnectionPlugin.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/plugin/efm/HostMonitoringConnectionPlugin.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.plugin.efm;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/plugin/efm/HostMonitoringConnectionPluginFactory.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/plugin/efm/HostMonitoringConnectionPluginFactory.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.plugin.efm;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/plugin/efm/Monitor.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/plugin/efm/Monitor.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.plugin.efm;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/plugin/efm/MonitorConnectionContext.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/plugin/efm/MonitorConnectionContext.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.plugin.efm;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/plugin/efm/MonitorImpl.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/plugin/efm/MonitorImpl.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.plugin.efm;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/plugin/efm/MonitorInitializer.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/plugin/efm/MonitorInitializer.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.plugin.efm;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/plugin/efm/MonitorService.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/plugin/efm/MonitorService.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.plugin.efm;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/plugin/efm/MonitorServiceImpl.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/plugin/efm/MonitorServiceImpl.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.plugin.efm;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/plugin/efm/MonitorThreadContainer.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/plugin/efm/MonitorThreadContainer.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.plugin.efm;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/plugin/failover/ClusterAwareReaderFailoverHandler.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/plugin/failover/ClusterAwareReaderFailoverHandler.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.plugin.failover;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/plugin/failover/ClusterAwareWriterFailoverHandler.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/plugin/failover/ClusterAwareWriterFailoverHandler.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.plugin.failover;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/plugin/failover/FailoverConnectionPlugin.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/plugin/failover/FailoverConnectionPlugin.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.plugin.failover;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/plugin/failover/FailoverConnectionPluginFactory.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/plugin/failover/FailoverConnectionPluginFactory.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.plugin.failover;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/plugin/failover/ReaderFailoverHandler.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/plugin/failover/ReaderFailoverHandler.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.plugin.failover;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/plugin/failover/ReaderFailoverResult.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/plugin/failover/ReaderFailoverResult.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.plugin.failover;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/plugin/failover/WriterFailoverHandler.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/plugin/failover/WriterFailoverHandler.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.plugin.failover;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/plugin/failover/WriterFailoverResult.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/plugin/failover/WriterFailoverResult.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.plugin.failover;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/profile/DriverConfigurationProfiles.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/profile/DriverConfigurationProfiles.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.profile;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/util/ConnectionUrlBuilder.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/util/ConnectionUrlBuilder.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.util;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/util/ConnectionUrlParser.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/util/ConnectionUrlParser.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.util;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/util/ExpiringCache.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/util/ExpiringCache.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.util;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/util/Messages.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/util/Messages.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.util;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/util/PropertyUtils.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/util/PropertyUtils.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.util;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/util/RdsUrlType.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/util/RdsUrlType.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.util;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/util/RdsUtils.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/util/RdsUtils.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.util;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/util/SqlState.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/util/SqlState.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.util;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/util/StringUtils.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/util/StringUtils.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.util;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/util/Utils.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/util/Utils.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.util;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/util/WrapperUtils.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/util/WrapperUtils.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.util;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/wrapper/ArrayWrapper.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/wrapper/ArrayWrapper.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.wrapper;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/wrapper/BlobWrapper.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/wrapper/BlobWrapper.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.wrapper;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/wrapper/CallableStatementWrapper.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/wrapper/CallableStatementWrapper.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.wrapper;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/wrapper/ClobWrapper.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/wrapper/ClobWrapper.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.wrapper;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/wrapper/ConnectionWrapper.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/wrapper/ConnectionWrapper.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.wrapper;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/wrapper/DatabaseMetaDataWrapper.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/wrapper/DatabaseMetaDataWrapper.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.wrapper;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/wrapper/NClobWrapper.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/wrapper/NClobWrapper.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.wrapper;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/wrapper/ParameterMetaDataWrapper.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/wrapper/ParameterMetaDataWrapper.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.wrapper;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/wrapper/PreparedStatementWrapper.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/wrapper/PreparedStatementWrapper.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.wrapper;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/wrapper/RefWrapper.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/wrapper/RefWrapper.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.wrapper;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/wrapper/ResultSetMetaDataWrapper.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/wrapper/ResultSetMetaDataWrapper.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.wrapper;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/wrapper/ResultSetWrapper.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/wrapper/ResultSetWrapper.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.wrapper;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/wrapper/SQLDataWrapper.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/wrapper/SQLDataWrapper.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.wrapper;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/wrapper/SQLInputWrapper.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/wrapper/SQLInputWrapper.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.wrapper;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/wrapper/SQLOutputWrapper.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/wrapper/SQLOutputWrapper.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.wrapper;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/wrapper/SQLTypeWrapper.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/wrapper/SQLTypeWrapper.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.wrapper;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/wrapper/SavepointWrapper.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/wrapper/SavepointWrapper.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.wrapper;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/wrapper/StatementWrapper.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/wrapper/StatementWrapper.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.wrapper;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/wrapper/StructWrapper.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/wrapper/StructWrapper.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.wrapper;

--- a/wrapper/src/main/resources/messages.properties
+++ b/wrapper/src/main/resources/messages.properties
@@ -1,16 +1,18 @@
-#    Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# 
-#    Licensed under the Apache License, Version 2.0 (the "License").
-#    You may not use this file except in compliance with the License.
-#    You may obtain a copy of the License at
-# 
-#    http://www.apache.org/licenses/LICENSE-2.0
-# 
-#    Unless required by applicable law or agreed to in writing, software
-#    distributed under the License is distributed on an "AS IS" BASIS,
-#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#    See the License for the specific language governing permissions and
-#    limitations under the License.
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 # Failover Connection Plugin
 Failover.transactionResolutionUnknownError=Transaction resolution unknown. Please re-configure session state if required and try restarting the transaction.

--- a/wrapper/src/main/version/com/amazon/awslabs/jdbc/util/DriverInfo.java
+++ b/wrapper/src/main/version/com/amazon/awslabs/jdbc/util/DriverInfo.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.util;

--- a/wrapper/src/test/config/standard-mysql-grant-root.sql
+++ b/wrapper/src/test/config/standard-mysql-grant-root.sql
@@ -1,1 +1,17 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 GRANT PROXY ON ''@'' TO 'root'@'%' WITH GRANT OPTION;

--- a/wrapper/src/test/java/com/amazon/awslabs/jdbc/ConnectionPluginManagerTests.java
+++ b/wrapper/src/test/java/com/amazon/awslabs/jdbc/ConnectionPluginManagerTests.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc;

--- a/wrapper/src/test/java/com/amazon/awslabs/jdbc/PluginServiceImplTests.java
+++ b/wrapper/src/test/java/com/amazon/awslabs/jdbc/PluginServiceImplTests.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc;

--- a/wrapper/src/test/java/com/amazon/awslabs/jdbc/hostlistprovider/AuroraHostListProviderTest.java
+++ b/wrapper/src/test/java/com/amazon/awslabs/jdbc/hostlistprovider/AuroraHostListProviderTest.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.hostlistprovider;

--- a/wrapper/src/test/java/com/amazon/awslabs/jdbc/mock/TestPluginOne.java
+++ b/wrapper/src/test/java/com/amazon/awslabs/jdbc/mock/TestPluginOne.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.mock;

--- a/wrapper/src/test/java/com/amazon/awslabs/jdbc/mock/TestPluginThree.java
+++ b/wrapper/src/test/java/com/amazon/awslabs/jdbc/mock/TestPluginThree.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.mock;

--- a/wrapper/src/test/java/com/amazon/awslabs/jdbc/mock/TestPluginThrowException.java
+++ b/wrapper/src/test/java/com/amazon/awslabs/jdbc/mock/TestPluginThrowException.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.mock;

--- a/wrapper/src/test/java/com/amazon/awslabs/jdbc/mock/TestPluginTwo.java
+++ b/wrapper/src/test/java/com/amazon/awslabs/jdbc/mock/TestPluginTwo.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.mock;

--- a/wrapper/src/test/java/com/amazon/awslabs/jdbc/plugin/DefaultConnectionPluginTest.java
+++ b/wrapper/src/test/java/com/amazon/awslabs/jdbc/plugin/DefaultConnectionPluginTest.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.plugin;

--- a/wrapper/src/test/java/com/amazon/awslabs/jdbc/plugin/IamAuthConnectionPluginTest.java
+++ b/wrapper/src/test/java/com/amazon/awslabs/jdbc/plugin/IamAuthConnectionPluginTest.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.plugin;

--- a/wrapper/src/test/java/com/amazon/awslabs/jdbc/plugin/efm/HostMonitoringConnectionPluginTest.java
+++ b/wrapper/src/test/java/com/amazon/awslabs/jdbc/plugin/efm/HostMonitoringConnectionPluginTest.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.plugin.efm;

--- a/wrapper/src/test/java/com/amazon/awslabs/jdbc/plugin/efm/MonitorConnectionContextTest.java
+++ b/wrapper/src/test/java/com/amazon/awslabs/jdbc/plugin/efm/MonitorConnectionContextTest.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.plugin.efm;

--- a/wrapper/src/test/java/com/amazon/awslabs/jdbc/plugin/efm/MonitorImplTest.java
+++ b/wrapper/src/test/java/com/amazon/awslabs/jdbc/plugin/efm/MonitorImplTest.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.plugin.efm;

--- a/wrapper/src/test/java/com/amazon/awslabs/jdbc/plugin/efm/MonitorServiceImplTest.java
+++ b/wrapper/src/test/java/com/amazon/awslabs/jdbc/plugin/efm/MonitorServiceImplTest.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.plugin.efm;

--- a/wrapper/src/test/java/com/amazon/awslabs/jdbc/plugin/efm/MultiThreadedDefaultMonitorServiceTest.java
+++ b/wrapper/src/test/java/com/amazon/awslabs/jdbc/plugin/efm/MultiThreadedDefaultMonitorServiceTest.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.plugin.efm;

--- a/wrapper/src/test/java/com/amazon/awslabs/jdbc/plugin/failover/ClusterAwareReaderFailoverHandlerTest.java
+++ b/wrapper/src/test/java/com/amazon/awslabs/jdbc/plugin/failover/ClusterAwareReaderFailoverHandlerTest.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.plugin.failover;

--- a/wrapper/src/test/java/com/amazon/awslabs/jdbc/plugin/failover/ClusterAwareWriterFailoverHandlerTest.java
+++ b/wrapper/src/test/java/com/amazon/awslabs/jdbc/plugin/failover/ClusterAwareWriterFailoverHandlerTest.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.plugin.failover;

--- a/wrapper/src/test/java/com/amazon/awslabs/jdbc/plugin/failover/FailoverConnectionPluginTest.java
+++ b/wrapper/src/test/java/com/amazon/awslabs/jdbc/plugin/failover/FailoverConnectionPluginTest.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.plugin.failover;

--- a/wrapper/src/test/java/com/amazon/awslabs/jdbc/util/ConnectionUrlParserTest.java
+++ b/wrapper/src/test/java/com/amazon/awslabs/jdbc/util/ConnectionUrlParserTest.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.util;

--- a/wrapper/src/test/java/com/amazon/awslabs/jdbc/util/WrapperUtilsTest.java
+++ b/wrapper/src/test/java/com/amazon/awslabs/jdbc/util/WrapperUtilsTest.java
@@ -1,19 +1,17 @@
 /*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *     Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     Licensed under the Apache License, Version 2.0 (the "License").
- *     You may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.amazon.awslabs.jdbc.util;

--- a/wrapper/src/test/resources/logging-test.properties
+++ b/wrapper/src/test/resources/logging-test.properties
@@ -1,16 +1,18 @@
-#    Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#    Licensed under the Apache License, Version 2.0 (the "License").
 #
-#    You may not use this file except in compliance with the License.
-#    You may obtain a copy of the License at
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-#    Unless required by applicable law or agreed to in writing, software
-#    distributed under the License is distributed on an "AS IS" BASIS,
-#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#    See the License for the specific language governing permissions and
-#    limitations under the License.
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 # Possible values for log level (from most detailed to less detailed): FINEST, FINER, FINE, CONFIG, INFO, WARNING, SEVERE
 .level=INFO

--- a/wrapper/src/test/resources/simplelogger.properties
+++ b/wrapper/src/test/resources/simplelogger.properties
@@ -1,16 +1,18 @@
-#    Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#    Licensed under the Apache License, Version 2.0 (the "License").
 #
-#    You may not use this file except in compliance with the License.
-#    You may obtain a copy of the License at
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-#    Unless required by applicable law or agreed to in writing, software
-#    distributed under the License is distributed on an "AS IS" BASIS,
-#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#    See the License for the specific language governing permissions and
-#    limitations under the License.
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 # Default logging detail level for all instances of SimpleLogger.
 # Must be one of ("trace", "debug", "info", "warn", or "error").


### PR DESCRIPTION
### Summary

fix: update copyright license and fix failing checkstyle tasks

### Description

- fix checkstyle plugin unable to find the license header
- fix files violating license headers

### Additional Reviewers

<!-- Any additional reviewers -->