### PR TITLE
fix: maskJunitHtmlReport gradle task to check if html report exists b…

### DIFF
--- a/wrapper/build.gradle.kts
+++ b/wrapper/build.gradle.kts
@@ -296,11 +296,13 @@ tasks.withType<Test> {
 
 tasks.register("maskJunitHtmlReport") {
     doLast {
-        val jsFile = project.file("${layout.buildDirectory.get()}/report/data.js")
-        var text = jsFile.readText()
-        var regex = "\"([^\"]*(AWS_ACCESS_|AWS_SECRET_|AWS_SESSION_)[^\"]*)\", value: \"([^\"]*)\"".toRegex(setOf(RegexOption.MULTILINE, RegexOption.IGNORE_CASE))
-        val maskedText = regex.replace(text, "\"$1\", value: \"*****\"")
-        jsFile.writeText(maskedText)
+        if (project.file("${layout.buildDirectory.get()}/report/data.js").exists()) {
+            val jsFile = project.file("${layout.buildDirectory.get()}/report/data.js")
+            var text = jsFile.readText()
+            var regex = "\"([^\"]*(AWS_ACCESS_|AWS_SECRET_|AWS_SESSION_)[^\"]*)\", value: \"([^\"]*)\"".toRegex(setOf(RegexOption.MULTILINE, RegexOption.IGNORE_CASE))
+            val maskedText = regex.replace(text, "\"$1\", value: \"*****\"")
+            jsFile.writeText(maskedText)
+        }
     }
 }
 


### PR DESCRIPTION
…efore masking

### Summary

fix: maskJunitHtmlReport gradle task to check if html report exists before masking

### Description

<!--- Details of what you changed -->

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.