### PR TITLE
fix: handle transaction sql with comments at the beginning

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/DefaultConnectionPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/DefaultConnectionPlugin.java
@@ -158,7 +158,7 @@ public final class DefaultConnectionPlugin implements ConnectionPlugin {
 
   public boolean doesOpenTransaction(String statement) {
     statement = statement.toUpperCase();
-    statement = statement.replaceAll("START(?:\\s*/\\*(.*?)\\*/\\s*)TRANSACTION", "START TRANSACTION");
+    statement = statement.replaceAll("\\s*/\\*(.*?)\\*/\\s*", " ").trim();
     return statement.startsWith("BEGIN") || statement.startsWith("START TRANSACTION");
   }
 

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/DefaultConnectionPluginTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/DefaultConnectionPluginTest.java
@@ -84,6 +84,9 @@ class DefaultConnectionPluginTest {
         Arguments.of("START/* COMMENT */TRANSACTION;", true),
         Arguments.of("START      /* COMMENT */    TRANSACTION;", true),
         Arguments.of("START   /*COMMENT*/TRANSACTION;", true),
+        Arguments.of("/*COMMENT*/START   /*COMMENT*/TRANSACTION;", true),
+        Arguments.of(" /*COMMENT*/ START   /*COMMENT*/TRANSACTION;", true),
+        Arguments.of(" /*COMMENT*/ begin", true),
         Arguments.of("commit", false)
     );
   }


### PR DESCRIPTION
### Summary

Fix some bugs around code detecting whether the session is in a transaction
#160

Github Actions are failing due to a flaky test, the fix for that test is in #164 

### Description

- handle transaction SQL statements with comments at the beginning, e.g. `\*comment*\ begin;`
- set transaction status in `setAutoCommit`

### Additional Reviewers

@congoamz 
@joyc-bq 
@davecramer 
@alecc-bq 