### PR TITLE
chore: fix typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [1.0.0] - 2022-08-23
 The Amazon Web Services (AWS) Advanced JDBC Wrapper allows an application to take advantage of the features of clustered Aurora databases.
 
-## Added
+### Added
 * Support for PostgreSQL
 * The [Failover Connection Plugin](./docs/using-the-jdbc-wrapper/using-plugins/UsingTheFailoverPlugin.md)
 * The [Host Monitoring Connection Plugin](./docs/using-the-jdbc-wrapper/using-plugins/UsingTheHostMonitoringPlugin.md)

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -12,7 +12,7 @@ If you are using the wrapper as part of a Gradle project, include the wrapper an
 
 ```gradle
 dependencies {
-    implementation group: 'software.amazon.jdbc.jdbc', name: 'aws-advanced-jdbc-wrapper', version: '1.0.0'
+    implementation group: 'software.amazon.jdbc', name: 'aws-advanced-jdbc-wrapper', version: '1.0.0'
     implementation group: 'org.postgresql', name: 'postgresql', version: '42.4.0'
 }
 ```


### PR DESCRIPTION
### Summary

chore: fix incorrect header level in changelog, fix typo in documentation

### Description

- fix incorrect group ID
- fix incorrect header level in changelog that causes GH workflow failing to parse it for releases
### Additional Reviewers

<!-- Any additional reviewers -->