### PR TITLE
fix: SlidingExpirationCache and SlidingExpirationCacheWithCleanupThread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### :bug: Fixed
 - Use the cluster URL as the default cluster ID ([PR #1131](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/1131)).
+- Fix logic in SlidingExpirationCache and SlidingExpirationCacheWithCleanupThread ([PR #1142](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/1142)).
 
 ## [2.4.0] - 2024-09-25
 

--- a/wrapper/src/main/java/software/amazon/jdbc/util/SlidingExpirationCache.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/SlidingExpirationCache.java
@@ -133,6 +133,10 @@ public class SlidingExpirationCache<K, V> {
       return cacheItem;
     });
 
+    if (itemList.isEmpty()) {
+      return;
+    }
+
     V item = itemList.get(0);
     if (item != null && itemDisposalFunc != null) {
       itemDisposalFunc.dispose(item);

--- a/wrapper/src/main/java/software/amazon/jdbc/util/SlidingExpirationCacheWithCleanupThread.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/SlidingExpirationCacheWithCleanupThread.java
@@ -32,8 +32,8 @@ public class SlidingExpirationCacheWithCleanupThread<K, V> extends SlidingExpira
     monitoringThread.setDaemon(true);
     return monitoringThread;
   });
+  protected final ReentrantLock initLock = new ReentrantLock();
   protected boolean isInitialized = false;
-  protected ReentrantLock initLock = new ReentrantLock();
 
   public SlidingExpirationCacheWithCleanupThread() {
     super();

--- a/wrapper/src/main/java/software/amazon/jdbc/util/SlidingExpirationCacheWithCleanupThread.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/SlidingExpirationCacheWithCleanupThread.java
@@ -27,13 +27,13 @@ public class SlidingExpirationCacheWithCleanupThread<K, V> extends SlidingExpira
   private static final Logger LOGGER =
       Logger.getLogger(SlidingExpirationCacheWithCleanupThread.class.getName());
 
-  protected static final ExecutorService cleanupThreadPool = Executors.newFixedThreadPool(1, runnableTarget -> {
+  protected final ExecutorService cleanupThreadPool = Executors.newFixedThreadPool(1, runnableTarget -> {
     final Thread monitoringThread = new Thread(runnableTarget);
     monitoringThread.setDaemon(true);
     return monitoringThread;
   });
-  protected static boolean isInitialized = false;
-  protected static ReentrantLock initLock = new ReentrantLock();
+  protected boolean isInitialized = false;
+  protected ReentrantLock initLock = new ReentrantLock();
 
   public SlidingExpirationCacheWithCleanupThread() {
     super();


### PR DESCRIPTION
### Summary

fix: SlidingExpirationCache and SlidingExpirationCacheWithCleanupThread

### Description

Contains fixes for SlidingExpirationCache and SlidingExpirationCacheWithCleanupThread:
- in SlidingExpirationCache, synchronized shouldCleanup check and subsequent removal from cache. This prevents the scenario where a cache item is grabbed after shouldCleanup() returns true but before its removed from the cache.
- in SlidingExpirationCacheWithCleanupThread, some cleanup thread variables were static, which made it so that only one cache could create a cleanup thread. By removing the static keyword we ensure each cache has its own cleanup thread.

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.