### PR TITLE
fix: unwrap nested exceptions when checking for login exceptions

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/exceptions/AbstractPgExceptionHandler.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/exceptions/AbstractPgExceptionHandler.java
@@ -62,8 +62,14 @@ public abstract class AbstractPgExceptionHandler implements ExceptionHandler {
       if (exception instanceof SQLLoginException) {
         return true;
       }
+
+      String sqlState = null;
       if (exception instanceof SQLException) {
-        return isLoginException(((SQLException) exception).getSQLState());
+        sqlState = ((SQLException) exception).getSQLState();
+      }
+
+      if (isLoginException(sqlState)) {
+        return true;
       }
 
       exception = exception.getCause();

--- a/wrapper/src/main/java/software/amazon/jdbc/exceptions/GenericExceptionHandler.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/exceptions/GenericExceptionHandler.java
@@ -73,8 +73,14 @@ public class GenericExceptionHandler implements ExceptionHandler {
       if (exception instanceof SQLLoginException) {
         return true;
       }
+
+      String sqlState = null;
       if (exception instanceof SQLException) {
-        return isLoginException(((SQLException) exception).getSQLState());
+        sqlState = ((SQLException) exception).getSQLState();
+      }
+
+      if (isLoginException(sqlState)) {
+        return true;
       }
 
       exception = exception.getCause();

--- a/wrapper/src/main/java/software/amazon/jdbc/exceptions/MySQLExceptionHandler.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/exceptions/MySQLExceptionHandler.java
@@ -71,10 +71,16 @@ public class MySQLExceptionHandler implements ExceptionHandler {
       if (exception instanceof SQLLoginException) {
         return true;
       }
+
+      String sqlState = null;
       if (exception instanceof SQLException) {
-        return isLoginException(((SQLException) exception).getSQLState());
+        sqlState = ((SQLException) exception).getSQLState();
       } else if (exception instanceof CJException) {
-        return isLoginException(((CJException) exception).getSQLState());
+        sqlState = ((CJException) exception).getSQLState();
+      }
+
+      if (isLoginException(sqlState)) {
+        return true;
       }
 
       exception = exception.getCause();


### PR DESCRIPTION
### Summary

fix: unwrap nested exceptions when checking for login exceptions

### Description

- fixes #1081 
  - when the secrets manager secret is rotated, the MySQL driver throws a nested exception where the outer exception does not indicate a login exception but the inner exception does. Prior to these changes, our driver incorrectly concluded that this was not a login exception and threw the exception. With these changes, our driver recognizes it as a login exception and re-fetches the rotated secret, allowing the connection to be retrieved. 
- note that this fix was made in the old aws mysql driver repo but has not been ported over yet (see [here](https://github.com/awslabs/aws-mysql-jdbc/pull/275))

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.