### PR TITLE
fix: copy all properties from the latest cache

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/AuroraHostListProvider.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/AuroraHostListProvider.java
@@ -332,6 +332,8 @@ public class AuroraHostListProvider implements HostListProvider, DynamicHostList
       clusterTopologyInfo = latestTopologyInfo;
     } else {
       clusterTopologyInfo.hosts = latestTopologyInfo.hosts;
+      clusterTopologyInfo.downHosts = latestTopologyInfo.downHosts;
+      clusterTopologyInfo.isMultiWriterCluster = latestTopologyInfo.isMultiWriterCluster;
     }
     clusterTopologyInfo.lastUpdated = Instant.now();
 


### PR DESCRIPTION
### Summary

Fix updateCache method not copying all required topology information

### Description

When updating cache we were missing some important topology information such as downHosts. This means the new cache will have outdated information of the topology, thinking some nodes are down when they are in fact available.

### Additional Reviewers

@sergiyvamz 