### PR TITLE
Use singleton for null telemetry objects in NullTelemetryFactory

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/util/telemetry/NullTelemetryFactory.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/telemetry/NullTelemetryFactory.java
@@ -18,9 +18,13 @@ package software.amazon.jdbc.util.telemetry;
 
 public class NullTelemetryFactory implements TelemetryFactory {
 
+  private static final TelemetryContext NULL_TELEMETRY_CONTEXT = new NullTelemetryContext("null");
+  private static final TelemetryCounter NULL_TELEMETRY_COUNTER = new NullTelemetryCounter("null");
+  private static final TelemetryGauge NULL_TELEMETRY_GAUGE = new NullTelemetryGauge("null");
+
   @Override
   public TelemetryContext openTelemetryContext(String name, TelemetryTraceLevel traceLevel) {
-    return new NullTelemetryContext(name);
+    return NULL_TELEMETRY_CONTEXT;
   }
 
   @Override
@@ -30,11 +34,11 @@ public class NullTelemetryFactory implements TelemetryFactory {
 
   @Override
   public TelemetryCounter createCounter(String name) {
-    return new NullTelemetryCounter(name);
+    return NULL_TELEMETRY_COUNTER;
   }
 
   @Override
   public TelemetryGauge createGauge(String name, GaugeCallable<Long> callback) {
-    return new NullTelemetryGauge(name);
+    return NULL_TELEMETRY_GAUGE;
   }
 }


### PR DESCRIPTION
### Summary

While testing our application for regressions in performance after adopting aws-advanced-jdbc-wrapper we found a lot of useless allocations from the NullTelemetryFactory [1].

[1] ![Screenshot 2024-11-12 131311](https://github.com/user-attachments/assets/d4f95f91-ee70-4161-9c49-5fa44ce76001)


### Description

Refactored NullTelemetryFactory to use a singleton instance for NullTelemetryContext, TelemetryCounter, and TelemetryGauge, eliminating repeated object creation and reducing memory allocations. 

I also considered using a caching approach but opted for the singleton pattern to further simplify the code and minimize memory churn. I verified software.amazon.jdbc.util.telemetry.NullTelemetryContext#getName is not used in any code paths.

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.