### PR TITLE
optimize topology cache

### DIFF
--- a/wrapper/src/test/java/software/amazon/jdbc/hostlistprovider/AuroraHostListProviderTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/hostlistprovider/AuroraHostListProviderTest.java
@@ -433,7 +433,7 @@ class AuroraHostListProviderTest {
     assertTrue(provider2.isPrimaryClusterId);
     assertEquals(2, AuroraHostListProvider.topologyCache.size());
     assertEquals("cluster-a.cluster-xyz.us-east-2.rds.amazonaws.com/",
-        AuroraHostListProvider.topologyCache.get(provider1.clusterId).suggestedPrimaryCluster);
+        AuroraHostListProvider.topologyCache.get(provider1.clusterId).suggestedPrimaryClusterId);
 
     //AuroraHostListProvider.logCache();
 


### PR DESCRIPTION
### Summary

Optimize topology cache by suggesting a clusterId associated with cluster endpoint.

### Description

- Suggest primary clusterId to other topology cache entries
- Add locks to topology cache
- Add onEvict() callback for topology cache

### Additional Reviewers

@karenc-bq 
@congoamz 
