### PR TITLE
upgrade org.mockito:mockito-inline to 4.11.0

### DIFF
--- a/benchmarks/build.gradle.kts
+++ b/benchmarks/build.gradle.kts
@@ -26,7 +26,7 @@ dependencies {
     implementation("com.zaxxer:HikariCP:4.0.3")
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.3")
-    testImplementation("org.mockito:mockito-inline:4.8.0")
+    testImplementation("org.mockito:mockito-inline:4.11.0") // 4.11.0 is the last version compatible with Java 8
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
 }
 

--- a/wrapper/build.gradle.kts
+++ b/wrapper/build.gradle.kts
@@ -51,7 +51,7 @@ dependencies {
     testImplementation("org.mariadb.jdbc:mariadb-java-client:3.1.4")
     testImplementation("com.zaxxer:HikariCP:4.0.3") // Version 4.+ is compatible with Java 8
     testImplementation("org.springframework.boot:spring-boot-starter-jdbc:2.7.13") // 2.7.13 is the last version compatible with Java 8
-    testImplementation("org.mockito:mockito-inline:4.8.0")
+    testImplementation("org.mockito:mockito-inline:4.11.0") // 4.11.0 is the last version compatible with Java 8
     testImplementation("software.amazon.awssdk:rds:2.20.49")
     testImplementation("software.amazon.awssdk:ec2:2.20.105")
     testImplementation("software.amazon.awssdk:secretsmanager:2.20.105")

--- a/wrapper/src/test/build.gradle.kts
+++ b/wrapper/src/test/build.gradle.kts
@@ -40,7 +40,7 @@ dependencies {
     testImplementation("org.mariadb.jdbc:mariadb-java-client:3.1.0")
     testImplementation("com.zaxxer:HikariCP:4.+") // version 4.+ is compatible with Java 8
     testImplementation("org.springframework.boot:spring-boot-starter-jdbc:2.7.13") // 2.7.13 is the last version compatible with Java 8
-    testImplementation("org.mockito:mockito-inline:4.8.0")
+    testImplementation("org.mockito:mockito-inline:4.11.0") // 4.11.0 is the last version compatible with Java 8
     testImplementation("software.amazon.awssdk:rds:2.20.49")
     testImplementation("software.amazon.awssdk:ec2:2.20.49")
     testImplementation("org.testcontainers:testcontainers:1.17.+")


### PR DESCRIPTION
### Summary

upgrade org.mockito:mockito-inline to 4.11.0

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.