### PR TITLE
fix: change init function's visibility in WrapperUtilsTest

### DIFF
--- a/wrapper/src/test/java/com/amazon/awslabs/jdbc/util/WrapperUtilsTest.java
+++ b/wrapper/src/test/java/com/amazon/awslabs/jdbc/util/WrapperUtilsTest.java
@@ -41,7 +41,7 @@ public class WrapperUtilsTest {
 
   @BeforeEach
   @SuppressWarnings("unchecked")
-  private void init() {
+  void init() {
     final ReentrantLock pluginManagerLock = new ReentrantLock();
     final ReentrantLock testLock = new ReentrantLock();
     closeable = MockitoAnnotations.openMocks(this);


### PR DESCRIPTION
### Summary

Junit 5.9 does not allow `BeforeEach` methods to be private

### Description

fix: change init function's visibility in WrapperUtilsTest from private to package private

### Additional Reviewers

@sergiyvamz 