### PR TITLE
Fix/limitless dialect check + refactor synchronous router fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### :bug: Fixed
 - Use the cluster URL as the default cluster ID ([PR #1131](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/1131)).
 - Fix logic in SlidingExpirationCache and SlidingExpirationCacheWithCleanupThread ([PR #1142](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/1142)).
+- Limitless Connection Plugin to check dialect and attempt recovery in case an unsupported dialect is encountered ([PR #1148](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/1148)).
+
+### :crab: Changed
+- Updated expected URL patterns for Limitless Databases ([PR #1147](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/1147)).
 
 ## [2.4.0] - 2024-09-25
 

--- a/docs/using-the-jdbc-driver/using-plugins/UsingTheLimitlessConnectionPlugin.md
+++ b/docs/using-the-jdbc-driver/using-plugins/UsingTheLimitlessConnectionPlugin.md
@@ -4,7 +4,7 @@
 
 Amazon Aurora Limitless Database is a new type of database that can horizontally scale to handle millions of write transactions per second and manage petabytes of data.
 Users will be able to use the AWS JDBC Driver with Aurora Limitless Databases and optimize their experience using the Limitless Connection Plugin. 
-To learn more about Aurora Limitless Database, see the [Amazon Aurora Limitless documentation](// TODO).
+To learn more about Aurora Limitless Database, see the [Amazon Aurora Limitless documentation](https://aws.amazon.com/about-aws/whats-new/2023/11/amazon-aurora-limitless-database/).
 
 ## Why use the Limitless Connection Plugin?
 

--- a/wrapper/src/main/java/software/amazon/jdbc/HostSpec.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/HostSpec.java
@@ -145,6 +145,10 @@ public class HostSpec {
     return this.weight;
   }
 
+  public void setWeight(long weight) {
+    this.weight = weight;
+  }
+
   public void addAlias(final String... alias) {
     if (alias == null || alias.length < 1) {
       return;

--- a/wrapper/src/main/java/software/amazon/jdbc/dialect/AuroraLimitlessDialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/dialect/AuroraLimitlessDialect.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.jdbc.dialect;
+
+public interface AuroraLimitlessDialect extends Dialect {
+  String getLimitlessRouterEndpointQuery();
+}

--- a/wrapper/src/main/java/software/amazon/jdbc/dialect/AuroraPgDialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/dialect/AuroraPgDialect.java
@@ -29,7 +29,7 @@ import software.amazon.jdbc.plugin.failover2.FailoverConnectionPlugin;
  * Suitable for the following AWS PG configurations.
  * - Regional Cluster
  */
-public class AuroraPgDialect extends PgDialect {
+public class AuroraPgDialect extends PgDialect implements AuroraLimitlessDialect {
   private static final Logger LOGGER = Logger.getLogger(AuroraPgDialect.class.getName());
 
   private static final String extensionsSql =
@@ -53,6 +53,8 @@ public class AuroraPgDialect extends PgDialect {
 
   private static final String NODE_ID_QUERY = "SELECT aurora_db_instance_identifier()";
   private static final String IS_READER_QUERY = "SELECT pg_is_in_recovery()";
+  protected static final String LIMITLESS_ROUTER_ENDPOINT_QUERY =
+      "select router_endopint, load from aurora_limitless_router_endpoints()";
 
   @Override
   public boolean isDialect(final Connection connection) {
@@ -148,5 +150,10 @@ public class AuroraPgDialect extends PgDialect {
           NODE_ID_QUERY,
           IS_READER_QUERY);
     };
+  }
+
+  @Override
+  public String getLimitlessRouterEndpointQuery() {
+    return LIMITLESS_ROUTER_ENDPOINT_QUERY;
   }
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/dialect/AuroraPgDialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/dialect/AuroraPgDialect.java
@@ -54,7 +54,7 @@ public class AuroraPgDialect extends PgDialect implements AuroraLimitlessDialect
   private static final String NODE_ID_QUERY = "SELECT aurora_db_instance_identifier()";
   private static final String IS_READER_QUERY = "SELECT pg_is_in_recovery()";
   protected static final String LIMITLESS_ROUTER_ENDPOINT_QUERY =
-      "select router_endopint, load from aurora_limitless_router_endpoints()";
+      "select router_endpoint, load from aurora_limitless_router_endpoints()";
 
   @Override
   public boolean isDialect(final Connection connection) {

--- a/wrapper/src/main/java/software/amazon/jdbc/dialect/DialectManager.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/dialect/DialectManager.java
@@ -170,7 +170,13 @@ public class DialectManager implements DialectProvider {
 
     if (driverProtocol.contains("postgresql")) {
       RdsUrlType type = this.rdsHelper.identifyRdsType(host);
-      if (type.isRdsCluster() || RdsUrlType.RDS_AURORA_LIMITLESS_DB_SHARD_GROUP.equals(type)) {
+      if (RdsUrlType.RDS_AURORA_LIMITLESS_DB_SHARD_GROUP.equals(type)) {
+        this.canUpdate = false;
+        this.dialectCode = DialectCodes.AURORA_PG;
+        this.dialect = knownDialectsByCode.get(DialectCodes.AURORA_PG);
+        return this.dialect;
+      }
+      if (type.isRdsCluster()) {
         this.canUpdate = true;
         this.dialectCode = DialectCodes.AURORA_PG;
         this.dialect = knownDialectsByCode.get(DialectCodes.AURORA_PG);

--- a/wrapper/src/main/java/software/amazon/jdbc/dialect/DialectManager.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/dialect/DialectManager.java
@@ -170,7 +170,7 @@ public class DialectManager implements DialectProvider {
 
     if (driverProtocol.contains("postgresql")) {
       RdsUrlType type = this.rdsHelper.identifyRdsType(host);
-      if (type.isRdsCluster()) {
+      if (type.isRdsCluster() || RdsUrlType.RDS_AURORA_LIMITLESS_DB_SHARD_GROUP.equals(type)) {
         this.canUpdate = true;
         this.dialectCode = DialectCodes.AURORA_PG;
         this.dialect = knownDialectsByCode.get(DialectCodes.AURORA_PG);

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/limitless/LimitlessConnectionPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/limitless/LimitlessConnectionPlugin.java
@@ -130,7 +130,7 @@ public class LimitlessConnectionPlugin extends AbstractConnectionPlugin {
       final boolean isInitialConnection,
       final JdbcCallable<Connection, SQLException> connectFunc) throws SQLException {
     final Dialect dialect = this.pluginService.getDialect();
-    if (AuroraLimitlessDialect.class.isAssignableFrom(dialect.getClass())) {
+    if (dialect instanceof AuroraLimitlessDialect) {
       return connectInternalWithDialect(driverProtocol, hostSpec, props, isInitialConnection, connectFunc);
     } else {
       return connectInternalWithoutDialect(driverProtocol, hostSpec, props, isInitialConnection, connectFunc);
@@ -204,7 +204,7 @@ public class LimitlessConnectionPlugin extends AbstractConnectionPlugin {
     final Connection conn = connectFunc.call();
 
     final Dialect dialect = this.pluginService.getDialect();
-    if (AuroraLimitlessDialect.class.isAssignableFrom(dialect.getClass())) {
+    if (dialect instanceof AuroraLimitlessDialect) {
       throw new SQLException(""); // TODO: add message
     }
 

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/limitless/LimitlessConnectionPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/limitless/LimitlessConnectionPlugin.java
@@ -67,8 +67,8 @@ public class LimitlessConnectionPlugin extends AbstractConnectionPlugin {
       "Max number of connection retries the Limitless Connection Plugin will attempt.");
   protected static final List<Class> SUPPORTED_DIALECTS = Arrays.asList(AuroraLimitlessDialect.class);
   protected final PluginService pluginService;
-  protected final @NonNull Properties properties;
-  private final @NonNull Supplier<LimitlessRouterService> limitlessRouterServiceSupplier;
+  protected final Properties properties;
+  private final Supplier<LimitlessRouterService> limitlessRouterServiceSupplier;
   private LimitlessRouterService limitlessRouterService;
   private static final Set<String> subscribedMethods =
       Collections.unmodifiableSet(new HashSet<String>() {
@@ -90,7 +90,7 @@ public class LimitlessConnectionPlugin extends AbstractConnectionPlugin {
   public LimitlessConnectionPlugin(final PluginService pluginService, final @NonNull Properties properties) {
     this(pluginService,
         properties,
-        LimitlessRouterServiceImpl::new);
+        () -> new LimitlessRouterServiceImpl(pluginService));
   }
 
   public LimitlessConnectionPlugin(
@@ -156,7 +156,7 @@ public class LimitlessConnectionPlugin extends AbstractConnectionPlugin {
     initLimitlessRouterMonitorService();
     if (isInitialConnection) {
       this.limitlessRouterService
-          .startMonitoring(pluginService, hostSpec, properties, INTERVAL_MILLIS.getInteger(properties));
+          .startMonitoring(hostSpec, properties, INTERVAL_MILLIS.getInteger(properties));
     }
 
     List<HostSpec> limitlessRouters = this.limitlessRouterService.getLimitlessRouters(

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/limitless/LimitlessConnectionPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/limitless/LimitlessConnectionPlugin.java
@@ -18,6 +18,7 @@ package software.amazon.jdbc.plugin.limitless;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -64,6 +65,7 @@ public class LimitlessConnectionPlugin extends AbstractConnectionPlugin {
       "limitlessConnectMaxRetries",
       "5",
       "Max number of connection retries the Limitless Connection Plugin will attempt.");
+  protected static final List<Class> SUPPORTED_DIALECTS = Arrays.asList(AuroraLimitlessDialect.class);
   protected final PluginService pluginService;
   protected final @NonNull Properties properties;
   private final @NonNull Supplier<LimitlessRouterService> limitlessRouterServiceSupplier;
@@ -109,7 +111,6 @@ public class LimitlessConnectionPlugin extends AbstractConnectionPlugin {
       final JdbcCallable<Connection, SQLException> connectFunc)
       throws SQLException {
     final Connection conn = connectInternal(driverProtocol, hostSpec, props, isInitialConnection, connectFunc);
-    checkDialectSupport();
     return conn;
   }
 
@@ -122,7 +123,6 @@ public class LimitlessConnectionPlugin extends AbstractConnectionPlugin {
       final @NonNull JdbcCallable<Connection, SQLException> forceConnectFunc)
       throws SQLException {
     final Connection conn = connectInternal(driverProtocol, hostSpec, props, isInitialConnection, forceConnectFunc);
-    checkDialectSupport();
     return conn;
   }
 
@@ -141,6 +141,18 @@ public class LimitlessConnectionPlugin extends AbstractConnectionPlugin {
       final boolean isInitialConnection,
       final JdbcCallable<Connection,
           SQLException> connectFunc) throws SQLException {
+
+//     final Dialect dialect = this.pluginService.getDialect();
+//     if (SUPPORTED_DIALECTS.contains(dialect)) {
+//       // TODO: happy path
+//
+//     } else {
+//       // TODO: unhappy path
+//       final Connection conn = connectFunc.call();
+//
+//     }
+
+
     initLimitlessRouterMonitorService();
     if (isInitialConnection) {
       this.limitlessRouterService
@@ -159,7 +171,9 @@ public class LimitlessConnectionPlugin extends AbstractConnectionPlugin {
         LOGGER.finest(Messages.get("LimitlessConnectionPlugin.usingProvidedConnectUrl"));
         return connectFunc.call();
       }
-    } else if (limitlessRouters.contains(hostSpec)) {
+    }
+
+    if (limitlessRouters.contains(hostSpec)) {
       LOGGER.finest(Messages.get("LimitlessConnectionPlugin.connectWithHost", new Object[] {hostSpec.getHost()}));
       return connectFunc.call();
     }

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/limitless/LimitlessQueryHelper.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/limitless/LimitlessQueryHelper.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.jdbc.plugin.limitless;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.SQLSyntaxErrorException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Executor;
+import java.util.logging.Logger;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import software.amazon.jdbc.HostRole;
+import software.amazon.jdbc.HostSpec;
+import software.amazon.jdbc.HostSpecBuilder;
+import software.amazon.jdbc.PluginService;
+import software.amazon.jdbc.dialect.AuroraLimitlessDialect;
+import software.amazon.jdbc.hostavailability.HostAvailability;
+import software.amazon.jdbc.hostavailability.SimpleHostAvailabilityStrategy;
+import software.amazon.jdbc.util.Messages;
+import software.amazon.jdbc.util.SynchronousExecutor;
+
+public class LimitlessQueryHelper {
+
+  private final @NonNull PluginService pluginService;
+  private static final Logger LOGGER = Logger.getLogger(LimitlessQueryHelper.class.getName());
+
+  public LimitlessQueryHelper(final @NonNull PluginService pluginService) {
+    this.pluginService = pluginService;
+  }
+
+  protected static final Executor networkTimeoutExecutor = new SynchronousExecutor();
+  protected static final int DEFAULT_QUERY_TIMEOUT_MS = 5000;
+
+  public List<HostSpec> queryForLimitlessRouters(final Connection conn, final int hostPortToMap) throws SQLException {
+    int networkTimeout = -1;
+    try {
+      networkTimeout = conn.getNetworkTimeout();
+      // The query is not monitored by the EFM plugin, so it needs a socket timeout
+      if (networkTimeout == 0) {
+        conn.setNetworkTimeout(networkTimeoutExecutor, DEFAULT_QUERY_TIMEOUT_MS);
+      }
+    } catch (SQLException e) {
+      LOGGER.warning(() -> Messages.get("LimitlessRouterMonitor.getNetworkTimeoutError",
+          new Object[] {e.getMessage()}));
+    }
+
+    try (final Statement stmt = conn.createStatement();
+         final ResultSet resultSet = stmt.executeQuery(
+             ((AuroraLimitlessDialect) this.pluginService.getDialect()).getLimitlessRouterEndpointQuery())) {
+      return mapResultSetToHostSpecList(resultSet, hostPortToMap);
+    } catch (final SQLSyntaxErrorException e) {
+      throw new SQLException(Messages.get("LimitlessRouterMonitor.invalidQuery"), e);
+    } finally {
+      if (networkTimeout == 0 && !conn.isClosed()) {
+        conn.setNetworkTimeout(networkTimeoutExecutor, networkTimeout);
+      }
+    }
+  }
+
+  private List<HostSpec> mapResultSetToHostSpecList(final ResultSet resultSet, final int hostPortToMap) throws SQLException {
+
+    List<HostSpec> hosts = new ArrayList<>();
+    while (resultSet.next()) {
+      final HostSpec host = createHost(resultSet, hostPortToMap);
+      hosts.add(host);
+    }
+
+    return hosts;
+  }
+
+  private HostSpec createHost(final ResultSet resultSet, final int hostPortToMap) throws SQLException {
+    final String hostName = resultSet.getString(1);
+    final float cpu = resultSet.getFloat(2);
+
+    long weight = Math.round(10 - cpu * 10);
+
+    if (weight < 1 || weight > 10) {
+      weight = 1; // default to 1
+      LOGGER.warning(() -> Messages.get(
+          "LimitlessRouterMonitor.invalidRouterLoad",
+          new Object[] {hostName, cpu}));
+    }
+
+    return new HostSpecBuilder(new SimpleHostAvailabilityStrategy())
+        .host(hostName)
+        .port(hostPortToMap)
+        .role(HostRole.WRITER)
+        .availability(HostAvailability.AVAILABLE)
+        .weight(weight)
+        .hostId(hostName)
+        .build();
+  }
+}

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/limitless/LimitlessQueryHelper.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/limitless/LimitlessQueryHelper.java
@@ -75,7 +75,9 @@ public class LimitlessQueryHelper {
     }
   }
 
-  private List<HostSpec> mapResultSetToHostSpecList(final ResultSet resultSet, final int hostPortToMap) throws SQLException {
+  private List<HostSpec> mapResultSetToHostSpecList(
+      final ResultSet resultSet,
+      final int hostPortToMap) throws SQLException {
 
     List<HostSpec> hosts = new ArrayList<>();
     while (resultSet.next()) {

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/limitless/LimitlessQueryHelper.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/limitless/LimitlessQueryHelper.java
@@ -60,6 +60,7 @@ public class LimitlessQueryHelper {
       LOGGER.warning(() -> Messages.get("LimitlessRouterMonitor.getNetworkTimeoutError",
           new Object[] {e.getMessage()}));
     }
+    // TODO: check dialect again
 
     try (final Statement stmt = conn.createStatement();
          final ResultSet resultSet = stmt.executeQuery(

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/limitless/LimitlessRouterMonitor.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/limitless/LimitlessRouterMonitor.java
@@ -46,6 +46,7 @@ import software.amazon.jdbc.hostavailability.HostAvailability;
 import software.amazon.jdbc.hostavailability.SimpleHostAvailabilityStrategy;
 import software.amazon.jdbc.util.Messages;
 import software.amazon.jdbc.util.PropertyUtils;
+import software.amazon.jdbc.util.SlidingExpirationCacheWithCleanupThread;
 import software.amazon.jdbc.util.SynchronousExecutor;
 import software.amazon.jdbc.util.Utils;
 import software.amazon.jdbc.util.telemetry.TelemetryContext;
@@ -57,19 +58,16 @@ public class LimitlessRouterMonitor implements AutoCloseable, Runnable {
   private static final Logger LOGGER =
       Logger.getLogger(LimitlessRouterMonitor.class.getName());
 
-  private static final String MONITORING_PROPERTY_PREFIX = "limitless-router-monitor-";
-  private final int intervalMs;
-  private final @NonNull HostSpec hostSpec;
-  private final @NonNull String limitlessRouterEndpointQuery;
-  private final AtomicBoolean stopped = new AtomicBoolean(false);
-  private final AtomicReference<List<HostSpec>> limitlessRouters;
-  private final @NonNull Properties props;
-  private final @NonNull PluginService pluginService;
+  protected static final String MONITORING_PROPERTY_PREFIX = "limitless-router-monitor-";
+  protected final int intervalMs;
+  protected final @NonNull HostSpec hostSpec;
+  protected final SlidingExpirationCacheWithCleanupThread<String, List<HostSpec>> limitlessRouterCache;
+  protected final String limitlessRouterCacheKey;
+  protected final @NonNull Properties props;
+  protected final @NonNull PluginService pluginService;
   protected final LimitlessQueryHelper queryHelper;
-  private final TelemetryFactory telemetryFactory;
-  private Connection monitoringConn = null;
-  final Executor networkTimeoutExecutor = new SynchronousExecutor();
-  static final int defaultQueryTimeoutMs = 5000;
+  protected final TelemetryFactory telemetryFactory;
+  protected Connection monitoringConn = null;
 
   private final ExecutorService threadPool = Executors.newFixedThreadPool(1, runnableTarget -> {
     final Thread monitoringThread = new Thread(runnableTarget);
@@ -77,18 +75,19 @@ public class LimitlessRouterMonitor implements AutoCloseable, Runnable {
     return monitoringThread;
   });
 
-  private final ReentrantLock lock = new ReentrantLock();
+  private final AtomicBoolean stopped = new AtomicBoolean(false);
 
   public LimitlessRouterMonitor(
       final @NonNull PluginService pluginService,
       final @NonNull HostSpec hostSpec,
-      final @NonNull List<HostSpec> limitlessRouters,
+      final @NonNull SlidingExpirationCacheWithCleanupThread<String, List<HostSpec>> limitlessRouterCache,
+      final @NonNull String limitlessRouterCacheKey,
       final @NonNull Properties props,
       final int intervalMs) {
     this.pluginService = pluginService;
     this.hostSpec = hostSpec;
-    this.limitlessRouterEndpointQuery = getLimitlessRouterEndpointQuery();
-    this.limitlessRouters = new AtomicReference<>(limitlessRouters);
+    this.limitlessRouterCache = limitlessRouterCache;
+    this.limitlessRouterCacheKey = limitlessRouterCacheKey;
     this.props = PropertyUtils.copyProperties(props);
     props.stringPropertyNames().stream()
         .filter(p -> p.startsWith(MONITORING_PROPERTY_PREFIX))
@@ -108,17 +107,9 @@ public class LimitlessRouterMonitor implements AutoCloseable, Runnable {
     this.threadPool.shutdown(); // No more task are accepted by pool.
   }
 
-  private String getLimitlessRouterEndpointQuery() {
-    Dialect dialect = this.pluginService.getDialect();
-    if (dialect instanceof AuroraLimitlessDialect) {
-      return ((AuroraLimitlessDialect) dialect).getLimitlessRouterEndpointQuery();
-    }
-    throw new UnsupportedOperationException(Messages.get("LimitlessRouterMonitor.unsupportedDialectOrDatabase",
-        new Object[] {dialect}));
-  }
-
   public List<HostSpec> getLimitlessRouters() {
-    return this.limitlessRouters.get();
+    return this.limitlessRouterCache.get(this.limitlessRouterCacheKey,
+        TimeUnit.MILLISECONDS.toNanos(LimitlessRouterServiceImpl.MONITOR_DISPOSAL_TIME_MS.getLong(props)));
   }
 
   public AtomicBoolean isStopped() {
@@ -155,9 +146,13 @@ public class LimitlessRouterMonitor implements AutoCloseable, Runnable {
         }
         List<HostSpec> newLimitlessRouters = queryHelper.queryForLimitlessRouters(this.monitoringConn,
             this.hostSpec.getPort());
-        this.limitlessRouters.set(Collections.unmodifiableList(newLimitlessRouters));
+
+        limitlessRouterCache.put(
+            this.limitlessRouterCacheKey,
+            newLimitlessRouters, LimitlessRouterServiceImpl.MONITOR_DISPOSAL_TIME_MS.getLong(props));
+
         RoundRobinHostSelector.setRoundRobinHostWeightPairsProperty(this.props, newLimitlessRouters);
-        LOGGER.finest(Utils.logTopology(limitlessRouters.get(), "[limitlessRouterMonitor]"));
+        LOGGER.finest(Utils.logTopology(newLimitlessRouters, "[limitlessRouterMonitor]"));
         TimeUnit.MILLISECONDS.sleep(this.intervalMs); // do not include this in the telemetry
       } catch (final InterruptedException exception) {
         LOGGER.finest(
@@ -179,27 +174,6 @@ public class LimitlessRouterMonitor implements AutoCloseable, Runnable {
           telemetryContext.closeContext();
         }
       }
-    }
-  }
-
-  public List<HostSpec> forceGetLimitlessRouters() throws SQLException {
-    LOGGER.finest(Messages.get("LimitlessRouterMonitor.forceGetLimitlessRouters"));
-
-    lock.lock();
-    try {
-      this.openConnection();
-      if (this.monitoringConn == null || this.monitoringConn.isClosed()) {
-        throw new SQLException(Messages.get("LimitlessRouterMonitor.forceGetLimitlessRoutersFailed"));
-      }
-      List<HostSpec> newLimitlessRouters = queryHelper.queryForLimitlessRouters(this.monitoringConn,
-          this.hostSpec.getPort());
-      this.limitlessRouters.set(Collections.unmodifiableList(newLimitlessRouters));
-      RoundRobinHostSelector.setRoundRobinHostWeightPairsProperty(this.props, newLimitlessRouters);
-      LOGGER.finest(Utils.logTopology(limitlessRouters.get(), "[limitlessRouterMonitor]"));
-      return newLimitlessRouters;
-
-    } finally {
-      lock.unlock();
     }
   }
 
@@ -226,64 +200,5 @@ public class LimitlessRouterMonitor implements AutoCloseable, Runnable {
       }
       throw ex;
     }
-  }
-
-  private List<HostSpec> queryForLimitlessRouters(final Connection conn) throws SQLException {
-    int networkTimeout = -1;
-    try {
-      networkTimeout = conn.getNetworkTimeout();
-      // The query is not monitored by the EFM plugin, so it needs a socket timeout
-      if (networkTimeout == 0) {
-        conn.setNetworkTimeout(networkTimeoutExecutor, defaultQueryTimeoutMs);
-      }
-    } catch (SQLException e) {
-      LOGGER.warning(() -> Messages.get("LimitlessRouterMonitor.getNetworkTimeoutError",
-          new Object[] {e.getMessage()}));
-    }
-
-    try (final Statement stmt = conn.createStatement();
-         final ResultSet resultSet = stmt.executeQuery(this.limitlessRouterEndpointQuery)) {
-      return mapResultSetToHostSpecList(resultSet);
-    } catch (final SQLSyntaxErrorException e) {
-      throw new SQLException(Messages.get("LimitlessRouterMonitor.invalidQuery"), e);
-    } finally {
-      if (networkTimeout == 0 && !conn.isClosed()) {
-        conn.setNetworkTimeout(networkTimeoutExecutor, networkTimeout);
-      }
-    }
-  }
-
-  private List<HostSpec> mapResultSetToHostSpecList(final ResultSet resultSet) throws SQLException {
-
-    List<HostSpec> hosts = new ArrayList<>();
-    while (resultSet.next()) {
-      final HostSpec host = createHost(resultSet);
-      hosts.add(host);
-    }
-
-    return hosts;
-  }
-
-  private HostSpec createHost(final ResultSet resultSet) throws SQLException {
-    final String hostName = resultSet.getString(1);
-    final float cpu = resultSet.getFloat(2);
-
-    long weight = Math.round(10 - cpu * 10);
-
-    if (weight < 1 || weight > 10) {
-      weight = 1; // default to 1
-      LOGGER.warning(() -> Messages.get(
-          "LimitlessRouterMonitor.invalidRouterLoad",
-          new Object[] {hostName, cpu}));
-    }
-
-    return new HostSpecBuilder(new SimpleHostAvailabilityStrategy())
-        .host(hostName)
-        .port(this.hostSpec.getPort())
-        .role(HostRole.WRITER)
-        .availability(HostAvailability.AVAILABLE)
-        .weight(weight)
-        .hostId(hostName)
-        .build();
   }
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/limitless/LimitlessRouterMonitor.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/limitless/LimitlessRouterMonitor.java
@@ -62,8 +62,7 @@ public class LimitlessRouterMonitor implements AutoCloseable, Runnable {
   private final @NonNull HostSpec hostSpec;
   private final @NonNull String limitlessRouterEndpointQuery;
   private final AtomicBoolean stopped = new AtomicBoolean(false);
-  private final AtomicReference<List<HostSpec>> limitlessRouters = new AtomicReference<>(
-      Collections.unmodifiableList(new ArrayList<>()));
+  private final AtomicReference<List<HostSpec>> limitlessRouters;
   private final @NonNull Properties props;
   private final @NonNull PluginService pluginService;
   private final TelemetryFactory telemetryFactory;
@@ -82,11 +81,13 @@ public class LimitlessRouterMonitor implements AutoCloseable, Runnable {
   public LimitlessRouterMonitor(
       final @NonNull PluginService pluginService,
       final @NonNull HostSpec hostSpec,
+      final @NonNull AtomicReference<List<HostSpec>> limitlessRouters,
       final @NonNull Properties props,
       final int intervalMs) {
     this.pluginService = pluginService;
     this.hostSpec = hostSpec;
     this.limitlessRouterEndpointQuery = getLimitlessRouterEndpointQuery();
+    this.limitlessRouters = limitlessRouters;
     this.props = PropertyUtils.copyProperties(props);
 
     props.stringPropertyNames().stream()

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/limitless/LimitlessRouterMonitor.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/limitless/LimitlessRouterMonitor.java
@@ -81,13 +81,13 @@ public class LimitlessRouterMonitor implements AutoCloseable, Runnable {
   public LimitlessRouterMonitor(
       final @NonNull PluginService pluginService,
       final @NonNull HostSpec hostSpec,
-      final @NonNull AtomicReference<List<HostSpec>> limitlessRouters,
+      final @NonNull List<HostSpec> limitlessRouters,
       final @NonNull Properties props,
       final int intervalMs) {
     this.pluginService = pluginService;
     this.hostSpec = hostSpec;
     this.limitlessRouterEndpointQuery = getLimitlessRouterEndpointQuery();
-    this.limitlessRouters = limitlessRouters;
+    this.limitlessRouters = new AtomicReference<>(limitlessRouters);
     this.props = PropertyUtils.copyProperties(props);
 
     props.stringPropertyNames().stream()

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/limitless/LimitlessRouterMonitorInitializer.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/limitless/LimitlessRouterMonitorInitializer.java
@@ -22,13 +22,15 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import software.amazon.jdbc.HostSpec;
 import software.amazon.jdbc.PluginService;
+import software.amazon.jdbc.util.SlidingExpirationCacheWithCleanupThread;
 
 @FunctionalInterface
 public interface LimitlessRouterMonitorInitializer {
   LimitlessRouterMonitor createLimitlessRouterMonitor(
       final PluginService pluginService,
       final HostSpec hostSpec,
-      final List<HostSpec> limitlessRouters,
+      final SlidingExpirationCacheWithCleanupThread<String, List<HostSpec>> limitlessRouterCache,
+      final String limitlessRouterCacheKey,
       final Properties props,
       final int intervalMs
   );

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/limitless/LimitlessRouterMonitorInitializer.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/limitless/LimitlessRouterMonitorInitializer.java
@@ -28,7 +28,7 @@ public interface LimitlessRouterMonitorInitializer {
   LimitlessRouterMonitor createLimitlessRouterMonitor(
       final PluginService pluginService,
       final HostSpec hostSpec,
-      final AtomicReference<List<HostSpec>> limitlessRouters,
+      final List<HostSpec> limitlessRouters,
       final Properties props,
       final int intervalMs
   );

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/limitless/LimitlessRouterMonitorInitializer.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/limitless/LimitlessRouterMonitorInitializer.java
@@ -16,7 +16,10 @@
 
 package software.amazon.jdbc.plugin.limitless;
 
+import java.util.List;
 import java.util.Properties;
+import java.util.concurrent.atomic.AtomicReference;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import software.amazon.jdbc.HostSpec;
 import software.amazon.jdbc.PluginService;
 
@@ -25,6 +28,7 @@ public interface LimitlessRouterMonitorInitializer {
   LimitlessRouterMonitor createLimitlessRouterMonitor(
       final PluginService pluginService,
       final HostSpec hostSpec,
+      final AtomicReference<List<HostSpec>> limitlessRouters,
       final Properties props,
       final int intervalMs
   );

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/limitless/LimitlessRouterService.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/limitless/LimitlessRouterService.java
@@ -30,7 +30,7 @@ public interface LimitlessRouterService {
   List<HostSpec> getLimitlessRouters(final String clusterId, final Properties props) throws SQLException;
 
   List<HostSpec> forceGetLimitlessRoutersWithConn(
-      final Supplier<Connection> connectionSupplier, final int hostPort, final Properties props)  throws SQLException;
+      final Connection connection, final int hostPort, final Properties props)  throws SQLException;
 
   List<HostSpec> forceGetLimitlessRouters(final String clusterId, final Properties props) throws SQLException;
 

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/limitless/LimitlessRouterService.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/limitless/LimitlessRouterService.java
@@ -16,6 +16,7 @@
 
 package software.amazon.jdbc.plugin.limitless;
 
+import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Properties;
@@ -27,9 +28,12 @@ public interface LimitlessRouterService {
 
   List<HostSpec> getLimitlessRouters(final String clusterId, final Properties props) throws SQLException;
 
+  List<HostSpec> forceGetLimitlessRoutersWithConn(
+      final Connection conn, final String clusterId, final int hostPort, final Properties props)  throws SQLException;
+
   List<HostSpec> forceGetLimitlessRouters(final String clusterId, final Properties props) throws SQLException;
 
-  void startMonitoring(final @NonNull PluginService pluginService,
+  void startMonitoring(
       final @NonNull HostSpec hostSpec,
       final @NonNull Properties props,
       final int intervalMs);

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/limitless/LimitlessRouterService.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/limitless/LimitlessRouterService.java
@@ -29,7 +29,7 @@ public interface LimitlessRouterService {
   List<HostSpec> getLimitlessRouters(final String clusterId, final Properties props) throws SQLException;
 
   List<HostSpec> forceGetLimitlessRoutersWithConn(
-      final Connection conn, final String clusterId, final int hostPort, final Properties props)  throws SQLException;
+      final Connection conn, final int hostPort, final Properties props)  throws SQLException;
 
   List<HostSpec> forceGetLimitlessRouters(final String clusterId, final Properties props) throws SQLException;
 

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/limitless/LimitlessRouterService.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/limitless/LimitlessRouterService.java
@@ -20,10 +20,8 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Properties;
-import java.util.function.Supplier;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import software.amazon.jdbc.HostSpec;
-import software.amazon.jdbc.PluginService;
 
 public interface LimitlessRouterService {
 
@@ -31,8 +29,6 @@ public interface LimitlessRouterService {
 
   List<HostSpec> forceGetLimitlessRoutersWithConn(
       final Connection connection, final int hostPort, final Properties props)  throws SQLException;
-
-  List<HostSpec> forceGetLimitlessRouters(final String clusterId, final Properties props) throws SQLException;
 
   void startMonitoring(
       final @NonNull HostSpec hostSpec,

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/limitless/LimitlessRouterService.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/limitless/LimitlessRouterService.java
@@ -20,6 +20,7 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Properties;
+import java.util.function.Supplier;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import software.amazon.jdbc.HostSpec;
 import software.amazon.jdbc.PluginService;
@@ -29,7 +30,7 @@ public interface LimitlessRouterService {
   List<HostSpec> getLimitlessRouters(final String clusterId, final Properties props) throws SQLException;
 
   List<HostSpec> forceGetLimitlessRoutersWithConn(
-      final Connection conn, final int hostPort, final Properties props)  throws SQLException;
+      final Supplier<Connection> connectionSupplier, final int hostPort, final Properties props)  throws SQLException;
 
   List<HostSpec> forceGetLimitlessRouters(final String clusterId, final Properties props) throws SQLException;
 

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/limitless/LimitlessRouterServiceImpl.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/limitless/LimitlessRouterServiceImpl.java
@@ -42,8 +42,8 @@ public class LimitlessRouterServiceImpl implements LimitlessRouterService {
   protected final LimitlessQueryHelper queryHelper;
   protected final LimitlessRouterMonitorInitializer limitlessRouterMonitorInitializer;
 
-  protected static final SlidingExpirationCacheWithCleanupThread<String, LimitlessRouterMonitor> limitlessRouterMonitors =
-      new SlidingExpirationCacheWithCleanupThread<>(
+  protected static final SlidingExpirationCacheWithCleanupThread<String, LimitlessRouterMonitor>
+      limitlessRouterMonitors = new SlidingExpirationCacheWithCleanupThread<>(
           limitlessRouterMonitor -> true,
           limitlessRouterMonitor -> {
             try {

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/limitless/LimitlessRouterServiceImpl.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/limitless/LimitlessRouterServiceImpl.java
@@ -18,13 +18,11 @@ package software.amazon.jdbc.plugin.limitless;
 
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
-import java.util.function.Supplier;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import software.amazon.jdbc.AwsWrapperProperty;
 import software.amazon.jdbc.HostSpec;
@@ -70,7 +68,9 @@ public class LimitlessRouterServiceImpl implements LimitlessRouterService {
     this(pluginService, LimitlessRouterMonitor::new);
   }
 
-  public LimitlessRouterServiceImpl(final @NonNull PluginService pluginService, final LimitlessRouterMonitorInitializer limitlessRouterMonitorInitializer) {
+  public LimitlessRouterServiceImpl(
+      final @NonNull PluginService pluginService,
+      final LimitlessRouterMonitorInitializer limitlessRouterMonitorInitializer) {
     this.pluginService = pluginService;
     this.limitlessRouterMonitorInitializer = limitlessRouterMonitorInitializer;
     this.queryHelper = new LimitlessQueryHelper(pluginService);
@@ -95,7 +95,8 @@ public class LimitlessRouterServiceImpl implements LimitlessRouterService {
 
     forceGetLimitlessRoutersLock.lock();
     try {
-      final List<HostSpec> limitlessRouters = limitlessRouterCache.get(this.pluginService.getHostListProvider().getClusterId(), cacheExpirationNano);
+      final List<HostSpec> limitlessRouters =
+          limitlessRouterCache.get(this.pluginService.getHostListProvider().getClusterId(), cacheExpirationNano);
       if (!Utils.isNullOrEmpty(limitlessRouters)) {
         return limitlessRouters;
       }

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/limitless/LimitlessRouterServiceImpl.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/limitless/LimitlessRouterServiceImpl.java
@@ -18,7 +18,6 @@ package software.amazon.jdbc.plugin.limitless;
 
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
@@ -28,7 +27,6 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import software.amazon.jdbc.AwsWrapperProperty;
 import software.amazon.jdbc.HostSpec;
 import software.amazon.jdbc.PluginService;
-import software.amazon.jdbc.util.Messages;
 import software.amazon.jdbc.util.SlidingExpirationCacheWithCleanupThread;
 import software.amazon.jdbc.util.Utils;
 
@@ -44,7 +42,7 @@ public class LimitlessRouterServiceImpl implements LimitlessRouterService {
   protected final LimitlessQueryHelper queryHelper;
   protected final LimitlessRouterMonitorInitializer limitlessRouterMonitorInitializer;
 
-  private static final SlidingExpirationCacheWithCleanupThread<String, LimitlessRouterMonitor> limitlessRouterMonitors =
+  protected static final SlidingExpirationCacheWithCleanupThread<String, LimitlessRouterMonitor> limitlessRouterMonitors =
       new SlidingExpirationCacheWithCleanupThread<>(
           limitlessRouterMonitor -> true,
           limitlessRouterMonitor -> {
@@ -57,7 +55,7 @@ public class LimitlessRouterServiceImpl implements LimitlessRouterService {
           CACHE_CLEANUP_NANO
       );
 
-  private static final SlidingExpirationCacheWithCleanupThread<String, List<HostSpec>>
+  protected static final SlidingExpirationCacheWithCleanupThread<String, List<HostSpec>>
       limitlessRouterCache =
       new SlidingExpirationCacheWithCleanupThread<>(
           x  -> true,
@@ -66,15 +64,16 @@ public class LimitlessRouterServiceImpl implements LimitlessRouterService {
       );
 
   public LimitlessRouterServiceImpl(final @NonNull PluginService pluginService) {
-    this(pluginService, LimitlessRouterMonitor::new);
+    this(pluginService, LimitlessRouterMonitor::new, new LimitlessQueryHelper(pluginService));
   }
 
   public LimitlessRouterServiceImpl(
       final @NonNull PluginService pluginService,
-      final LimitlessRouterMonitorInitializer limitlessRouterMonitorInitializer) {
+      final LimitlessRouterMonitorInitializer limitlessRouterMonitorInitializer,
+      final LimitlessQueryHelper queryHelper) {
     this.pluginService = pluginService;
     this.limitlessRouterMonitorInitializer = limitlessRouterMonitorInitializer;
-    this.queryHelper = new LimitlessQueryHelper(pluginService);
+    this.queryHelper = queryHelper;
   }
 
   @Override

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/limitless/LimitlessRouterServiceImpl.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/limitless/LimitlessRouterServiceImpl.java
@@ -89,7 +89,7 @@ public class LimitlessRouterServiceImpl implements LimitlessRouterService {
 
   @Override
   public List<HostSpec> forceGetLimitlessRoutersWithConn(
-      final Supplier<Connection> connectionSupplier, final int hostPort, final Properties props) throws SQLException {
+      final Connection connection, final int hostPort, final Properties props) throws SQLException {
     final long cacheExpirationNano = TimeUnit.MILLISECONDS.toNanos(
         MONITOR_DISPOSAL_TIME_MS.getLong(props));
 
@@ -101,8 +101,9 @@ public class LimitlessRouterServiceImpl implements LimitlessRouterService {
       }
 
       final List<HostSpec> newLimitLessRouters =
-          this.queryHelper.queryForLimitlessRouters(connectionSupplier.get(), hostPort);
-      
+          this.queryHelper.queryForLimitlessRouters(connection, hostPort);
+
+      limitlessRouterCache.remove(this.pluginService.getHostListProvider().getClusterId());
       limitlessRouterCache.computeIfAbsent(
           this.pluginService.getHostListProvider().getClusterId(),
           key -> Collections.unmodifiableList(newLimitLessRouters),
@@ -146,7 +147,7 @@ public class LimitlessRouterServiceImpl implements LimitlessRouterService {
     try {
       final String limitlessRouterMonitorKey = pluginService.getHostListProvider().getClusterId();
       final long cacheExpirationNano = TimeUnit.MILLISECONDS.toNanos(MONITOR_DISPOSAL_TIME_MS.getLong(props));
-      final List<HostSpec> limitlessRouters = Collections.unmodifiableList(new ArrayList<>());
+      final List<HostSpec> limitlessRouters = Collections.emptyList();
 
       limitlessRouterMonitors.computeIfAbsent(
           limitlessRouterMonitorKey,

--- a/wrapper/src/main/java/software/amazon/jdbc/util/SlidingExpirationCache.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/SlidingExpirationCache.java
@@ -95,13 +95,6 @@ public class SlidingExpirationCache<K, V> {
     return cacheItem.withExtendExpiration(itemExpirationNano).item;
   }
 
-  /**
-   *
-   * @param key                the key with which the specified value is to be associated
-   * @param value    the function to compute a value
-   * @param itemExpirationNano the expiration time of the new or renewed entry
-   * @return
-   */
   public V put(
       final K key,
       final V value,

--- a/wrapper/src/main/java/software/amazon/jdbc/util/SlidingExpirationCache.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/SlidingExpirationCache.java
@@ -95,6 +95,25 @@ public class SlidingExpirationCache<K, V> {
     return cacheItem.withExtendExpiration(itemExpirationNano).item;
   }
 
+  /**
+   *
+   * @param key                the key with which the specified value is to be associated
+   * @param value    the function to compute a value
+   * @param itemExpirationNano the expiration time of the new or renewed entry
+   * @return
+   */
+  public V put(
+      final K key,
+      final V value,
+      final long itemExpirationNano) {
+    cleanUp();
+    final CacheItem cacheItem =  cache.put(key, new CacheItem(value, itemExpirationNano));
+    if (cacheItem == null) {
+      return null;
+    }
+    return cacheItem.item;
+  }
+
   public V get(final K key, final long itemExpirationNano) {
     cleanUp();
     final CacheItem cacheItem = cache.get(key);

--- a/wrapper/src/main/resources/aws_advanced_jdbc_wrapper_messages.properties
+++ b/wrapper/src/main/resources/aws_advanced_jdbc_wrapper_messages.properties
@@ -203,6 +203,9 @@ LimitlessConnectionPlugin.unsupportedDialectOrDatabase=Unsupported dialect ''{0}
 # Limitless Router Service Impl
 LimitlessRouterServiceImpl.nulLimitlessRouterMonitor=LimitlessRouterMonitor with cluster ID {0} is null.
 
+# Limitless Query Helper
+LimitlessQueryHelper.unsupportedDialectOrDatabase=Unsupported dialect ''{0}'' encountered. Please ensure JDBC connection parameters are correct, and refer to the documentation to ensure that the connecting database is compatible with the Limitless Connection Plugin.
+
 # Limitless Router Monitor
 LimitlessRouterMonitor.exceptionDuringMonitoringStop=Unhandled exception was thrown in Limitless Router Monitoring thread for node {0}.
 LimitlessRouterMonitor.forceGetLimitlessRouters=Fetching Limitless Transaction Routers synchronously.
@@ -215,7 +218,6 @@ LimitlessRouterMonitor.openingConnection=Opening Limitless Router Monitor connec
 LimitlessRouterMonitor.openedConnection=Opened Limitless Router Monitor connection: {0}.
 LimitlessRouterMonitor.running=Limitless Router Monitor thread running on node {0}.
 LimitlessRouterMonitor.stopped=Limitless Router Monitor thread stopped on node {0].
-LimitlessRouterMonitor.unsupportedDialectOrDatabase=Unsupported dialect ''{0}'' encountered. Please ensure JDBC connection parameters are correct, and refer to the documentation to ensure that the connecting database is compatible with the Limitless Connection Plugin.
 
 # Log Query Connection Plugin
 LogQueryConnectionPlugin.executingQuery=[{0}] Executing query: {1}

--- a/wrapper/src/main/resources/aws_advanced_jdbc_wrapper_messages.properties
+++ b/wrapper/src/main/resources/aws_advanced_jdbc_wrapper_messages.properties
@@ -190,26 +190,20 @@ LimitlessConnectionPlugin.connectWithHost=Connecting to host {0}.
 LimitlessConnectionPlugin.usingProvidedConnectUrl=Connecting using provided connection URL.
 LimitlessConnectionPlugin.failedToConnectToHost=Failed to connect to host {0}.
 LimitlessConnectionPlugin.incorrectConfiguration=Limitless Connection Plugin is unable to run. Please ensure the connection settings are correct.
-LimitlessConnectionPlugin.interruptedThread=Thread was interrupted.
 LimitlessConnectionPlugin.limitlessRouterCacheEmpty=Limitless Router cache is empty. This normal during application start up when the cache is not yet populated.
 LimitlessConnectionPlugin.maxRetriesExceeded=Max number of connection retries has been exceeded.
-LimitlessConnectionPlugin.noRoutersAvailable=There are no transaction routers available.
-LimitlessConnectionPlugin.noRoutersAvailableForRetry=There are no transaction routers available for connection retry.
+LimitlessConnectionPlugin.noRoutersAvailable=No transaction routers available.
+LimitlessConnectionPlugin.noRoutersAvailableForRetry=No transaction routers available for connection retry. Retrying with original connection.
 LimitlessConnectionPlugin.selectedHost=Host {0} has been selected.
 LimitlessConnectionPlugin.selectedHostForRetry=Host {0} has been selected for connection retry.
 LimitlessConnectionPlugin.synchronouslyGetLimitlessRouters=Fetching Limitless Routers synchronously.
 LimitlessConnectionPlugin.unsupportedDialectOrDatabase=Unsupported dialect ''{0}'' encountered. Please ensure JDBC connection parameters are correct, and refer to the documentation to ensure that the connecting database is compatible with the Limitless Connection Plugin.
-
-# Limitless Router Service Impl
-LimitlessRouterServiceImpl.nulLimitlessRouterMonitor=LimitlessRouterMonitor with cluster ID {0} is null.
 
 # Limitless Query Helper
 LimitlessQueryHelper.unsupportedDialectOrDatabase=Unsupported dialect ''{0}'' encountered. Please ensure JDBC connection parameters are correct, and refer to the documentation to ensure that the connecting database is compatible with the Limitless Connection Plugin.
 
 # Limitless Router Monitor
 LimitlessRouterMonitor.exceptionDuringMonitoringStop=Unhandled exception was thrown in Limitless Router Monitoring thread for node {0}.
-LimitlessRouterMonitor.forceGetLimitlessRouters=Fetching Limitless Transaction Routers synchronously.
-LimitlessRouterMonitor.forceGetLimitlessRoutersFailed=Failed to fetch Limitless Routers due to closed connection.
 LimitlessRouterMonitor.interruptedExceptionDuringMonitoring=Limitless Router Monitoring thread for node {0} was interrupted.
 LimitlessRouterMonitor.invalidQuery=Limitless Connection Plugin has encountered an error obtaining Limitless Router endpoints. Please ensure that you are connecting to an Aurora Limitless Database Shard Group Endpoint URL.
 LimitlessRouterMonitor.invalidRouterLoad=Invalid load metric value of ''{1}''from the transaction router query aurora_limitless_router_endpoints() for transaction router ''{0}''. The load metric value must be a decimal value between 0 and 1. Host weight be assigned a default weight of 1.

--- a/wrapper/src/main/resources/aws_advanced_jdbc_wrapper_messages.properties
+++ b/wrapper/src/main/resources/aws_advanced_jdbc_wrapper_messages.properties
@@ -198,6 +198,7 @@ LimitlessConnectionPlugin.noRoutersAvailableForRetry=There are no transaction ro
 LimitlessConnectionPlugin.selectedHost=Host {0} has been selected.
 LimitlessConnectionPlugin.selectedHostForRetry=Host {0} has been selected for connection retry.
 LimitlessConnectionPlugin.synchronouslyGetLimitlessRouters=Fetching Limitless Routers synchronously.
+LimitlessConnectionPlugin.unsupportedDialectOrDatabase=Unsupported dialect ''{0}'' encountered. Please ensure JDBC connection parameters are correct, and refer to the documentation to ensure that the connecting database is compatible with the Limitless Connection Plugin.
 
 # Limitless Router Service Impl
 LimitlessRouterServiceImpl.nulLimitlessRouterMonitor=LimitlessRouterMonitor with cluster ID {0} is null.
@@ -214,6 +215,7 @@ LimitlessRouterMonitor.openingConnection=Opening Limitless Router Monitor connec
 LimitlessRouterMonitor.openedConnection=Opened Limitless Router Monitor connection: {0}.
 LimitlessRouterMonitor.running=Limitless Router Monitor thread running on node {0}.
 LimitlessRouterMonitor.stopped=Limitless Router Monitor thread stopped on node {0].
+LimitlessRouterMonitor.unsupportedDialectOrDatabase=Unsupported dialect ''{0}'' encountered. Please ensure JDBC connection parameters are correct, and refer to the documentation to ensure that the connecting database is compatible with the Limitless Connection Plugin.
 
 # Log Query Connection Plugin
 LogQueryConnectionPlugin.executingQuery=[{0}] Executing query: {1}

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/limitless/LimitlessConnectionPluginTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/limitless/LimitlessConnectionPluginTest.java
@@ -92,7 +92,7 @@ public class LimitlessConnectionPluginTest {
 
     plugin.connect(DRIVER_PROTOCOL, INPUT_HOST_SPEC, props, true, mockConnectFuncLambda);
 
-    verify(mockLimitlessRouterService, times(1)).startMonitoring(mockPluginService, INPUT_HOST_SPEC,
+    verify(mockLimitlessRouterService, times(1)).startMonitoring(INPUT_HOST_SPEC,
         props, Integer.parseInt(LimitlessConnectionPlugin.INTERVAL_MILLIS.defaultValue));
     verify(mockLimitlessRouterService, times(1)).getLimitlessRouters(CLUSTER_ID, props);
     verify(mockPluginService, times(1)).getHostSpecByStrategy(endpointHostSpecList,
@@ -116,7 +116,7 @@ public class LimitlessConnectionPluginTest {
 
     plugin.connect(DRIVER_PROTOCOL, INPUT_HOST_SPEC, props, false, mockConnectFuncLambda);
 
-    verify(mockLimitlessRouterService, times(0)).startMonitoring(mockPluginService, INPUT_HOST_SPEC,
+    verify(mockLimitlessRouterService, times(0)).startMonitoring(INPUT_HOST_SPEC,
         props, Integer.parseInt(LimitlessConnectionPlugin.INTERVAL_MILLIS.defaultValue));
     verify(mockLimitlessRouterService, times(1)).getLimitlessRouters(CLUSTER_ID, props);
     verify(mockPluginService, times(1)).getHostSpecByStrategy(endpointHostSpecList,
@@ -145,7 +145,7 @@ public class LimitlessConnectionPluginTest {
 
     plugin.connect(DRIVER_PROTOCOL, INPUT_HOST_SPEC, propsWaitForRouterInfoSetFalse, false, mockConnectFuncLambda);
 
-    verify(mockLimitlessRouterService, times(0)).startMonitoring(mockPluginService, INPUT_HOST_SPEC,
+    verify(mockLimitlessRouterService, times(0)).startMonitoring(INPUT_HOST_SPEC,
         props, Integer.parseInt(LimitlessConnectionPlugin.INTERVAL_MILLIS.defaultValue));
     verify(mockLimitlessRouterService, times(1)).getLimitlessRouters(CLUSTER_ID, propsWaitForRouterInfoSetFalse);
     verify(mockPluginService, times(0)).getHostSpecByStrategy(emptyEndpointHostSpecList,
@@ -170,7 +170,7 @@ public class LimitlessConnectionPluginTest {
 
     plugin.connect(DRIVER_PROTOCOL, INPUT_HOST_SPEC, props, false, mockConnectFuncLambda);
 
-    verify(mockLimitlessRouterService, times(0)).startMonitoring(mockPluginService, INPUT_HOST_SPEC,
+    verify(mockLimitlessRouterService, times(0)).startMonitoring(INPUT_HOST_SPEC,
         props, Integer.parseInt(LimitlessConnectionPlugin.INTERVAL_MILLIS.defaultValue));
     verify(mockLimitlessRouterService, times(1)).getLimitlessRouters(CLUSTER_ID, props);
     verify(mockPluginService, times(0)).getHostSpecByStrategy(endpointHostSpecList,
@@ -210,7 +210,7 @@ public class LimitlessConnectionPluginTest {
 
     assertEquals(expectedConnection, actualConnection);
 
-    verify(mockLimitlessRouterService, times(1)).startMonitoring(mockPluginService, INPUT_HOST_SPEC,
+    verify(mockLimitlessRouterService, times(1)).startMonitoring(INPUT_HOST_SPEC,
         props, Integer.parseInt(LimitlessConnectionPlugin.INTERVAL_MILLIS.defaultValue));
     verify(mockLimitlessRouterService, times(1)).getLimitlessRouters(CLUSTER_ID, props);
     verify(mockPluginService, times(1)).getHostSpecByStrategy(endpointHostSpecList,
@@ -251,7 +251,7 @@ public class LimitlessConnectionPluginTest {
         SQLException.class,
         () -> plugin.connect(DRIVER_PROTOCOL, INPUT_HOST_SPEC, props, true, mockConnectFuncLambda));
 
-    verify(mockLimitlessRouterService, times(1)).startMonitoring(mockPluginService, INPUT_HOST_SPEC,
+    verify(mockLimitlessRouterService, times(1)).startMonitoring(INPUT_HOST_SPEC,
         props, Integer.parseInt(LimitlessConnectionPlugin.INTERVAL_MILLIS.defaultValue));
     verify(mockLimitlessRouterService, times(1)).getLimitlessRouters(CLUSTER_ID, props);
     verify(mockLimitlessRouterService, times(1)).forceGetLimitlessRouters(CLUSTER_ID, props);
@@ -297,7 +297,7 @@ public class LimitlessConnectionPluginTest {
         SQLException.class,
         () -> plugin.connect(DRIVER_PROTOCOL, INPUT_HOST_SPEC, propsWithMaxRetries, true, mockConnectFuncLambda));
 
-    verify(mockLimitlessRouterService, times(1)).startMonitoring(mockPluginService, INPUT_HOST_SPEC,
+    verify(mockLimitlessRouterService, times(1)).startMonitoring(INPUT_HOST_SPEC,
         props, Integer.parseInt(LimitlessConnectionPlugin.INTERVAL_MILLIS.defaultValue));
     verify(mockLimitlessRouterService, times(1)).getLimitlessRouters(CLUSTER_ID, propsWithMaxRetries);
     verify(mockPluginService, times(1)).getHostSpecByStrategy(endpointHostSpecList,

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/limitless/LimitlessConnectionPluginTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/limitless/LimitlessConnectionPluginTest.java
@@ -302,9 +302,10 @@ public class LimitlessConnectionPluginTest {
     final int maxRetries = 7;
     propsWithMaxRetries.setProperty(LimitlessConnectionPlugin.MAX_RETRIES.name, String.valueOf(maxRetries));
 
-    assertThrows(
-        SQLException.class,
-        () -> plugin.connect(DRIVER_PROTOCOL, INPUT_HOST_SPEC, propsWithMaxRetries, true, mockConnectFuncLambda));
+
+    final Connection actualConn = plugin
+        .connect(DRIVER_PROTOCOL, INPUT_HOST_SPEC, propsWithMaxRetries, true, mockConnectFuncLambda);
+    assertEquals(mockConnection, actualConn);
 
     verify(mockLimitlessRouterService, times(1)).startMonitoring(INPUT_HOST_SPEC,
         props, Integer.parseInt(LimitlessConnectionPlugin.INTERVAL_MILLIS.defaultValue));

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/limitless/LimitlessRouterServiceImplTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/limitless/LimitlessRouterServiceImplTest.java
@@ -71,7 +71,7 @@ public class LimitlessRouterServiceImplTest {
 
     final LimitlessRouterService limitlessRouterService =
         new LimitlessRouterServiceImpl(mockPluginService, (a, b, c, d, e) -> mockLimitlessRouterMonitor);
-    limitlessRouterService.startMonitoring(mockPluginService, hostSpec, props, intervalMs);
+    limitlessRouterService.startMonitoring(hostSpec, props, intervalMs);
 
     final List<HostSpec> actualEndpointHostSpecList = limitlessRouterService.getLimitlessRouters(CLUSTER_ID, props);
 

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/limitless/LimitlessRouterServiceImplTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/limitless/LimitlessRouterServiceImplTest.java
@@ -24,6 +24,7 @@ import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
+import org.junit.Ignore;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -69,7 +70,7 @@ public class LimitlessRouterServiceImplTest {
     when(mockLimitlessRouterMonitor.getLimitlessRouters()).thenReturn(endpointHostSpecList);
 
     final LimitlessRouterService limitlessRouterService =
-        new LimitlessRouterServiceImpl((a, b, c, d) -> mockLimitlessRouterMonitor);
+        new LimitlessRouterServiceImpl((a, b, c, d, e) -> mockLimitlessRouterMonitor);
     limitlessRouterService.startMonitoring(mockPluginService, hostSpec, props, intervalMs);
 
     final List<HostSpec> actualEndpointHostSpecList = limitlessRouterService.getLimitlessRouters(CLUSTER_ID, props);
@@ -80,7 +81,7 @@ public class LimitlessRouterServiceImplTest {
   @Test
   void test_nullLimitlessRouterMonitor() {
     final LimitlessRouterService limitlessRouterService =
-        new LimitlessRouterServiceImpl((a, b, c, d) -> null);
+        new LimitlessRouterServiceImpl((a, b, c, d, e) -> null);
     assertThrows(SQLException.class, () -> limitlessRouterService.getLimitlessRouters(OTHER_CLUSTER_ID, props));
   }
 }

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/limitless/LimitlessRouterServiceImplTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/limitless/LimitlessRouterServiceImplTest.java
@@ -70,7 +70,7 @@ public class LimitlessRouterServiceImplTest {
     when(mockLimitlessRouterMonitor.getLimitlessRouters()).thenReturn(endpointHostSpecList);
 
     final LimitlessRouterService limitlessRouterService =
-        new LimitlessRouterServiceImpl((a, b, c, d, e) -> mockLimitlessRouterMonitor);
+        new LimitlessRouterServiceImpl(mockPluginService, (a, b, c, d, e) -> mockLimitlessRouterMonitor);
     limitlessRouterService.startMonitoring(mockPluginService, hostSpec, props, intervalMs);
 
     final List<HostSpec> actualEndpointHostSpecList = limitlessRouterService.getLimitlessRouters(CLUSTER_ID, props);
@@ -81,7 +81,7 @@ public class LimitlessRouterServiceImplTest {
   @Test
   void test_nullLimitlessRouterMonitor() {
     final LimitlessRouterService limitlessRouterService =
-        new LimitlessRouterServiceImpl((a, b, c, d, e) -> null);
+        new LimitlessRouterServiceImpl(mockPluginService, (a, b, c, d, e) -> null);
     assertThrows(SQLException.class, () -> limitlessRouterService.getLimitlessRouters(OTHER_CLUSTER_ID, props));
   }
 }

--- a/wrapper/src/test/java/software/amazon/jdbc/util/RdsUtilsTests.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/util/RdsUtilsTests.java
@@ -315,7 +315,41 @@ public class RdsUtilsTests {
 
   @Test
   public void testIsLimitlessDbShardGroupDns() {
+    assertFalse(target.isLimitlessDbShardGroupDns(usEastRegionCluster));
+    assertFalse(target.isLimitlessDbShardGroupDns(usEastRegionClusterReadOnly));
+    assertFalse(target.isLimitlessDbShardGroupDns(usEastRegionInstance));
+    assertFalse(target.isLimitlessDbShardGroupDns(usEastRegionProxy));
+    assertFalse(target.isLimitlessDbShardGroupDns(usEastRegionCustomDomain));
+    assertFalse(target.isLimitlessDbShardGroupDns(usEastRegionElbUrl));
+    assertTrue(target.isLimitlessDbShardGroupDns(usEastRegionLimitlessDbShardGroup));
 
+    assertFalse(target.isLimitlessDbShardGroupDns(usIsobEastRegionCluster));
+    assertFalse(target.isLimitlessDbShardGroupDns(usIsobEastRegionClusterReadOnly));
+    assertFalse(target.isLimitlessDbShardGroupDns(usIsobEastRegionInstance));
+    assertFalse(target.isLimitlessDbShardGroupDns(usIsobEastRegionProxy));
+    assertFalse(target.isLimitlessDbShardGroupDns(usIsobEastRegionCustomDomain));
+    assertTrue(target.isLimitlessDbShardGroupDns(usIsobEastRegionLimitlessDbShardGroup));
+
+    assertFalse(target.isLimitlessDbShardGroupDns(usIsoEastRegionCluster));
+    assertFalse(target.isLimitlessDbShardGroupDns(usIsoEastRegionClusterReadOnly));
+    assertFalse(target.isLimitlessDbShardGroupDns(usIsoEastRegionInstance));
+    assertFalse(target.isLimitlessDbShardGroupDns(usIsoEastRegionProxy));
+    assertFalse(target.isLimitlessDbShardGroupDns(usIsoEastRegionCustomDomain));
+    assertTrue(target.isLimitlessDbShardGroupDns(usIsoEastRegionLimitlessDbShardGroup));
+
+    assertFalse(target.isLimitlessDbShardGroupDns(chinaRegionCluster));
+    assertFalse(target.isLimitlessDbShardGroupDns(chinaRegionClusterReadOnly));
+    assertFalse(target.isLimitlessDbShardGroupDns(chinaRegionInstance));
+    assertFalse(target.isLimitlessDbShardGroupDns(chinaRegionProxy));
+    assertFalse(target.isLimitlessDbShardGroupDns(chinaRegionCustomDomain));
+    assertTrue(target.isLimitlessDbShardGroupDns(chinaRegionLimitlessDbShardGroup));
+
+    assertFalse(target.isLimitlessDbShardGroupDns(oldChinaRegionCluster));
+    assertFalse(target.isLimitlessDbShardGroupDns(oldChinaRegionClusterReadOnly));
+    assertFalse(target.isLimitlessDbShardGroupDns(oldChinaRegionInstance));
+    assertFalse(target.isLimitlessDbShardGroupDns(oldChinaRegionProxy));
+    assertFalse(target.isLimitlessDbShardGroupDns(oldChinaRegionCustomDomain));
+    assertTrue(target.isLimitlessDbShardGroupDns(oldChinaRegionLimitlessDbShardGroup));
   }
 
   @Test


### PR DESCRIPTION
### Summary

Add checks for limitless dialect  + refactor synchronous router fetch #1148

### Description

- added dialect checks in mulitple places. 
- new code path incase dialect is not right, and trying to resolve it
- move limitless router endpoint fetching to a helper class `LimitlessQueryHelper`. 
- move synchronous fetch of limitless routers into service class
- move router cache out of monitor and into service
- add `put` method to SlidingExpirationCache
- added a check in DialectManager specifically for PG Limitless to resolve to Aurora PG dialect

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.