### PR TITLE
docs: clarify blue/green support limitations and default behaviour fo…

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,15 @@ To find all the documentation and concrete examples on how to use the AWS JDBC D
 
 #### Amazon RDS Blue/Green Deployments
 
-This driver currently does not support switchover in Amazon RDS Blue/Green Deployments. If you do execute a Blue/Green deployment with the driver, please ensure your application is coded to retry the database connection. Retry will allow the driver to re-establish a connection to an available database instance. Without a retry, the driver would not be able to identify an available database instance, after a switchover has happened between the blue and green environments. However, please note that even with your application coded to retry the database connection, you may still encounter other unexpected errors. Support for Amazon RDS Blue/Green Deployments is in the backlog, but we cannot comment on a timeline right now.
+Although the AWS Advanced JDBC Wrapper is not compatible with [AWS Blue/Green Deployments](https://docs.aws.amazon.com/whitepapers/latest/overview-deployment-options/bluegreen-deployments.html) and does not officially support them, the combination of the AWS Advanced JDBC Wrapper and the Failover Plugin has been validated for use with clusters that employ Blue/Green Deployments. While general basic connectivity to both Blue and Green clusters is always in place, some failover cases are not fully supported.
+
+The current limitations are:
+- After a Blue/Green switchover, the wrapper may not be able to properly detect the new topology and handle failover, as there are discrepancies between the metadata and the available endpoints.
+- The specific version requirements for Aurora MySQL versus Aurora PostgreSQL may vary, as the internal systems used by the wrapper can differ[^1].
+
+The development team is aware of these limitations and is working to improve the wrapper's awareness and handling of Blue/Green switchovers. In the meantime, users can consider utilizing the `enableGreenNodeReplacement` configuration parameter, which allows the driver to override incorrect topology metadata and try to connect to available new Blue endpoints.
+
+[^1]: Aurora MySQL requires v3.07 or later.
 
 #### Amazon Aurora Global Databases
 

--- a/docs/using-the-jdbc-driver/using-plugins/UsingTheAuroraConnectionTrackerPlugin.md
+++ b/docs/using-the-jdbc-driver/using-plugins/UsingTheAuroraConnectionTrackerPlugin.md
@@ -1,7 +1,7 @@
 # Aurora Connection Tracker Plugin
 
 This plugin tracks all the opened connections. In the event of a cluster failover, this plugin will close all the impacted connections.
-This plugin is enabled by default.
+If no plugins are explicitly specified, this plugin is enabled by default.
 
 ## Use Case
 User applications can have two types of connections:


### PR DESCRIPTION
### Summary

- Blue/Green limitations are more prominent on the main README.md section, mirroring wording from using the failover plugin documentation.
- Clarify some confusion that the aurora connection tracker plugin is always enabled by default.

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.