### PR TITLE
fix: commit transaction after topology query (fixes #1168)

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/HostListProviderService.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/HostListProviderService.java
@@ -38,4 +38,6 @@ public interface HostListProviderService {
   Dialect getDialect();
 
   HostSpecBuilder getHostSpecBuilder();
+
+  boolean isInTransaction();
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/RdsHostListProvider.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/RdsHostListProvider.java
@@ -360,12 +360,17 @@ public class RdsHostListProvider implements DynamicHostListProvider {
           new Object[] {e.getMessage()}));
     }
 
+    boolean shouldCommit = !conn.getAutoCommit() && !this.hostListProviderService.isInTransaction();
+
     try (final Statement stmt = conn.createStatement();
          final ResultSet resultSet = stmt.executeQuery(this.topologyQuery)) {
       return processQueryResults(resultSet);
     } catch (final SQLSyntaxErrorException e) {
       throw new SQLException(Messages.get("RdsHostListProvider.invalidQuery"), e);
     } finally {
+      if (shouldCommit) {
+        conn.commit();
+      }
       if (networkTimeout == 0 && !conn.isClosed()) {
         conn.setNetworkTimeout(networkTimeoutExecutor, networkTimeout);
       }


### PR DESCRIPTION
### Summary

This PR tries to fix #1168, where `queryForTopology` automatically fired by FailOverPlugin opens a transaction and never closes, resulting in an unexpected change in the connection state.

### Description

If the connection doesn't auto-commit and wasn't in a transaction already, `queryForTopology` leaves a new transaction open. We have to either commit or roll back the transaction.

Note that this PR is a suggestion merely based on a speculation. I haven't tested that this works, nor do I fully understand the meaning of `this.hostListProviderService.isInTransaction()`. Please review and close/edit as you see fit.

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.