### PR TITLE
fix: flakey test testGetTopology_returnCachedTopology

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/AuroraHostListProvider.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/AuroraHostListProvider.java
@@ -97,7 +97,10 @@ public class AuroraHostListProvider implements HostListProvider, DynamicHostList
   private RdsUrlType rdsUrlType;
   private final RdsUtils rdsHelper;
 
-  private int refreshRateInMilliseconds;
+  private int refreshRateInMilliseconds = Integer.parseInt(
+      CLUSTER_TOPOLOGY_REFRESH_RATE_MS.defaultValue != null
+          ? CLUSTER_TOPOLOGY_REFRESH_RATE_MS.defaultValue
+          : "30000");
   private List<HostSpec> hostList = new ArrayList<>();
   private List<HostSpec> lastReturnedHostList;
   private List<HostSpec> initialHostList = new ArrayList<>();


### PR DESCRIPTION
### Summary

fix: initialize cluster topology refresh rate to a non-zero default value

### Description

testGetTopology_returnCachedTopology is flaky because when it calls `getTopology` `refreshNeeded(topology)` will always true.
This method always return true because it checks if the elapsed time has exceeded `refreshRateInMilliseconds`, which is initialized to 0, so the elapsed time will always be greater.

This fix was originally in #143, taking this fix out to unblock other PRs
### Additional Reviewers

@congoamz 