### PR TITLE
fix: limitless connection plugin - add synchornized lock for synchron…

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/limitless/LimitlessConnectionPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/limitless/LimitlessConnectionPlugin.java
@@ -137,16 +137,16 @@ public class LimitlessConnectionPlugin extends AbstractConnectionPlugin {
         this.pluginService.getHostListProvider().getClusterId(), props);
 
     if (limitlessRouters.isEmpty()) {
-      LOGGER.fine(Messages.get("LimitlessConnectionPlugin.limitlessRouterCacheEmpty"));
+      LOGGER.finest(Messages.get("LimitlessConnectionPlugin.limitlessRouterCacheEmpty"));
       final boolean waitForRouterInfo = WAIT_F0R_ROUTER_INFO.getBoolean(props);
       if (waitForRouterInfo) {
         limitlessRouters = synchronouslyGetLimitlessRoutersWithRetry(props);
       } else {
-        LOGGER.fine(Messages.get("LimitlessConnectionPlugin.usingProvidedConnectUrl"));
+        LOGGER.finest(Messages.get("LimitlessConnectionPlugin.usingProvidedConnectUrl"));
         return connectFunc.call();
       }
     } else if (limitlessRouters.contains(hostSpec)) {
-      LOGGER.fine(Messages.get("LimitlessConnectionPlugin.connectWithHost", new Object[] {hostSpec.getHost()}));
+      LOGGER.finest(Messages.get("LimitlessConnectionPlugin.connectWithHost", new Object[] {hostSpec.getHost()}));
       return connectFunc.call();
     }
 
