### PR TITLE
fix: add RdsHostListProvider.getClusterId() to call init() in case of…

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/HostListProvider.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/HostListProvider.java
@@ -42,5 +42,5 @@ public interface HostListProvider {
 
   HostSpec identifyConnection(Connection connection) throws SQLException;
 
-  String getClusterId() throws UnsupportedOperationException;
+  String getClusterId() throws UnsupportedOperationException, SQLException;
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/RdsHostListProvider.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/RdsHostListProvider.java
@@ -694,7 +694,8 @@ public class RdsHostListProvider implements DynamicHostListProvider {
   }
 
   @Override
-  public String getClusterId() throws UnsupportedOperationException {
+  public String getClusterId() throws UnsupportedOperationException, SQLException {
+    init();
     return this.clusterId;
   }
 

--- a/wrapper/src/main/resources/aws_advanced_jdbc_wrapper_messages.properties
+++ b/wrapper/src/main/resources/aws_advanced_jdbc_wrapper_messages.properties
@@ -243,6 +243,9 @@ LimitlessRouterMonitor.openedConnection=Opened Limitless Router Monitor connecti
 LimitlessRouterMonitor.running=Limitless Router Monitor thread running on node {0}.
 LimitlessRouterMonitor.stopped=Limitless Router Monitor thread stopped on node {0].
 
+# Limitless Router Service
+LimitlessRouterServiceImpl.errorStartingMonitor=An error occurred while starting Limitless Router Monitor. {0}
+
 # Log Query Connection Plugin
 LogQueryConnectionPlugin.executingQuery=[{0}] Executing query: {1}
 


### PR DESCRIPTION
… unintialized clusterId

### Summary
fix: add RdsHostListProvider.getClusterId() to call init() in case of unintialized/null clusterId causing NPEs. 

### Description

<!--- Details of what you changed -->

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.