### PR TITLE
avoid updating topology before setReadOnly()

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/util/SubscribedMethodHelper.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/SubscribedMethodHelper.java
@@ -56,7 +56,6 @@ public class SubscribedMethodHelper {
       "Connection.connect",
       "Connection.isValid",
       "Connection.setAutoCommit",
-      "Connection.setReadOnly",
       "Statement.execute",
       "Statement.executeBatch",
       "Statement.executeLargeBatch",


### PR DESCRIPTION
### Summary

[<!--- General summary / title -->](https://github.com/aws/aws-advanced-jdbc-wrapper/issues/1168)

### Additional Reviewers

@karenc-bq 
@aaron-congo 

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.