### PR TITLE
add china region support

### DIFF
--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/hostlistprovider/AuroraHostListProvider.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/hostlistprovider/AuroraHostListProvider.java
@@ -21,7 +21,6 @@ import com.amazon.awslabs.jdbc.HostListProvider;
 import com.amazon.awslabs.jdbc.HostRole;
 import com.amazon.awslabs.jdbc.HostSpec;
 import com.amazon.awslabs.jdbc.PluginService;
-import com.amazon.awslabs.jdbc.PropertyDefinition;
 import com.amazon.awslabs.jdbc.ProxyDriverProperty;
 import com.amazon.awslabs.jdbc.util.ExpiringCache;
 import com.amazon.awslabs.jdbc.util.Messages;

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/util/RdsUtils.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/util/RdsUtils.java
@@ -21,31 +21,59 @@ import java.util.regex.Pattern;
 
 public class RdsUtils {
 
-  public static final Pattern AURORA_DNS_PATTERN =
+  private static final Pattern AURORA_DNS_PATTERN =
       Pattern.compile(
           "(?<instance>.+)\\."
               + "(?<dns>proxy-|cluster-|cluster-ro-|cluster-custom-)?"
-              + "(?<domain>[a-zA-Z0-9]+\\.[a-zA-Z0-9\\-]+\\.rds\\.amazonaws\\.com)",
+              + "(?<domain>[a-zA-Z0-9]+\\.(?<region>[a-zA-Z0-9\\-]+)\\.rds\\.amazonaws\\.com)",
           Pattern.CASE_INSENSITIVE);
 
   private static final Pattern AURORA_CLUSTER_PATTERN =
       Pattern.compile(
           "(?<instance>.+)\\."
               + "(?<dns>cluster-|cluster-ro-)+"
-              + "(?<domain>[a-zA-Z0-9]+\\.[a-zA-Z0-9\\-]+\\.rds\\.amazonaws\\.com)",
+              + "(?<domain>[a-zA-Z0-9]+\\.(?<region>[a-zA-Z0-9\\-]+)\\.rds\\.amazonaws\\.com)",
           Pattern.CASE_INSENSITIVE);
   private static final Pattern AURORA_CUSTOM_CLUSTER_PATTERN =
       Pattern.compile(
           "(?<instance>.+)\\."
               + "(?<dns>cluster-custom-)+"
-              + "(?<domain>[a-zA-Z0-9]+\\.[a-zA-Z0-9\\-]+\\.rds\\.amazonaws\\.com)",
+              + "(?<domain>[a-zA-Z0-9]+\\.(?<region>[a-zA-Z0-9\\-]+)\\.rds\\.amazonaws\\.com)",
           Pattern.CASE_INSENSITIVE);
+
   private static final Pattern AURORA_PROXY_DNS_PATTERN =
       Pattern.compile(
           "(?<instance>.+)\\."
               + "(?<dns>proxy-)+"
-              + "(?<domain>[a-zA-Z0-9]+\\.[a-zA-Z0-9\\-]+\\.rds\\.amazonaws\\.com)",
+              + "(?<domain>[a-zA-Z0-9]+\\.(?<region>[a-zA-Z0-9\\-]+)\\.rds\\.amazonaws\\.com)",
           Pattern.CASE_INSENSITIVE);
+
+  private static final Pattern AURORA_CHINA_DNS_PATTERN =
+      Pattern.compile(
+          "(?<instance>.+)\\."
+              + "(?<dns>proxy-|cluster-|cluster-ro-|cluster-custom-)?"
+              + "(?<domain>[a-zA-Z0-9]+\\.rds\\.(?<region>[a-zA-Z0-9\\-]+)\\.amazonaws\\.com\\.cn)",
+          Pattern.CASE_INSENSITIVE);
+
+  private static final Pattern AURORA_CHINA_CLUSTER_PATTERN =
+      Pattern.compile(
+          "(?<instance>.+)\\."
+              + "(?<dns>cluster-|cluster-ro-)+"
+              + "(?<domain>[a-zA-Z0-9]+\\.rds\\.(?<region>[a-zA-Z0-9\\-]+)\\.amazonaws\\.com\\.cn)",
+          Pattern.CASE_INSENSITIVE);
+  private static final Pattern AURORA_CHINA_CUSTOM_CLUSTER_PATTERN =
+      Pattern.compile(
+          "(?<instance>.+)\\."
+              + "(?<dns>cluster-custom-)+"
+              + "(?<domain>[a-zA-Z0-9]+\\.rds\\.(?<region>[a-zA-Z0-9\\-]+)\\.amazonaws\\.com\\.cn)",
+          Pattern.CASE_INSENSITIVE);
+  private static final Pattern AURORA_CHINA_PROXY_DNS_PATTERN =
+      Pattern.compile(
+          "(?<instance>.+)\\."
+              + "(?<dns>proxy-)+"
+              + "(?<domain>[a-zA-Z0-9]+\\.rds\\.(?<region>[a-zA-Z0-9\\-])+\\.amazonaws\\.com\\.cn)",
+          Pattern.CASE_INSENSITIVE);
+
   private static final Pattern IP_V4 =
       Pattern.compile(
           "^(([1-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){1}"
@@ -58,17 +86,22 @@ public class RdsUtils {
               + "::(([0-9A-Fa-f]{1,4}(:[0-9A-Fa-f]{1,4}){0,5})?)$");
   private static final String DNS_GROUP = "dns";
   private static final String DOMAIN_GROUP = "domain";
+  private static final String REGION_GROUP = "region";
 
   public boolean isRdsClusterDns(String host) {
-    return !StringUtils.isNullOrEmpty(host) && AURORA_CLUSTER_PATTERN.matcher(host).find();
+    return !StringUtils.isNullOrEmpty(host)
+        && (AURORA_CLUSTER_PATTERN.matcher(host).find() || AURORA_CHINA_CLUSTER_PATTERN.matcher(host).find());
   }
 
   public boolean isRdsCustomClusterDns(String host) {
-    return !StringUtils.isNullOrEmpty(host) && AURORA_CUSTOM_CLUSTER_PATTERN.matcher(host).find();
+    return !StringUtils.isNullOrEmpty(host)
+        && (AURORA_CUSTOM_CLUSTER_PATTERN.matcher(host).find()
+            || AURORA_CHINA_CUSTOM_CLUSTER_PATTERN.matcher(host).find());
   }
 
   public boolean isRdsDns(String host) {
-    return !StringUtils.isNullOrEmpty(host) && AURORA_DNS_PATTERN.matcher(host).find();
+    return !StringUtils.isNullOrEmpty(host)
+        && (AURORA_DNS_PATTERN.matcher(host).find() || AURORA_CHINA_DNS_PATTERN.matcher(host).find());
   }
 
   public boolean isRdsProxyDns(String host) {
@@ -76,7 +109,7 @@ public class RdsUtils {
       return false;
 
     }
-    return AURORA_PROXY_DNS_PATTERN.matcher(host).find();
+    return AURORA_PROXY_DNS_PATTERN.matcher(host).find() || AURORA_CHINA_PROXY_DNS_PATTERN.matcher(host).find();
   }
 
   public String getRdsInstanceHostPattern(String host) {
@@ -88,10 +121,30 @@ public class RdsUtils {
     if (matcher.find()) {
       return "?." + matcher.group(DOMAIN_GROUP);
     }
+    Matcher chinaMatcher = AURORA_CHINA_DNS_PATTERN.matcher(host);
+    if (chinaMatcher.find()) {
+      return "?." + chinaMatcher.group(DOMAIN_GROUP);
+    }
     return "?";
   }
 
-  private boolean isWriterClusterDns(String host) {
+  public String getRdsRegion(String host) {
+    if (StringUtils.isNullOrEmpty(host)) {
+      return null;
+    }
+
+    Matcher matcher = AURORA_DNS_PATTERN.matcher(host);
+    if (matcher.find()) {
+      return matcher.group(REGION_GROUP);
+    }
+    Matcher chinaMatcher = AURORA_CHINA_DNS_PATTERN.matcher(host);
+    if (chinaMatcher.find()) {
+      return chinaMatcher.group(REGION_GROUP);
+    }
+    return null;
+  }
+
+  public boolean isWriterClusterDns(String host) {
     if (StringUtils.isNullOrEmpty(host)) {
       return false;
     }
@@ -99,6 +152,10 @@ public class RdsUtils {
     final Matcher matcher = AURORA_CLUSTER_PATTERN.matcher(host);
     if (matcher.find()) {
       return "cluster-".equalsIgnoreCase(matcher.group(DNS_GROUP));
+    }
+    final Matcher chinaMatcher = AURORA_CHINA_CLUSTER_PATTERN.matcher(host);
+    if (chinaMatcher.find()) {
+      return "cluster-".equalsIgnoreCase(chinaMatcher.group(DNS_GROUP));
     }
     return false;
   }
@@ -112,6 +169,10 @@ public class RdsUtils {
     if (matcher.find()) {
       return "cluster-ro-".equalsIgnoreCase(matcher.group(DNS_GROUP));
     }
+    final Matcher chinaMatcher = AURORA_CHINA_CLUSTER_PATTERN.matcher(host);
+    if (chinaMatcher.find()) {
+      return "cluster-ro-".equalsIgnoreCase(chinaMatcher.group(DNS_GROUP));
+    }
     return false;
   }
 
@@ -123,6 +184,10 @@ public class RdsUtils {
     Matcher matcher = AURORA_CLUSTER_PATTERN.matcher(host);
     if (matcher.find()) {
       return host.replaceAll(AURORA_CLUSTER_PATTERN.pattern(), "${instance}.cluster-${domain}");
+    }
+    Matcher chinaMatcher = AURORA_CHINA_CLUSTER_PATTERN.matcher(host);
+    if (chinaMatcher.find()) {
+      return host.replaceAll(AURORA_CHINA_CLUSTER_PATTERN.pattern(), "${instance}.cluster-${domain}");
     }
     return null;
   }

--- a/wrapper/src/test/java/com/amazon/awslabs/jdbc/util/RdsUtilsTests.java
+++ b/wrapper/src/test/java/com/amazon/awslabs/jdbc/util/RdsUtilsTests.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.amazon.awslabs.jdbc.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class RdsUtilsTests {
+
+  private static final String usEastRegionCluster =
+      "database-test-name.cluster-XYZ.us-east-2.rds.amazonaws.com";
+  private static final String usEastRegionClusterReadOnly =
+      "database-test-name.cluster-ro-XYZ.us-east-2.rds.amazonaws.com";
+  private static final String usEastRegionInstance =
+      "instance-test-name.XYZ.us-east-2.rds.amazonaws.com";
+  private static final String usEastRegionProxy =
+      "proxy-test-name.proxy-XYZ.us-east-2.rds.amazonaws.com";
+  private static final String usEastRegionCustomDomain =
+      "custom-test-name.cluster-custom-XYZ.us-east-2.rds.amazonaws.com";
+
+  private static final String chinaRegionCluster =
+      "database-test-name.cluster-XYZ.rds.cn-northwest-1.amazonaws.com.cn";
+  private static final String chinaRegionClusterReadOnly =
+      "database-test-name.cluster-ro-XYZ.rds.cn-northwest-1.amazonaws.com.cn";
+  private static final String chinaRegionInstance =
+      "instance-test-name.XYZ.rds.cn-northwest-1.amazonaws.com.cn";
+  private static final String chinaRegionProxy =
+      "proxy-test-name.proxy-XYZ.rds.cn-northwest-1.amazonaws.com.cn";
+  private static final String chinaRegionCustomDomain =
+      "custom-test-name.cluster-custom-XYZ.rds.cn-northwest-1.amazonaws.com.cn";
+
+  @Test
+  public void testIsRdsDns() {
+    RdsUtils target = new RdsUtils();
+
+    assertTrue(target.isRdsDns(usEastRegionCluster));
+    assertTrue(target.isRdsDns(usEastRegionClusterReadOnly));
+    assertTrue(target.isRdsDns(usEastRegionInstance));
+    assertTrue(target.isRdsDns(usEastRegionProxy));
+    assertTrue(target.isRdsDns(usEastRegionCustomDomain));
+
+    assertTrue(target.isRdsDns(chinaRegionCluster));
+    assertTrue(target.isRdsDns(chinaRegionClusterReadOnly));
+    assertTrue(target.isRdsDns(chinaRegionInstance));
+    assertTrue(target.isRdsDns(chinaRegionProxy));
+    assertTrue(target.isRdsDns(chinaRegionCustomDomain));
+  }
+
+  @Test
+  public void testGetRdsInstanceHostPattern() {
+    RdsUtils target = new RdsUtils();
+
+    final String expectedHostPattern = "?.XYZ.us-east-2.rds.amazonaws.com";
+    assertEquals(expectedHostPattern, target.getRdsInstanceHostPattern(usEastRegionCluster));
+    assertEquals(expectedHostPattern, target.getRdsInstanceHostPattern(usEastRegionClusterReadOnly));
+    assertEquals(expectedHostPattern, target.getRdsInstanceHostPattern(usEastRegionInstance));
+    assertEquals(expectedHostPattern, target.getRdsInstanceHostPattern(usEastRegionProxy));
+    assertEquals(expectedHostPattern, target.getRdsInstanceHostPattern(usEastRegionCustomDomain));
+
+    final String chinaExpectedHostPattern = "?.XYZ.rds.cn-northwest-1.amazonaws.com.cn";
+    assertEquals(chinaExpectedHostPattern, target.getRdsInstanceHostPattern(chinaRegionCluster));
+    assertEquals(chinaExpectedHostPattern, target.getRdsInstanceHostPattern(chinaRegionClusterReadOnly));
+    assertEquals(chinaExpectedHostPattern, target.getRdsInstanceHostPattern(chinaRegionInstance));
+    assertEquals(chinaExpectedHostPattern, target.getRdsInstanceHostPattern(chinaRegionProxy));
+    assertEquals(chinaExpectedHostPattern, target.getRdsInstanceHostPattern(chinaRegionCustomDomain));
+  }
+
+  @Test
+  public void testIsRdsClusterDns() {
+    RdsUtils target = new RdsUtils();
+
+    assertTrue(target.isRdsClusterDns(usEastRegionCluster));
+    assertTrue(target.isRdsClusterDns(usEastRegionClusterReadOnly));
+    assertFalse(target.isRdsClusterDns(usEastRegionInstance));
+    assertFalse(target.isRdsClusterDns(usEastRegionProxy));
+    assertFalse(target.isRdsClusterDns(usEastRegionCustomDomain));
+
+    assertTrue(target.isRdsClusterDns(chinaRegionCluster));
+    assertTrue(target.isRdsClusterDns(chinaRegionClusterReadOnly));
+    assertFalse(target.isRdsClusterDns(chinaRegionInstance));
+    assertFalse(target.isRdsClusterDns(chinaRegionProxy));
+    assertFalse(target.isRdsClusterDns(chinaRegionCustomDomain));
+  }
+
+  @Test
+  public void testIsWriterClusterDns() {
+    RdsUtils target = new RdsUtils();
+
+    assertTrue(target.isWriterClusterDns(usEastRegionCluster));
+    assertFalse(target.isWriterClusterDns(usEastRegionClusterReadOnly));
+    assertFalse(target.isWriterClusterDns(usEastRegionInstance));
+    assertFalse(target.isWriterClusterDns(usEastRegionProxy));
+    assertFalse(target.isWriterClusterDns(usEastRegionCustomDomain));
+
+    assertTrue(target.isWriterClusterDns(chinaRegionCluster));
+    assertFalse(target.isWriterClusterDns(chinaRegionClusterReadOnly));
+    assertFalse(target.isWriterClusterDns(chinaRegionInstance));
+    assertFalse(target.isWriterClusterDns(chinaRegionProxy));
+    assertFalse(target.isWriterClusterDns(chinaRegionCustomDomain));
+  }
+
+  @Test
+  public void testIsReaderClusterDns() {
+    RdsUtils target = new RdsUtils();
+
+    assertFalse(target.isReaderClusterDns(usEastRegionCluster));
+    assertTrue(target.isReaderClusterDns(usEastRegionClusterReadOnly));
+    assertFalse(target.isReaderClusterDns(usEastRegionInstance));
+    assertFalse(target.isReaderClusterDns(usEastRegionProxy));
+    assertFalse(target.isReaderClusterDns(usEastRegionCustomDomain));
+
+    assertFalse(target.isReaderClusterDns(chinaRegionCluster));
+    assertTrue(target.isReaderClusterDns(chinaRegionClusterReadOnly));
+    assertFalse(target.isReaderClusterDns(chinaRegionInstance));
+    assertFalse(target.isReaderClusterDns(chinaRegionProxy));
+    assertFalse(target.isReaderClusterDns(chinaRegionCustomDomain));
+  }
+
+  @Test
+  public void testGetRdsRegion() {
+    RdsUtils target = new RdsUtils();
+
+    final String expectedHostPattern = "us-east-2";
+    assertEquals(expectedHostPattern, target.getRdsRegion(usEastRegionCluster));
+    assertEquals(expectedHostPattern, target.getRdsRegion(usEastRegionClusterReadOnly));
+    assertEquals(expectedHostPattern, target.getRdsRegion(usEastRegionInstance));
+    assertEquals(expectedHostPattern, target.getRdsRegion(usEastRegionProxy));
+    assertEquals(expectedHostPattern, target.getRdsRegion(usEastRegionCustomDomain));
+
+    final String chinaExpectedHostPattern = "cn-northwest-1";
+    assertEquals(chinaExpectedHostPattern, target.getRdsRegion(chinaRegionCluster));
+    assertEquals(chinaExpectedHostPattern, target.getRdsRegion(chinaRegionClusterReadOnly));
+    assertEquals(chinaExpectedHostPattern, target.getRdsRegion(chinaRegionInstance));
+    assertEquals(chinaExpectedHostPattern, target.getRdsRegion(chinaRegionProxy));
+    assertEquals(chinaExpectedHostPattern, target.getRdsRegion(chinaRegionCustomDomain));
+  }
+}


### PR DESCRIPTION
### Summary

Add AWS China region support

### Description

Since AWS China regions has different domain name structure, RdsUtility class has been adjusted accordingly.
Example of AWS China region domain name:
<db-cluster-name>.cluster-<client-id>.rds.<region-name>.amazonaws.com.cn
database-test-name.cluster-XYZ.rds.cn-northwest-1.amazonaws.com.cn

### Additional Reviewers

@karenc-bq 