### PR TITLE
chore: update hibernate buildscript to use the wrapper project as dependency

### DIFF
--- a/examples/HibernateExample/build.gradle
+++ b/examples/HibernateExample/build.gradle
@@ -3,9 +3,6 @@ plugins {
     id 'application'
 }
 
-group 'software.amazon'
-version '1.0-SNAPSHOT'
-
 repositories {
     mavenCentral()
     mavenLocal()
@@ -18,7 +15,7 @@ dependencies {
     implementation 'jakarta.persistence:jakarta.persistence-api:3.1.0'
     runtimeOnly 'org.postgresql:postgresql:42.5.0'
     runtimeOnly 'mysql:mysql-connector-java:8.0.30'
-    runtimeOnly 'software.amazon.jdbc:aws-advanced-jdbc-wrapper:1.0.0'
+    runtimeOnly project(':aws-advanced-jdbc-wrapper')
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.0'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.0'
 }


### PR DESCRIPTION
### Summary

chore: update the hibernate build script to use the wrapper project as dependency

The Hibernate subproject was fetching the AWS Wrapper directly from Maven Central. We should be using the most up-to-date Wrapper JAR instead.

### Description

Update `build.gradle` to use `project(':aws-advanced-jdbc-wrapper')`

### Additional Reviewers

@sergiyvamz 