### PR TITLE
fix: enableGreenNodeReplacement being ignored 

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/DataSourceConnectionProvider.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/DataSourceConnectionProvider.java
@@ -131,11 +131,6 @@ public class DataSourceConnectionProvider implements ConnectionProvider {
       LOGGER.finest(() -> "Use a separate DataSource object to create a connection.");
       // use a new data source instance to instantiate a connection
       final DataSource ds = createDataSource();
-      targetDriverDialect.prepareDataSource(
-          ds,
-          protocol,
-          hostSpec,
-          copy);
       conn = this.openConnection(ds, protocol, targetDriverDialect, hostSpec, copy);
 
     } else {
@@ -145,11 +140,6 @@ public class DataSourceConnectionProvider implements ConnectionProvider {
       this.lock.lock();
       LOGGER.finest(() -> "Use main DataSource object to create a connection.");
       try {
-        targetDriverDialect.prepareDataSource(
-            this.dataSource,
-            protocol,
-            hostSpec,
-            copy);
         conn = this.openConnection(this.dataSource, protocol, targetDriverDialect, hostSpec, copy);
       } finally {
         this.lock.unlock();
@@ -170,11 +160,16 @@ public class DataSourceConnectionProvider implements ConnectionProvider {
       final @NonNull HostSpec hostSpec,
       final @NonNull Properties props)
       throws SQLException {
-
+    final boolean enableGreenNodeReplacement = PropertyDefinition.ENABLE_GREEN_NODE_REPLACEMENT.getBoolean(props);
     try {
+      targetDriverDialect.prepareDataSource(
+          ds,
+          protocol,
+          hostSpec,
+          props);
       return ds.getConnection();
     } catch (Throwable throwable) {
-      if (!PropertyDefinition.ENABLE_GREEN_NODE_REPLACEMENT.getBoolean(props)) {
+      if (!enableGreenNodeReplacement) {
         throw throwable;
       }
 


### PR DESCRIPTION

### Summary

- store enableGreenNodeReplacement parameter value so it can be correctly accessed after removing wrapper specific properties before connecting
- fixes #1059 

### Description

Before establishing connections using the DataSource, the wrapper removes all wrapper-specific connection properties to avoid errors. This can be problematic when the connection fails and the wrapper needs to access wrapper-specific properties to perform specific handling. This fix moves the removal logic to the lowest-level method possible to address this issue.

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.