### PR TITLE
Remove step uploading Qodana reports to GH Pages

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -22,9 +22,3 @@ jobs:
           fetch-depth: 0
       - name: 'Qodana Scan'
         uses: JetBrains/qodana-action@v2022.2.1
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ${{ runner.temp }}/qodana/results/report
-          destination_dir: ./


### PR DESCRIPTION
### Summary

Remove step uploading Qodana reports to GH pages.
- GitHub Pages is reserved for documentation

### Description

<!--- Details of what you changed -->

### Additional Reviewers

@congoamz 
@hsuamz 
@alecc-bq 
@joyc-bq 