### PR TITLE
Enable previously disabled tests

### DIFF
--- a/docs/using-the-jdbc-wrapper/sample-code/DataSourceSample.java
+++ b/docs/using-the-jdbc-wrapper/sample-code/DataSourceSample.java
@@ -38,7 +38,7 @@ public class DataSourceSample {
     ds.setServerPropertyName("serverName");
     ds.setPortPropertyName("port");
 
-    // Specify ther driver-specific data source:
+    // Specify the driver-specific data source:
     ds.setTargetDataSourceClassName("org.postgresql.ds.PGSimpleDataSource");
 
     // Configure the driver-specific data source:

--- a/wrapper/src/main/java/com/amazon/awslabs/jdbc/plugin/efm/HostMonitoringConnectionPlugin.java
+++ b/wrapper/src/main/java/com/amazon/awslabs/jdbc/plugin/efm/HostMonitoringConnectionPlugin.java
@@ -108,6 +108,11 @@ public class HostMonitoringConnectionPlugin extends AbstractConnectionPlugin
       final @NonNull PluginService pluginService,
       final @NonNull Properties properties,
       final @NonNull Supplier<MonitorService> monitorServiceSupplier) {
+    if (pluginService == null) {
+      throw new IllegalArgumentException("pluginService");
+    } else if (properties == null) {
+      throw new IllegalArgumentException("properties");
+    }
 
     this.pluginService = pluginService;
     this.properties = properties;

--- a/wrapper/src/test/java/com/amazon/awslabs/jdbc/plugin/efm/HostMonitoringConnectionPluginTest.java
+++ b/wrapper/src/test/java/com/amazon/awslabs/jdbc/plugin/efm/HostMonitoringConnectionPluginTest.java
@@ -40,7 +40,6 @@ import java.util.function.Supplier;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -127,8 +126,6 @@ class HostMonitoringConnectionPluginTest {
 
   @ParameterizedTest
   @MethodSource("generateNullArguments")
-  @Disabled // TODO: Need to enforce @NonNull and @Nullable checks for entire project to pass this
-  // test
   void test_1_initWithNullArguments(
       final PluginService pluginService, final Properties properties) {
     assertThrows(

--- a/wrapper/src/test/java/integration/container/aurora/postgres/AuroraPostgresFailoverTest.java
+++ b/wrapper/src/test/java/integration/container/aurora/postgres/AuroraPostgresFailoverTest.java
@@ -298,13 +298,12 @@ public class AuroraPostgresFailoverTest extends AuroraPostgresBaseTest {
    * Writer connection failover within the connection pool.
    */
   @Test
-  @Disabled // TODO: enable test once datasource is supported
   public void test_pooledWriterConnection_BasicFailover() throws SQLException, InterruptedException {
 
     final String initialWriterId = instanceIDs[0];
     final String nominatedWriterId = instanceIDs[1];
 
-    try (final Connection conn = createPooledConnectionWithInstanceId(initialWriterId)) {
+    try (final Connection conn = createPooledConnectionWithFailoverUsingInstanceId(initialWriterId)) {
       // Crash writer Instance1 and nominate Instance2 as the new writer
       failoverClusterToATargetAndWaitUntilWriterChanged(initialWriterId, nominatedWriterId);
 

--- a/wrapper/src/test/java/integration/container/standard/mysql/HikariTests.java
+++ b/wrapper/src/test/java/integration/container/standard/mysql/HikariTests.java
@@ -18,13 +18,13 @@ package integration.container.standard.mysql;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.amazon.awslabs.jdbc.ds.AwsWrapperDataSource;
 import com.amazon.awslabs.jdbc.wrapper.ConnectionWrapper;
 import com.zaxxer.hikari.HikariDataSource;
 import com.zaxxer.hikari.pool.HikariProxyConnection;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Properties;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 public class HikariTests extends StandardMysqlBaseTest {
@@ -51,15 +51,27 @@ public class HikariTests extends StandardMysqlBaseTest {
   }
 
   @Test
-  @Disabled // TODO: check
   public void testOpenConnectionWithMysqlDataSourceClassName() throws SQLException {
 
     HikariDataSource ds = new HikariDataSource();
-    ds.setDataSourceClassName("com.amazon.awslabs.jdbc.ds.AwsWrapperDataSource");
+    ds.setDataSourceClassName(AwsWrapperDataSource.class.getName());
+
+    // Configure the connection pool:
     ds.setUsername(STANDARD_MYSQL_USERNAME);
     ds.setPassword(STANDARD_MYSQL_PASSWORD);
+
+    // Configure AwsWrapperDataSource:
+    ds.addDataSourceProperty("jdbcProtocol", "jdbc:mysql:");
+    ds.addDataSourceProperty("userPropertyName", "user");
+    ds.addDataSourceProperty("passwordPropertyName", "password");
+    ds.addDataSourceProperty("databasePropertyName", "databaseName");
+    ds.addDataSourceProperty("portPropertyName", "port");
+    ds.addDataSourceProperty("serverPropertyName", "serverName");
+
+    // Specify the driver-specific data source for AwsWrapperDataSource:
     ds.addDataSourceProperty("targetDataSourceClassName", "com.mysql.cj.jdbc.MysqlDataSource");
 
+    // Configuring MysqlDataSource:
     Properties targetDataSourceProps = new Properties();
     targetDataSourceProps.setProperty("serverName", STANDARD_MYSQL_HOST);
     targetDataSourceProps.setProperty("databaseName", STANDARD_MYSQL_DB);


### PR DESCRIPTION
### Summary

<!--- General summary / title -->
Enable previously disabled tests

### Description

<!--- Details of what you changed -->
- Enabled test_pooledWriterConnectionBasicFailover
- Enabled testOpenConnectionWithMysqlDataSourceClassName
- Enabled test_1_initWithNullArguments
- Added null checking for the Host Monitoring Connection Plugin constructor
- Fixed an error in the DataSource sample code

### Additional Reviewers

<!-- Any additional reviewers -->