### PR TITLE
fix: using bundled jar with adfs throws nullpointerexception

### DIFF
--- a/aws-advanced-jdbc-wrapper-bundle/build.gradle.kts
+++ b/aws-advanced-jdbc-wrapper-bundle/build.gradle.kts
@@ -24,6 +24,7 @@ repositories {
 }
 
 dependencies {
+    implementation("org.apache.httpcomponents:httpclient:4.5.14")
     implementation("software.amazon.awssdk:rds:2.25.70")
     implementation("software.amazon.awssdk:sts:2.25.60")
     implementation(project(":aws-advanced-jdbc-wrapper"))


### PR DESCRIPTION
### Summary

The bundled jar for ADFS authentication was missing a required dependency, causing a NullPointerException when using the jar.

### Description

<!--- Details of what you changed -->

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.