### PR TITLE
chore: change tj-actions/changed-files to directly use SHA reference

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: 'Get changed files'
-        uses: tj-actions/changed-files@v41
+        uses: tj-actions/changed-files@cbda684547adc8c052d50711417fa61b428a9f88
         id: changed-files-specific
         with:
           files_yaml: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
           fetch-depth: 50
       - name: 'Get changed files'
         id: changed-files-specific
-        uses: tj-actions/changed-files@v41
+        uses: tj-actions/changed-files@cbda684547adc8c052d50711417fa61b428a9f88
         with:
           files_yaml: |
             doc:

--- a/.github/workflows/run-hibernate-orm-tests.yml
+++ b/.github/workflows/run-hibernate-orm-tests.yml
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 50
       - name: 'Get changed files'
         id: changed-files-specific
-        uses: tj-actions/changed-files@v41
+        uses: tj-actions/changed-files@cbda684547adc8c052d50711417fa61b428a9f88
         with:
           files_yaml: |
             doc:

--- a/.github/workflows/run-standard-integration-tests.yml
+++ b/.github/workflows/run-standard-integration-tests.yml
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 50
       - name: 'Get changed files'
         id: changed-files-specific
-        uses: tj-actions/changed-files@v41
+        uses: tj-actions/changed-files@cbda684547adc8c052d50711417fa61b428a9f88
         with:
           files_yaml: |
             doc:


### PR DESCRIPTION
### Summary

chore: change tj-actions/changed-files to directly use SHA reference

### Description



### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.