### PR TITLE
chore: make sure cleanup steps always run even if tests fail

### DIFF
--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -170,6 +170,7 @@ jobs:
   clean-up-mysql:
     name: 'Clean up AWS Aurora MySQL clusters'
     runs-on: ubuntu-latest
+    if: always()
     needs: [ aurora-mysql-integration-tests ]
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -195,6 +196,7 @@ jobs:
   clean-up-postgres:
     name: 'Clean up AWS Aurora Postgres clusters'
     runs-on: ubuntu-latest
+    if: always()
     needs: [ aurora-postgres-integration-tests ]
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
### Summary

Ensure clusters and deleted even if integration tests fail to prevent hitting the instances quota

### Description

<!--- Details of what you changed -->

### Additional Reviewers

@congoamz 