### PR TITLE
fix: copy initial connection props properly

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/failover/ClusterAwareReaderFailoverHandler.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/failover/ClusterAwareReaderFailoverHandler.java
@@ -396,7 +396,9 @@ public class ClusterAwareReaderFailoverHandler implements ReaderFailoverHandler 
               new Object[] {this.newHost.getUrl(), initialConnectionProps}));
 
       try {
-        final Properties copy = new Properties(initialConnectionProps);
+        final Properties copy = new Properties();
+        copy.putAll(initialConnectionProps);
+
         final Connection conn = pluginService.forceConnect(this.newHost, copy);
         pluginService.setAvailability(this.newHost.asAliases(), HostAvailability.AVAILABLE);
         LOGGER.fine(


### PR DESCRIPTION
### Summary

Calling `Properties copy = new Properties(originalProps)` doesn't actually copy the properties.

### Description

<!--- Details of what you changed -->

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.