### PR TITLE
Edits to README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ GitHub issues are intended for bug reports and feature requests. Keeping the lis
 When opening a new issue, please include a reproduction case and logs for the issue to help expedite the investigation process.
 
 ## How to Contribute
-1. Set up your environment by following the directions in the [Development Guide](docs/development-guide/DevelopmentGuide.md)
+1. Set up your environment by following the directions in the [Development Guide](docs/development-guide/DevelopmentGuide.md).
 2. To contribute, first make a fork of this project. 
 3. Make any changes on your fork. Make sure you are aware of the requirements for the project (e.g. do not require Java 7 if we are supporting Java 8 and higher).
 4. Create a pull request from your fork. 


### PR DESCRIPTION
### Summary

In this commit, I've tweaked capitalization and organization of the contents of the README.md file for JDBC wrapper.

### Description

In this commit, I've tweaked capitalization/punctuation and arrangement of the README.md file for the JDBC wrapper; similar content is broken into similar heading sections, link to the Logging section is moved out of Getting Help (into its own section), proper names of pages and sections are capitalized.

### Additional Reviewers

<!-- Any additional reviewers -->