### PR TITLE
fix: ensure abort interrupts running queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/#semantic-versioning-200).
 
+### :bug: Fixed
+- Custom endpoint monitor obeys refresh rate ([PR #1175](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/1175)).
+- Abort interrupts running queries ([PR #1182](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/1182))
+
 ## [2.5.2] - 2024-11-4
 ### :bug: Fixed
 - Limitless Connection Plugin to reduce extra connections made during new connection creation ([PR #1174](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/1174)).

--- a/wrapper/src/main/java/software/amazon/jdbc/util/AsynchronousMethodsHelper.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/AsynchronousMethodsHelper.java
@@ -22,6 +22,7 @@ import java.util.List;
 public class AsynchronousMethodsHelper {
   public static final List<String> ASYNCHRONOUS_METHODS = Arrays.asList(
       "Statement.cancel",
-      "PreparedStatement.cancel"
+      "PreparedStatement.cancel",
+      "Connection.abort"
   );
 }


### PR DESCRIPTION
### Description
- fixes #1173 
- abort was not interrupting queries because the plugin manager was locked during query execution and abort was not included in ASYNCHRONOUS_METHODS. This PR fixes this problem by allowing abort to be executed asynchronously
- after allowing asynchronous abort, the exception triggered by abort was triggering failover. To avoid this, closedExplicitly is set when abort is called and checked in shouldExceptionTriggerConnectionSwitch

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.