### PR TITLE
fix: use hostId instead of host to retrieve the host weight pairs

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/RoundRobinHostSelector.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/RoundRobinHostSelector.java
@@ -57,7 +57,7 @@ public class RoundRobinHostSelector implements HostSelector {
     final StringBuilder builder = new StringBuilder();
     for (int i = 0; i < hosts.size(); i++) {
       builder
-          .append(hosts.get(i).getHost())
+          .append(hosts.get(i).getHostId())
           .append(":")
           .append(hosts.get(i).getWeight());
       if (i < hosts.size() - 1) {

--- a/wrapper/src/main/java/software/amazon/jdbc/RoundRobinHostSelector.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/RoundRobinHostSelector.java
@@ -111,7 +111,7 @@ public class RoundRobinHostSelector implements HostSelector {
         targetHostIndex = 0;
       }
 
-      final Integer weight = clusterInfo.clusterWeightsMap.get(eligibleHosts.get(targetHostIndex).getHost());
+      final Integer weight = clusterInfo.clusterWeightsMap.get(eligibleHosts.get(targetHostIndex).getHostId());
       clusterInfo.weightCounter = weight == null ? clusterInfo.defaultWeight : weight;
     }
 

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/limitless/LimitlessRouterMonitor.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/limitless/LimitlessRouterMonitor.java
@@ -258,6 +258,7 @@ public class LimitlessRouterMonitor implements AutoCloseable, Runnable {
         .role(HostRole.WRITER)
         .availability(HostAvailability.AVAILABLE)
         .weight(weight)
+        .hostId(hostName)
         .build();
   }
 }

--- a/wrapper/src/test/java/software/amazon/jdbc/RoundRobinHostSelectorTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/RoundRobinHostSelectorTest.java
@@ -527,19 +527,22 @@ public class RoundRobinHostSelectorTest {
 
   @Test
   void testSetRoundRobinHostWeightPairsProperty() {
-    final String expectedPropertyValue = "instance-1:2,instance-2:1,instance-3:0";
+    final String expectedPropertyValue = "instance-1-id:2,instance-2-id:1,instance-3-id:0";
 
     final List<HostSpec> hosts = Arrays.asList(
         new HostSpecBuilder(new SimpleHostAvailabilityStrategy())
             .host("instance-1")
+            .hostId("instance-1-id")
             .weight(2)
             .build(),
         new HostSpecBuilder(new SimpleHostAvailabilityStrategy())
             .host("instance-2")
+            .hostId("instance-2-id")
             .weight(1)
             .build(),
         new HostSpecBuilder(new SimpleHostAvailabilityStrategy())
             .host("instance-3")
+            .hostId("instance-3-id")
             .weight(0)
             .build()
     );

--- a/wrapper/src/test/java/software/amazon/jdbc/RoundRobinHostSelectorTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/RoundRobinHostSelectorTest.java
@@ -38,16 +38,27 @@ public class RoundRobinHostSelectorTest {
   private static Properties defaultProps;
   private static Properties weightedProps;
 
+  private final String host0 = "host-0";
+  private final String host1 = "host-1";
+  private final String host2 = "host-2";
+  private final String host3 = "host-3";
+  private final String host4 = "host-4";
+  private final String instance0 = "instance-0";
+  private final String instance1 = "instance-1";
+  private final String instance2 = "instance-2";
+  private final String instance3 = "instance-3";
+  private final String instance4 = "instance-4";
+
   private final HostSpec writerHostSpec = new HostSpecBuilder(new SimpleHostAvailabilityStrategy())
-      .host("instance-0").port(TEST_PORT).build();
+      .host(host0).hostId(instance0).port(TEST_PORT).build();
   private final HostSpec readerHostSpec1 = new HostSpecBuilder(new SimpleHostAvailabilityStrategy())
-      .host("instance-1").port(TEST_PORT).role(HostRole.READER).build();
+      .host(host1).hostId(instance1).port(TEST_PORT).role(HostRole.READER).build();
   private final HostSpec readerHostSpec2 = new HostSpecBuilder(new SimpleHostAvailabilityStrategy())
-      .host("instance-2").port(TEST_PORT).role(HostRole.READER).build();
+      .host(host2).hostId(instance2).port(TEST_PORT).role(HostRole.READER).build();
   private final HostSpec readerHostSpec3 = new HostSpecBuilder(new SimpleHostAvailabilityStrategy())
-      .host("instance-3").port(TEST_PORT).role(HostRole.READER).build();
+      .host(host3).hostId(instance3).port(TEST_PORT).role(HostRole.READER).build();
   private final HostSpec readerHostSpec4 = new HostSpecBuilder(new SimpleHostAvailabilityStrategy())
-      .host("instance-4").port(TEST_PORT).role(HostRole.READER).build();
+      .host(host4).hostId(instance4).port(TEST_PORT).role(HostRole.READER).build();
 
   // Each number at the end of the host list represents which readers have been added.
   private final List<HostSpec> hostsList123 = Arrays.asList(


### PR DESCRIPTION
### Summary

Use hostId instead of host to retrieve the host weight pairs

### Description

The round robin host selector strategy was using the host instance of the hostId to obtain user provided weights from the `roundRobinHostWeightPairs` property.

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.