### PR TITLE
Refactor failover plugin to only subscribe to network-bound JDBC calls

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/failover/FailoverConnectionPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/failover/FailoverConnectionPlugin.java
@@ -18,7 +18,6 @@ package software.amazon.jdbc.plugin.failover;
 
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashSet;
@@ -47,6 +46,7 @@ import software.amazon.jdbc.util.Messages;
 import software.amazon.jdbc.util.RdsUrlType;
 import software.amazon.jdbc.util.RdsUtils;
 import software.amazon.jdbc.util.SqlState;
+import software.amazon.jdbc.util.SubscribedMethodHelper;
 import software.amazon.jdbc.util.Utils;
 
 /**
@@ -56,37 +56,9 @@ import software.amazon.jdbc.util.Utils;
 public class FailoverConnectionPlugin extends AbstractConnectionPlugin {
 
   private static final Logger LOGGER = Logger.getLogger(FailoverConnectionPlugin.class.getName());
-  private static final List<String> pgNetworkMethods = Arrays.asList(
-      "initHostProvider",
-      "Connection.sendQueryCancel",
-      "Connection.connect",
-      "Connection.isValid",
-      "Connection.setReadOnly",
-      "Connection.setAutoCommit",
-      "Statement.executeQuery",
-      "Statement.executeUpdate",
-      "Statement.execute",
-      "Statement.executeWithFlags",
-      "Statement.executeLargeBatch",
-      "Statement.executeLargeUpdate",
-      "Statement.executeBatch",
-      "Statement.cancel",
-      "PreparedStatement.execute",
-      "PreparedStatement.executeQuery",
-      "PreparedStatement.executeUpdate",
-      "PreparedStatement.executeLargeUpdate",
-      "PreparedStatement.executeWithFlags",
-      "PreparedStatement.executeBatch",
-      "PreparedStatement.getParameterMetaData",
-      "CallableStatement.execute",
-      "CallableStatement.executeWithFlags",
-      "CallableStatement.executeQuery",
-      "CallableStatement.executeUpdate",
-      "CallableStatement.executeLargeUpdate"
-  );
 
   private static final Set<String> subscribedMethods =
-      Collections.unmodifiableSet(new HashSet<>(pgNetworkMethods));
+      Collections.unmodifiableSet(new HashSet<>(SubscribedMethodHelper.NETWORK_BOUND_METHODS));
 
   static final String METHOD_SET_READ_ONLY = "setReadOnly";
   static final String METHOD_SET_AUTO_COMMIT = "setAutoCommit";

--- a/wrapper/src/main/java/software/amazon/jdbc/util/SubscribedMethodHelper.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/SubscribedMethodHelper.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.jdbc.util;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class SubscribedMethodHelper {
+
+  public static final List<String> NETWORK_BOUND_METHODS = Arrays.asList(
+      "initHostProvider",
+      "Connection.sendQueryCancel",
+      "Connection.connect",
+      "Connection.isValid",
+      "Connection.setReadOnly",
+      "Connection.setAutoCommit",
+      "Statement.executeQuery",
+      "Statement.executeUpdate",
+      "Statement.execute",
+      "Statement.executeWithFlags",
+      "Statement.executeLargeBatch",
+      "Statement.executeLargeUpdate",
+      "Statement.executeBatch",
+      "Statement.cancel",
+      "PreparedStatement.execute",
+      "PreparedStatement.executeQuery",
+      "PreparedStatement.executeUpdate",
+      "PreparedStatement.executeLargeUpdate",
+      "PreparedStatement.executeWithFlags",
+      "PreparedStatement.executeBatch",
+      "PreparedStatement.getParameterMetaData",
+      "CallableStatement.execute",
+      "CallableStatement.executeWithFlags",
+      "CallableStatement.executeQuery",
+      "CallableStatement.executeUpdate",
+      "CallableStatement.executeLargeUpdate"
+  );
+}


### PR DESCRIPTION
### Summary

Refactor failover plugin to only subscribe to network-bound JDBC calls for Postgres

### Description

Failover connection plugin is currently subscribed to every method call, but it didn't need to be run on all method calls.


### Additional Reviewers
