### PR TITLE
chore: update versions and store versions as variable

### DIFF
--- a/benchmarks/build.gradle.kts
+++ b/benchmarks/build.gradle.kts
@@ -18,14 +18,20 @@ plugins {
     id("me.champeau.jmh")
 }
 
+val pgVersion : String by project
+val mysqlVersion : String by project
+val mariaVersion : String by project
+val jupiterVersion : String by project
+val mockitoVersion : String by project
+
 dependencies {
     jmhImplementation(project(":aws-advanced-jdbc-wrapper"))
-    implementation("org.postgresql:postgresql:42.+")
-    implementation("mysql:mysql-connector-java:8.0.+")
-    implementation("org.mariadb.jdbc:mariadb-java-client:3.+")
+    implementation("org.postgresql:postgresql:$pgVersion")
+    implementation("mysql:mysql-connector-java:$mysqlVersion")
+    implementation("org.mariadb.jdbc:mariadb-java-client:$mariaVersion")
 
-    testImplementation("org.junit.jupiter:junit-jupiter-api:5.6.2")
-    testImplementation("org.mockito:mockito-inline:4.+")
+    testImplementation("org.junit.jupiter:junit-jupiter-api:$jupiterVersion")
+    testImplementation("org.mockito:mockito-inline:$mockitoVersion")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,3 +16,19 @@ aws-advanced-jdbc-wrapper.version.major=1
 aws-advanced-jdbc-wrapper.version.minor=0
 aws-advanced-jdbc-wrapper.version.subminor=0
 snapshot=false
+
+# Dependency versions
+pgVersion=42.+
+mysqlVersion=8.0.+
+mariaVersion=3.+
+awsSdkVersion=2.17.+
+junitVersion=1.9.+
+jupiterVersion=5.9.+
+testContainerVersion=1.17.+
+jacksonVersion=2.13.+
+hikariVersion=4.+
+mockitoVersion=4.+
+slf4jVersion=2.0.+
+apachePoiVersion=5.+
+apacheCommonsVersion=2.9.+
+springVersion=2.7.+

--- a/wrapper/build.gradle.kts
+++ b/wrapper/build.gradle.kts
@@ -24,40 +24,55 @@ plugins {
     id("com.github.vlsi.ide")
 }
 
+val pgVersion : String by project
+val mysqlVersion : String by project
+val mariaVersion : String by project
+val awsSdkVersion : String by project
+val junitVersion : String by project
+val jupiterVersion : String by project
+val testContainerVersion : String by project
+val jacksonVersion : String by project
+val hikariVersion : String by project
+val mockitoVersion : String by project
+val slf4jVersion : String by project
+val apachePoiVersion : String by project
+val apacheCommonsVersion : String by project
+val springVersion : String by project
+
 dependencies {
     implementation("org.checkerframework:checker-qual:3.23.+")
-    compileOnly("software.amazon.awssdk:rds:2.17.267")
-    compileOnly("com.zaxxer:HikariCP:4.+") // Version 4.+ is compatible with Java 8
-    compileOnly("software.amazon.awssdk:secretsmanager:2.17.267")
-    compileOnly("com.fasterxml.jackson.core:jackson-databind:2.13.3")
+    compileOnly("software.amazon.awssdk:rds:$awsSdkVersion")
+    compileOnly("com.zaxxer:HikariCP:$hikariVersion") // Version 4.+ is compatible with Java 8
+    compileOnly("software.amazon.awssdk:secretsmanager:$awsSdkVersion")
+    compileOnly("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
 
-    testImplementation("org.junit.platform:junit-platform-commons:1.9.+")
-    testImplementation("org.junit.platform:junit-platform-engine:1.9.+")
-    testImplementation("org.junit.platform:junit-platform-launcher:1.9.+")
-    testImplementation("org.junit.platform:junit-platform-suite-engine:1.9.+")
-    testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.+")
-    testImplementation("org.junit.jupiter:junit-jupiter-params:5.9.+")
+    testImplementation("org.junit.platform:junit-platform-commons:$junitVersion")
+    testImplementation("org.junit.platform:junit-platform-engine:$junitVersion")
+    testImplementation("org.junit.platform:junit-platform-launcher:$junitVersion")
+    testImplementation("org.junit.platform:junit-platform-suite-engine:$junitVersion")
+    testImplementation("org.junit.jupiter:junit-jupiter-api:$jupiterVersion")
+    testImplementation("org.junit.jupiter:junit-jupiter-params:$jupiterVersion")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
 
-    testImplementation("org.apache.commons:commons-dbcp2:2.9.+")
-    testImplementation("org.postgresql:postgresql:42.+")
-    testImplementation("mysql:mysql-connector-java:8.0.+")
-    testImplementation("org.mariadb.jdbc:mariadb-java-client:3.+")
-    testImplementation("com.zaxxer:HikariCP:4.+") // Version 4.+ is compatible with Java 8
-    testImplementation("org.springframework.boot:spring-boot-starter-jdbc:2.7.+")
-    testImplementation("org.mockito:mockito-inline:4.+")
-    testImplementation("software.amazon.awssdk:rds:2.17.267")
-    testImplementation("software.amazon.awssdk:ec2:2.17.267")
-    testImplementation("org.testcontainers:testcontainers:1.17.+")
-    testImplementation("org.testcontainers:mysql:1.17.+")
-    testImplementation("org.testcontainers:postgresql:1.17.+")
-    testImplementation("org.testcontainers:mariadb:1.17.+")
-    testImplementation("org.testcontainers:junit-jupiter:1.17.+")
-    testImplementation("org.testcontainers:toxiproxy:1.17.+")
-    testImplementation("org.apache.poi:poi-ooxml:5.2.2")
-    testImplementation("org.slf4j:slf4j-simple:2.0.+")
-    testImplementation("software.amazon.awssdk:secretsmanager:2.17.267")
-    testImplementation("com.fasterxml.jackson.core:jackson-databind:2.13.3")
+    testImplementation("org.apache.commons:commons-dbcp2:$apacheCommonsVersion")
+    testImplementation("org.postgresql:postgresql:$pgVersion")
+    testImplementation("mysql:mysql-connector-java:$mysqlVersion")
+    testImplementation("org.mariadb.jdbc:mariadb-java-client:$mariaVersion")
+    testImplementation("com.zaxxer:HikariCP:$hikariVersion") // Version 4.+ is compatible with Java 8
+    testImplementation("org.springframework.boot:spring-boot-starter-jdbc:$springVersion")
+    testImplementation("org.mockito:mockito-inline:$mockitoVersion")
+    testImplementation("software.amazon.awssdk:rds:$awsSdkVersion")
+    testImplementation("software.amazon.awssdk:ec2:$awsSdkVersion")
+    testImplementation("org.testcontainers:testcontainers:$testContainerVersion")
+    testImplementation("org.testcontainers:mysql:$testContainerVersion")
+    testImplementation("org.testcontainers:postgresql:$testContainerVersion")
+    testImplementation("org.testcontainers:mariadb:$testContainerVersion")
+    testImplementation("org.testcontainers:junit-jupiter:$testContainerVersion")
+    testImplementation("org.testcontainers:toxiproxy:$testContainerVersion")
+    testImplementation("org.apache.poi:poi-ooxml:$apachePoiVersion")
+    testImplementation("org.slf4j:slf4j-simple:$slf4jVersion")
+    testImplementation("software.amazon.awssdk:secretsmanager:$awsSdkVersion")
+    testImplementation("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
 }
 
 repositories {


### PR DESCRIPTION
### Summary

storing versions as variables make it easier to update the version of multiple dependencies with the same versioning across multiple subprojects

### Description

<!--- Details of what you changed -->

### Additional Reviewers

@joyc-bq 
@congoamz 
@alecc-bq 