### PR TITLE
fix - update limitless DB Shard Group DNS pattern

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/ConnectionPluginManager.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/ConnectionPluginManager.java
@@ -67,7 +67,7 @@ public class ConnectionPluginManager implements CanReleaseResources, Wrapper {
   protected static final Map<Class<? extends ConnectionPlugin>, String> pluginNameByClass =
       new HashMap<Class<? extends ConnectionPlugin>, String>() {
         {
-          put(LimitlessConnectionPlugin.class, "plugin:endpoint");
+          put(LimitlessConnectionPlugin.class, "plugin:limitless");
           put(ExecutionTimeConnectionPlugin.class, "plugin:executionTime");
           put(AuroraConnectionTrackerPlugin.class, "plugin:auroraConnectionTracker");
           put(LogQueryConnectionPlugin.class, "plugin:logQuery");

--- a/wrapper/src/main/java/software/amazon/jdbc/util/RdsUtils.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/RdsUtils.java
@@ -75,7 +75,7 @@ public class RdsUtils {
   private static final Pattern AURORA_DNS_PATTERN =
       Pattern.compile(
           "^(?<instance>.+)\\."
-              + "(?<dns>proxy-|cluster-|cluster-ro-|cluster-custom-|limitless-)?"
+              + "(?<dns>proxy-|cluster-|cluster-ro-|cluster-custom-|shardgrp-)?"
               + "(?<domain>[a-zA-Z0-9]+\\.(?<region>[a-zA-Z0-9\\-]+)"
               + "\\.rds\\.amazonaws\\.com)$",
           Pattern.CASE_INSENSITIVE);
@@ -90,14 +90,14 @@ public class RdsUtils {
   private static final Pattern AURORA_LIMITLESS_CLUSTER_PATTERN =
       Pattern.compile(
           "(?<instance>.+)\\."
-              + "(?<dns>limitless-)+"
+              + "(?<dns>shardgrp-)+"
               + "(?<domain>[a-zA-Z0-9]+\\.(?<region>[a-zA-Z0-9\\-]+)"
-              + "\\.rds\\.(amazonaws\\.com(\\.cn)?|sc2s\\.sgov\\.gov|c2s\\.ic\\.gov))",
+              + "\\.rds\\.(amazonaws\\.com(\\.cn)?|sc2s\\.sgov\\.gov|c2s\\.ic\\.gov))$",
           Pattern.CASE_INSENSITIVE);
   private static final Pattern AURORA_CHINA_DNS_PATTERN =
       Pattern.compile(
           "^(?<instance>.+)\\."
-              + "(?<dns>proxy-|cluster-|cluster-ro-|cluster-custom-|limitless-)?"
+              + "(?<dns>proxy-|cluster-|cluster-ro-|cluster-custom-|shardgrp-)?"
               + "(?<domain>[a-zA-Z0-9]+\\.rds\\.(?<region>[a-zA-Z0-9\\-]+)"
               + "\\.amazonaws\\.com\\.cn)$",
           Pattern.CASE_INSENSITIVE);
@@ -113,7 +113,7 @@ public class RdsUtils {
   private static final Pattern AURORA_OLD_CHINA_DNS_PATTERN =
       Pattern.compile(
           "^(?<instance>.+)\\."
-              + "(?<dns>proxy-|cluster-|cluster-ro-|cluster-custom-|limitless-)?"
+              + "(?<dns>proxy-|cluster-|cluster-ro-|cluster-custom-|shardgrp-)?"
               + "(?<domain>[a-zA-Z0-9]+\\.(?<region>[a-zA-Z0-9\\-]+)"
               + "\\.rds\\.amazonaws\\.com\\.cn)$",
           Pattern.CASE_INSENSITIVE);
@@ -129,7 +129,7 @@ public class RdsUtils {
   private static final Pattern AURORA_GOV_DNS_PATTERN =
       Pattern.compile(
           "^(?<instance>.+)\\."
-              + "(?<dns>proxy-|cluster-|cluster-ro-|cluster-custom-|limitless-)?"
+              + "(?<dns>proxy-|cluster-|cluster-ro-|cluster-custom-|shardgrp-)?"
               + "(?<domain>[a-zA-Z0-9]+\\.rds\\.(?<region>[a-zA-Z0-9\\-]+)"
               + "\\.(amazonaws\\.com|c2s\\.ic\\.gov|sc2s\\.sgov\\.gov))$",
           Pattern.CASE_INSENSITIVE);
@@ -258,7 +258,7 @@ public class RdsUtils {
 
   public boolean isLimitlessDbShardGroupDns(final String host) {
     final String dnsGroup = getDnsGroup(host);
-    return dnsGroup != null && dnsGroup.equalsIgnoreCase("limitless-");
+    return dnsGroup != null && dnsGroup.equalsIgnoreCase("shardgrp-");
   }
 
   public String getRdsClusterHostUrl(final String host) {
@@ -284,7 +284,7 @@ public class RdsUtils {
     }
     final Matcher limitlessMatcher = AURORA_LIMITLESS_CLUSTER_PATTERN.matcher(host);
     if (limitlessMatcher.find()) {
-      return host.replaceAll(AURORA_LIMITLESS_CLUSTER_PATTERN.pattern(), "${instance}.limitless-${domain}");
+      return host.replaceAll(AURORA_LIMITLESS_CLUSTER_PATTERN.pattern(), "${instance}.cluster-${domain}");
     }
     return null;
   }

--- a/wrapper/src/test/java/software/amazon/jdbc/util/RdsUtilsTests.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/util/RdsUtilsTests.java
@@ -38,7 +38,7 @@ public class RdsUtilsTests {
   private static final String usEastRegionCustomDomain =
       "custom-test-name.cluster-custom-XYZ.us-east-2.rds.amazonaws.com";
   private static final String usEastRegionLimitlessDbShardGroup =
-      "database-test-name.limitless-XYZ.us-east-2.rds.amazonaws.com";
+      "database-test-name.shardgrp-XYZ.us-east-2.rds.amazonaws.com";
 
   private static final String chinaRegionCluster =
       "database-test-name.cluster-XYZ.rds.cn-northwest-1.amazonaws.com.cn";
@@ -51,7 +51,7 @@ public class RdsUtilsTests {
   private static final String chinaRegionCustomDomain =
       "custom-test-name.cluster-custom-XYZ.rds.cn-northwest-1.amazonaws.com.cn";
   private static final String chinaRegionLimitlessDbShardGroup =
-      "database-test-name.limitless-XYZ.rds.cn-northwest-1.amazonaws.com.cn";
+      "database-test-name.shardgrp-XYZ.rds.cn-northwest-1.amazonaws.com.cn";
 
   private static final String oldChinaRegionCluster =
       "database-test-name.cluster-XYZ.cn-northwest-1.rds.amazonaws.com.cn";
@@ -64,7 +64,7 @@ public class RdsUtilsTests {
   private static final String oldChinaRegionCustomDomain =
       "custom-test-name.cluster-custom-XYZ.cn-northwest-1.rds.amazonaws.com.cn";
   private static final String oldChinaRegionLimitlessDbShardGroup =
-      "database-test-name.limitless-XYZ.cn-northwest-1.rds.amazonaws.com.cn";
+      "database-test-name.shardgrp-XYZ.cn-northwest-1.rds.amazonaws.com.cn";
 
   private static final String extraRdsChinaPath =
       "database-test-name.cluster-XYZ.rds.cn-northwest-1.rds.amazonaws.com.cn";
@@ -88,7 +88,7 @@ public class RdsUtilsTests {
   private static final String usIsobEastRegionCustomDomain =
       "custom-test-name.cluster-custom-XYZ.rds.us-isob-east-1.sc2s.sgov.gov";
   private static final String usIsobEastRegionLimitlessDbShardGroup =
-      "database-test-name.limitless-XYZ.rds.us-isob-east-1.sc2s.sgov.gov";
+      "database-test-name.shardgrp-XYZ.rds.us-isob-east-1.sc2s.sgov.gov";
 
   private static final String usGovEastRegionCluster =
       "database-test-name.cluster-XYZ.rds.us-gov-east-1.amazonaws.com";
@@ -103,7 +103,7 @@ public class RdsUtilsTests {
   private static final String usIsoEastRegionCustomDomain =
       "custom-test-name.cluster-custom-XYZ.rds.us-iso-east-1.c2s.ic.gov";
   private static final String usIsoEastRegionLimitlessDbShardGroup =
-      "database-test-name.limitless-XYZ.rds.us-iso-east-1.c2s.ic.gov";
+      "database-test-name.shardgrp-XYZ.rds.us-iso-east-1.c2s.ic.gov";
 
   @BeforeEach
   public void setupTests() {


### PR DESCRIPTION
### Summary

fix - update limitless DB Shard Group DNS pattern

### Description

Change the limitless DNS Pattern from "limitless" to "dbshardgrp"

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.