### PR TITLE
feat: Limitless plugin - change column name from dns_host to router_endpoint in router query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Logic and a connection property to enable driver failover when network exceptions occur in the connect pipeline (PR #1099)[https://github.com/aws/aws-advanced-jdbc-wrapper/pull/1099]
 - A new reworked and re-architected failover plugin (PR #1089)[https://github.com/aws/aws-advanced-jdbc-wrapper/pull/1089]
 - Virtual Threading support (PR #1120)[https://github.com/aws/aws-advanced-jdbc-wrapper/pull/1120]
+- Limitless Connection Plugin. See [UsingTheLimitlessConnectionPlugin.md](https://github.com/aws/aws-advanced-jdbc-wrapper/blob/main/docs/using-the-jdbc-driver/using-plugins/UsingTheLimitlessConnectionPlugin.md).
 
 ## [2.3.9] - 2024-08-09
 

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/limitless/LimitlessRouterMonitor.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/limitless/LimitlessRouterMonitor.java
@@ -227,7 +227,7 @@ public class LimitlessRouterMonitor implements AutoCloseable, Runnable {
 
     try (final Statement stmt = conn.createStatement();
          final ResultSet resultSet = stmt.executeQuery(
-             "select dns_host, load from aurora_limitless_router_endpoints()")) {
+             "select router_endpoint, load from aurora_limitless_router_endpoints()")) {
       return mapResultSetToHostSpecList(resultSet);
     } catch (final SQLSyntaxErrorException e) {
       throw new SQLException(Messages.get("LimitlessRouterMonitor.invalidQuery"), e);


### PR DESCRIPTION
### Summary

The column name for the router query is changing names. This is to adjust to that. 

### Description

<!--- Details of what you changed -->

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.