### PR TITLE
Don't get Statement from closed ResultSet

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/util/WrapperUtils.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/WrapperUtils.java
@@ -579,7 +579,7 @@ public class WrapperUtils {
         return !stmt.isClosed() ? stmt.getConnection() : null;
       } else if (obj instanceof ResultSet) {
         final ResultSet rs = (ResultSet) obj;
-        final Statement stmt = rs.getStatement();
+        final Statement stmt = !rs.isClosed() ? rs.getStatement() : null;
         return stmt != null && !stmt.isClosed() ? stmt.getConnection() : null;
       }
     } catch (final SQLException | UnsupportedOperationException e) {

--- a/wrapper/src/test/java/software/amazon/jdbc/util/WrapperUtilsTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/util/WrapperUtilsTest.java
@@ -161,6 +161,16 @@ public class WrapperUtilsTest {
   }
 
   @Test
+  void getConnectionFromSqlObjectChecksResultSetNotClosed() throws Exception {
+    final ResultSet mockResultSet = mock(ResultSet.class);
+    when(mockResultSet.isClosed()).thenReturn(true);
+    when(mockResultSet.getStatement()).thenThrow(IllegalStateException.class);
+
+    final Connection rsConn = WrapperUtils.getConnectionFromSqlObject(mockResultSet);
+    assertNull(rsConn);
+  }
+
+  @Test
   void testStatementWrapper() throws InstantiationException {
     ConnectionPluginManager mockPluginManager = mock(ConnectionPluginManager.class);
 


### PR DESCRIPTION
### Summary

Don't attempt to get a statement from a closed ResultSet in getConnectionFromSqlObject.

### Description

It's possible that getConnectionFromSqlObject is called on a ResultSet that is already closed, e.g. in DefaultConnectionPlugin when calling .close on a ResultSet. With some implementations, such as PgResultSet, calling getStatement on a closed ResultSet throws an SQLException. There is a performance overhead associated with creating and catching these exceptions everytime a ResultSet is used, and closed, so it should be avoided.

This is similar to an earlier issue fixed here: https://github.com/aws/aws-advanced-jdbc-wrapper/pull/682

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.