### PR TITLE
refactor: performance optimization for connection plugin manager

### DIFF
--- a/wrapper/src/test/java/software/amazon/jdbc/ConnectionPluginManagerTests.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/ConnectionPluginManagerTests.java
@@ -24,6 +24,7 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Properties;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import software.amazon.jdbc.mock.TestPluginOne;
 import software.amazon.jdbc.mock.TestPluginThree;
@@ -32,6 +33,11 @@ import software.amazon.jdbc.mock.TestPluginTwo;
 import software.amazon.jdbc.wrapper.ConnectionWrapper;
 
 public class ConnectionPluginManagerTests {
+
+  @BeforeEach
+  void setUp() {
+    ConnectionPluginManager.releasePipelineCache();
+  }
 
   @Test
   public void testExecuteJdbcCallA() throws Exception {


### PR DESCRIPTION
### Summary

Refactor `ConnectionPluginManager#executeWithSubscribedPlugins` to improve performance

### Description

Cache execute pipeline to avoid recalculating the pipeline for every JDBC method call.

#### Benchmark Result on Dev
| Benchmark                                              | Mode | Cnt | Score      | Error        | Units |
|--------------------------------------------------------|------|-----|------------|--------------|-------|
| ConnectionPluginManagerBenchmarks.executeWithNoPlugins | ss   | 30  | 188463.233 | ± 43793.010    | ns/op |
| ConnectionPluginManagerBenchmarks.executeWithPlugins   | ss   | 30  | 233770.000 | ± 110537.445 | ns/op |

#### Benchmark Result after refactoring
Run 1

| Benchmark                                              | Mode | Cnt | Score        | Error     | Units |
|--------------------------------------------------------|------|-----|--------------|-----------|-------|
| ConnectionPluginManagerBenchmarks.executeWithNoPlugins | ss   | 30  | 164670.100 | ± 23456.383 | ns/op |
| ConnectionPluginManagerBenchmarks.executeWithPlugins   | ss   | 30  | 189289.867 | ± 30212.896 | ns/op |

Run 2

| Benchmark                                              | Mode | Cnt | Score        | Error     | Units |
|--------------------------------------------------------|------|-----|--------------|-----------|-------|
| ConnectionPluginManagerBenchmarks.executeWithNoPlugins | ss   | 30  | 182463.500 | ± 38570.152 | ns/op |
| ConnectionPluginManagerBenchmarks.executeWithPlugins   | ss   | 30  | 205983.233 | ± 59252.605 | ns/op |
### Additional Reviewers

<!-- Any additional reviewers -->