@@ -166,7 +166,7 @@ public class LimitlessConnectionPlugin extends AbstractConnectionPlugin {
     try {
       return pluginService.connect(selectedHostSpec, props);
     } catch (SQLException e) {
-      LOGGER.warning(Messages.get(
+      LOGGER.fine(Messages.get(
           "LimitlessConnectionPlugin.failedToConnectToHost",
           new Object[] {selectedHostSpec.getHost()}));
       selectedHostSpec.setAvailability(HostAvailability.NOT_AVAILABLE);
@@ -186,9 +186,7 @@ public class LimitlessConnectionPlugin extends AbstractConnectionPlugin {
 
     List<HostSpec> currentRouters = limitlessRouters;
     int retryCount = 0;
-    final int maxRetries = MAX_RETRIES.getInteger(props) >= 0
-        ? MAX_RETRIES.getInteger(props)
-        : Integer.valueOf(MAX_RETRIES.defaultValue);
+    final int maxRetries = MAX_RETRIES.getInteger(props);
 
     while (retryCount++ < maxRetries) {
       if (!currentRouters.stream().anyMatch(h -> h.getAvailability().equals(HostAvailability.AVAILABLE))) {
@@ -207,7 +205,7 @@ public class LimitlessConnectionPlugin extends AbstractConnectionPlugin {
         // Select healthiest router for best chance of connection over load-balancing with round-robin
         selectedHostSpec = this.pluginService.getHostSpecByStrategy(limitlessRouters,
             HostRole.WRITER, HighestWeightHostSelector.STRATEGY_HIGHEST_WEIGHT);
-        LOGGER.fine(Messages.get(
+        LOGGER.finest(Messages.get(
             "LimitlessConnectionPlugin.selectedHostForRetry",
             new Object[] {selectedHostSpec.getHost()}));
       } catch (UnsupportedOperationException e) {
@@ -219,7 +217,7 @@ public class LimitlessConnectionPlugin extends AbstractConnectionPlugin {
         return pluginService.connect(selectedHostSpec, props);
       } catch (SQLException e) {
         selectedHostSpec.setAvailability(HostAvailability.NOT_AVAILABLE);
-        LOGGER.warning(Messages.get(
+        LOGGER.finest(Messages.get(
             "LimitlessConnectionPlugin.failedToConnectToHost",
             new Object[] {selectedHostSpec.getHost()}));
       }
@@ -228,7 +226,7 @@ public class LimitlessConnectionPlugin extends AbstractConnectionPlugin {
   }
 
   private List<HostSpec> synchronouslyGetLimitlessRoutersWithRetry(final Properties props) throws SQLException {
-    LOGGER.fine(Messages.get("LimitlessConnectionPlugin.synchronouslyGetLimitlessRouters"));
+    LOGGER.finest(Messages.get("LimitlessConnectionPlugin.synchronouslyGetLimitlessRouters"));
     int retryCount = -1; // start at -1 since the first try is not a retry.
     int maxRetries = GET_ROUTER_MAX_RETRIES.getInteger(props);
     int retryIntervalMs = GET_ROUTER_RETRY_INTERVAL_MILLIS.getInteger(props);

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/limitless/LimitlessRouterMonitor.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/limitless/LimitlessRouterMonitor.java
@@ -165,9 +165,10 @@ public class LimitlessRouterMonitor implements AutoCloseable, Runnable {
   }
 
   public synchronized List<HostSpec> forceGetLimitlessRouters() throws SQLException {
+    LOGGER.fine(Messages.get("LimitlessRouterMonitor.forceGetLimitlessRouters"));
     this.openConnection();
     if (this.monitoringConn == null || this.monitoringConn.isClosed()) {
-      LOGGER.warning(Messages.get("LimitlessRouterMonitor.forceGetLimitlessRoutersFailed"));
+      LOGGER.fine(Messages.get("LimitlessRouterMonitor.forceGetLimitlessRoutersFailed"));
       return Collections.emptyList();
     }
     List<HostSpec> newLimitlessRouters = queryForLimitlessRouters(this.monitoringConn);

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/limitless/LimitlessRouterMonitor.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/limitless/LimitlessRouterMonitor.java
@@ -168,8 +168,7 @@ public class LimitlessRouterMonitor implements AutoCloseable, Runnable {
     LOGGER.fine(Messages.get("LimitlessRouterMonitor.forceGetLimitlessRouters"));
     this.openConnection();
     if (this.monitoringConn == null || this.monitoringConn.isClosed()) {
-      LOGGER.fine(Messages.get("LimitlessRouterMonitor.forceGetLimitlessRoutersFailed"));
-      return Collections.emptyList();
+      throw new SQLException(Messages.get("LimitlessRouterMonitor.forceGetLimitlessRoutersFailed"));
     }
     List<HostSpec> newLimitlessRouters = queryForLimitlessRouters(this.monitoringConn);
     this.limitlessRouters.set(Collections.unmodifiableList(newLimitlessRouters));

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/limitless/LimitlessRouterMonitor.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/limitless/LimitlessRouterMonitor.java
@@ -116,14 +116,14 @@ public class LimitlessRouterMonitor implements AutoCloseable, Runnable {
     if (!this.threadPool.awaitTermination(5, TimeUnit.SECONDS)) {
       this.threadPool.shutdownNow();
     }
-    LOGGER.fine(() -> Messages.get(
+    LOGGER.finest(() -> Messages.get(
         "LimitlessRouterMonitor.stopped",
         new Object[] {this.hostSpec.getHost()}));
   }
 
   @Override
   public void run() {
-    LOGGER.fine(() -> Messages.get(
+    LOGGER.finest(() -> Messages.get(
         "LimitlessRouterMonitor.running",
         new Object[] {this.hostSpec.getHost()}));
 
@@ -139,7 +139,7 @@ public class LimitlessRouterMonitor implements AutoCloseable, Runnable {
         List<HostSpec> newLimitlessRouters = queryForLimitlessRouters(this.monitoringConn);
         this.limitlessRouters.set(Collections.unmodifiableList(newLimitlessRouters));
         RoundRobinHostSelector.setRoundRobinHostWeightPairsProperty(this.props, newLimitlessRouters);
-        LOGGER.fine(Utils.logTopology(limitlessRouters.get(), "[limitlessRouterMonitor]"));
+        LOGGER.finest(Utils.logTopology(limitlessRouters.get(), "[limitlessRouterMonitor]"));
         TimeUnit.MILLISECONDS.sleep(this.intervalMs); // do not include this in the telemetry
       } catch (final InterruptedException exception) {
         LOGGER.finest(
@@ -165,7 +165,7 @@ public class LimitlessRouterMonitor implements AutoCloseable, Runnable {
   }
 
   public synchronized List<HostSpec> forceGetLimitlessRouters() throws SQLException {
-    LOGGER.fine(Messages.get("LimitlessRouterMonitor.forceGetLimitlessRouters"));
+    LOGGER.finest(Messages.get("LimitlessRouterMonitor.forceGetLimitlessRouters"));
     this.openConnection();
     if (this.monitoringConn == null || this.monitoringConn.isClosed()) {
       throw new SQLException(Messages.get("LimitlessRouterMonitor.forceGetLimitlessRoutersFailed"));
@@ -173,7 +173,7 @@ public class LimitlessRouterMonitor implements AutoCloseable, Runnable {
     List<HostSpec> newLimitlessRouters = queryForLimitlessRouters(this.monitoringConn);
     this.limitlessRouters.set(Collections.unmodifiableList(newLimitlessRouters));
     RoundRobinHostSelector.setRoundRobinHostWeightPairsProperty(this.props, newLimitlessRouters);
-    LOGGER.fine(Utils.logTopology(limitlessRouters.get(), "[limitlessRouterMonitor]"));
+    LOGGER.finest(Utils.logTopology(limitlessRouters.get(), "[limitlessRouterMonitor]"));
     return newLimitlessRouters;
   }
 
@@ -181,11 +181,11 @@ public class LimitlessRouterMonitor implements AutoCloseable, Runnable {
     try {
       if (this.monitoringConn == null || this.monitoringConn.isClosed()) {
         // open a new connection
-        LOGGER.fine(() -> Messages.get(
+        LOGGER.finest(() -> Messages.get(
             "LimitlessRouterMonitor.openingConnection",
             new Object[] {this.hostSpec.getUrl()}));
         this.monitoringConn = this.pluginService.forceConnect(this.hostSpec, this.props);
-        LOGGER.fine(() -> Messages.get(
+        LOGGER.finest(() -> Messages.get(
             "LimitlessRouterMonitor.openedConnection",
             new Object[] {this.monitoringConn}));
       }

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/limitless/LimitlessRouterService.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/limitless/LimitlessRouterService.java
@@ -25,7 +25,7 @@ import software.amazon.jdbc.PluginService;
 
 public interface LimitlessRouterService {
 
-  List<HostSpec> getLimitlessRouters(final String clusterId, final Properties props);
+  List<HostSpec> getLimitlessRouters(final String clusterId, final Properties props) throws SQLException;
 
   List<HostSpec> forceGetLimitlessRouters(final String clusterId, final Properties props) throws SQLException;
 

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/limitless/LimitlessRouterServiceImpl.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/limitless/LimitlessRouterServiceImpl.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import software.amazon.jdbc.AwsWrapperProperty;
 import software.amazon.jdbc.HostSpec;
@@ -28,13 +29,13 @@ import software.amazon.jdbc.PluginService;
 import software.amazon.jdbc.util.SlidingExpirationCacheWithCleanupThread;
 
 public class LimitlessRouterServiceImpl implements LimitlessRouterService {
-
   public static final AwsWrapperProperty MONITOR_DISPOSAL_TIME_MS =
       new AwsWrapperProperty(
           "limitlessTransactionRouterMonitorDisposalTimeMs",
           "600000", // 10min
           "Interval in milliseconds for an Limitless router monitor to be considered inactive and to be disposed.");
   protected static final long CACHE_CLEANUP_NANO = TimeUnit.MINUTES.toNanos(1);
+  protected static final ReentrantLock forceGetLimitlessRoutersLock = new ReentrantLock();
   private final LimitlessRouterMonitorInitializer limitlessRouterMonitorInitializer;
 
   private static final SlidingExpirationCacheWithCleanupThread<String, LimitlessRouterMonitor> limitlessRouterMonitors =
@@ -73,6 +74,7 @@ public class LimitlessRouterServiceImpl implements LimitlessRouterService {
 
   @Override
   public List<HostSpec> forceGetLimitlessRouters(final String clusterId, final Properties props) throws SQLException {
+
     final long cacheExpirationNano = TimeUnit.MILLISECONDS.toNanos(
         MONITOR_DISPOSAL_TIME_MS.getLong(props));
 
@@ -81,7 +83,16 @@ public class LimitlessRouterServiceImpl implements LimitlessRouterService {
     if (limitlessRouterMonitor == null) {
       return Collections.EMPTY_LIST;
     }
-    return limitlessRouterMonitor.forceGetLimitlessRouters();
+    forceGetLimitlessRoutersLock.lock();
+    try {
+      final List<HostSpec> limitlessRouterList = limitlessRouterMonitor.getLimitlessRouters();
+      if (limitlessRouterList != null && !limitlessRouterList.isEmpty()) {
+        return limitlessRouterList;
+      }
+      return limitlessRouterMonitor.forceGetLimitlessRouters();
+    } finally {
+      forceGetLimitlessRoutersLock.unlock();
+    }
   }
 
   @Override

--- a/wrapper/src/main/resources/aws_advanced_jdbc_wrapper_messages.properties
+++ b/wrapper/src/main/resources/aws_advanced_jdbc_wrapper_messages.properties
@@ -202,6 +202,7 @@ LimitlessConnectionPlugin.synchronouslyGetLimitlessRouters=Fetching Limitless Ro
 
 # Limitless Router Monitor
 LimitlessRouterMonitor.exceptionDuringMonitoringStop=Unhandled exception was thrown in Limitless Router Monitoring thread for node {0}.
+LimitlessRouterMonitor.forceGetLimitlessRouters=Fetching Limitless Transaction Routers synchronously.
 LimitlessRouterMonitor.forceGetLimitlessRoutersFailed=Failed to fetch Limitless Routers due to closed connection.
 LimitlessRouterMonitor.interruptedExceptionDuringMonitoring=Limitless Router Monitoring thread for node {0} was interrupted.
 LimitlessRouterMonitor.invalidQuery=Limitless Connection Plugin has encountered an error obtaining Limitless Router endpoints. Please ensure that you are connecting to an Aurora Limitless Database Shard Group Endpoint URL.

--- a/wrapper/src/main/resources/aws_advanced_jdbc_wrapper_messages.properties
+++ b/wrapper/src/main/resources/aws_advanced_jdbc_wrapper_messages.properties
@@ -192,6 +192,7 @@ LimitlessConnectionPlugin.connectWithHost=Connecting to host {0}.
 LimitlessConnectionPlugin.usingProvidedConnectUrl=Connecting using provided connection URL.
 LimitlessConnectionPlugin.failedToConnectToHost=Failed to connect to host {0}.
 LimitlessConnectionPlugin.incorrectConfiguration=Limitless Connection Plugin is unable to run. Please ensure the connection settings are correct.
+LimitlessConnectionPlugin.interruptedThread=Thread was interrupted.
 LimitlessConnectionPlugin.limitlessRouterCacheEmpty=Limitless Router cache is empty. This normal during application start up when the cache is not yet populated.
 LimitlessConnectionPlugin.maxRetriesExceeded=Max number of connection retries has been exceeded.
 LimitlessConnectionPlugin.noRoutersAvailable=There are no transaction routers available.
@@ -199,6 +200,9 @@ LimitlessConnectionPlugin.noRoutersAvailableForRetry=There are no transaction ro
 LimitlessConnectionPlugin.selectedHost=Host {0} has been selected.
 LimitlessConnectionPlugin.selectedHostForRetry=Host {0} has been selected for connection retry.
 LimitlessConnectionPlugin.synchronouslyGetLimitlessRouters=Fetching Limitless Routers synchronously.
+
+# Limitless Router Service Impl
+LimitlessRouterServiceImpl.nulLimitlessRouterMonitor=LimitlessRouterMonitor with cluster ID {0} is null.
 
 # Limitless Router Monitor
 LimitlessRouterMonitor.exceptionDuringMonitoringStop=Unhandled exception was thrown in Limitless Router Monitoring thread for node {0}.

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/limitless/LimitlessConnectionPluginTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/limitless/LimitlessConnectionPluginTest.java
@@ -241,6 +241,8 @@ public class LimitlessConnectionPluginTest {
 
     when(mockLimitlessRouterService.getLimitlessRouters(any(), any()))
         .thenReturn(endpointHostSpecList, Collections.emptyList());
+    when(mockLimitlessRouterService.forceGetLimitlessRouters(any(), any()))
+        .thenReturn(endpointHostSpecList, Collections.emptyList());
     when(mockPluginService.getHostSpecByStrategy(any(), any(), eq(RoundRobinHostSelector.STRATEGY_ROUND_ROBIN)))
         .thenReturn(expectedSelectedHostSpec);
     when(mockPluginService.connect(eq(expectedSelectedHostSpec), any())).thenThrow(SQLException.class);
@@ -251,7 +253,10 @@ public class LimitlessConnectionPluginTest {
 
     verify(mockLimitlessRouterService, times(1)).startMonitoring(mockPluginService, INPUT_HOST_SPEC,
         props, Integer.parseInt(LimitlessConnectionPlugin.INTERVAL_MILLIS.defaultValue));
-    verify(mockLimitlessRouterService, times(2)).getLimitlessRouters(CLUSTER_ID, props);
+    verify(mockLimitlessRouterService, times(1)).getLimitlessRouters(CLUSTER_ID, props);
+    verify(mockLimitlessRouterService,
+        times(Integer.valueOf(LimitlessConnectionPlugin.GET_ROUTER_MAX_RETRIES.defaultValue) + 2))
+        .forceGetLimitlessRouters(CLUSTER_ID, props);
     verify(mockPluginService, times(1)).getHostSpecByStrategy(endpointHostSpecList,
         HostRole.WRITER, RoundRobinHostSelector.STRATEGY_ROUND_ROBIN);
     verify(

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/limitless/LimitlessConnectionPluginTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/limitless/LimitlessConnectionPluginTest.java
@@ -254,9 +254,7 @@ public class LimitlessConnectionPluginTest {
     verify(mockLimitlessRouterService, times(1)).startMonitoring(mockPluginService, INPUT_HOST_SPEC,
         props, Integer.parseInt(LimitlessConnectionPlugin.INTERVAL_MILLIS.defaultValue));
     verify(mockLimitlessRouterService, times(1)).getLimitlessRouters(CLUSTER_ID, props);
-    verify(mockLimitlessRouterService,
-        times(Integer.valueOf(LimitlessConnectionPlugin.GET_ROUTER_MAX_RETRIES.defaultValue) + 2))
-        .forceGetLimitlessRouters(CLUSTER_ID, props);
+    verify(mockLimitlessRouterService, times(1)).forceGetLimitlessRouters(CLUSTER_ID, props);
     verify(mockPluginService, times(1)).getHostSpecByStrategy(endpointHostSpecList,
         HostRole.WRITER, RoundRobinHostSelector.STRATEGY_ROUND_ROBIN);
     verify(

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/limitless/LimitlessRouterServiceImplTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/limitless/LimitlessRouterServiceImplTest.java
@@ -17,6 +17,7 @@
 package software.amazon.jdbc.plugin.limitless;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.when;
 
 import java.sql.SQLException;
@@ -54,7 +55,7 @@ public class LimitlessRouterServiceImplTest {
   }
 
   @Test
-  void test() {
+  void test() throws SQLException {
     when(mockPluginService.getHostListProvider()).thenReturn(mockHostListProvider);
     when(mockHostListProvider.getClusterId()).thenReturn(CLUSTER_ID);
     final List<HostSpec> endpointHostSpecList = Arrays.asList(
@@ -80,8 +81,6 @@ public class LimitlessRouterServiceImplTest {
   void test_nullLimitlessRouterMonitor() {
     final LimitlessRouterService limitlessRouterService =
         new LimitlessRouterServiceImpl((a, b, c, d) -> null);
-    final List<HostSpec> actualEndpointHostSpecList =
-        limitlessRouterService.getLimitlessRouters(OTHER_CLUSTER_ID, props);
-    assertEquals(0, actualEndpointHostSpecList.size());
+    assertThrows(SQLException.class, () -> limitlessRouterService.getLimitlessRouters(OTHER_CLUSTER_ID, props));
   }
 }


### PR DESCRIPTION
…ous fetch of routers

### Summary
Add synchronized lock to the synchronous fetch of routers so `synchronized` will apply to all instances of the Limitless plugin. 

Before this fix, I did a test spinning up 100 callables creating connections. I noticed `limitlessRouterService#forceGetLimitlessRouters` being called 10+  times at start up, when only 1 is needed. This should remedy that.  

Also moved the `retryCounter` to `finally` block so that if an exception is encountered, there isnt an infinite loop.

### Description

Added a static synchronized lock to the LimitlessConnectionPlugin to be used for `synchronouslyGetLimitlessRouters()`.

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.