### PR TITLE
fix: don't override cluster ID with null strings

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/AuroraHostListProvider.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/AuroraHostListProvider.java
@@ -139,9 +139,9 @@ public class AuroraHostListProvider implements HostListProvider, DynamicHostList
       // identification
       this.clusterId = this.pluginService.getCurrentHostSpec().getUrl();
     } else if (rdsUrlType.isRds()) {
-      this.clusterId = this.rdsHelper.getRdsClusterHostUrl(originalUrl);
-      if (!StringUtils.isNullOrEmpty(this.clusterId)) {
-        this.clusterId = this.clusterId + ":" + this.clusterInstanceTemplate.getPort();
+      final String clusterRdsHostUrl = this.rdsHelper.getRdsClusterHostUrl(originalUrl);
+      if (!StringUtils.isNullOrEmpty(clusterRdsHostUrl)) {
+        this.clusterId = clusterRdsHostUrl + ":" + this.clusterInstanceTemplate.getPort();
       }
     }
 


### PR DESCRIPTION
### Summary

Fix small bug that may set clusterID to null.

### Description

<!--- Details of what you changed -->

### Additional Reviewers

@sergiyvamz 