### PR TITLE
fix: use iamHost property in federated auth and okta plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### :bug: Fixed
 - Custom endpoint monitor obeys refresh rate ([PR #1175](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/1175)).
 - Abort interrupts running queries ([PR #1182](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/1182))
+- Use iamHost property in federated auth and okta plugins ([PR #1191](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/1191))
 
 ## [2.5.2] - 2024-11-4
 ### :bug: Fixed

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/federatedauth/FederatedAuthPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/federatedauth/FederatedAuthPlugin.java
@@ -208,7 +208,7 @@ public class FederatedAuthPlugin extends AbstractConnectionPlugin {
               new Object[] {tokenInfo.getToken()}));
       PropertyDefinition.PASSWORD.set(props, tokenInfo.getToken());
     } else {
-      updateAuthenticationToken(hostSpec, props, region, cacheKey);
+      updateAuthenticationToken(hostSpec, props, region, cacheKey, host);
     }
 
     PropertyDefinition.USER.set(props, DB_USER.getString(props));
@@ -216,7 +216,7 @@ public class FederatedAuthPlugin extends AbstractConnectionPlugin {
     try {
       return connectFunc.call();
     } catch (final SQLException exception) {
-      updateAuthenticationToken(hostSpec, props, region, cacheKey);
+      updateAuthenticationToken(hostSpec, props, region, cacheKey, host);
       return connectFunc.call();
     } catch (final Exception exception) {
       LOGGER.warning(
@@ -227,8 +227,12 @@ public class FederatedAuthPlugin extends AbstractConnectionPlugin {
     }
   }
 
-  private void updateAuthenticationToken(final HostSpec hostSpec, final Properties props, final Region region,
-      final String cacheKey)
+  private void updateAuthenticationToken(
+      final HostSpec hostSpec,
+      final Properties props,
+      final Region region,
+      final String cacheKey,
+      final String host)
       throws SQLException {
     final int tokenExpirationSec = IAM_TOKEN_EXPIRATION.getInteger(props);
     final Instant tokenExpiry = Instant.now().plus(tokenExpirationSec, ChronoUnit.SECONDS);
@@ -243,7 +247,7 @@ public class FederatedAuthPlugin extends AbstractConnectionPlugin {
         this.iamTokenUtility,
         this.pluginService,
         DB_USER.getString(props),
-        hostSpec.getHost(),
+        host,
         port,
         region,
         credentialsProvider);

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/federatedauth/OktaAuthPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/federatedauth/OktaAuthPlugin.java
@@ -180,7 +180,7 @@ public class OktaAuthPlugin extends AbstractConnectionPlugin {
               new Object[] {tokenInfo.getToken()}));
       PropertyDefinition.PASSWORD.set(props, tokenInfo.getToken());
     } else {
-      updateAuthenticationToken(hostSpec, props, region, cacheKey);
+      updateAuthenticationToken(hostSpec, props, region, cacheKey, host);
     }
 
     PropertyDefinition.USER.set(props, DB_USER.getString(props));
@@ -188,7 +188,7 @@ public class OktaAuthPlugin extends AbstractConnectionPlugin {
     try {
       return connectFunc.call();
     } catch (final SQLException exception) {
-      updateAuthenticationToken(hostSpec, props, region, cacheKey);
+      updateAuthenticationToken(hostSpec, props, region, cacheKey, host);
       return connectFunc.call();
     } catch (final Exception exception) {
       LOGGER.warning(
@@ -199,8 +199,12 @@ public class OktaAuthPlugin extends AbstractConnectionPlugin {
     }
   }
 
-  private void updateAuthenticationToken(final HostSpec hostSpec, final Properties props, final Region region,
-      final String cacheKey)
+  private void updateAuthenticationToken(
+      final HostSpec hostSpec,
+      final Properties props,
+      final Region region,
+      final String cacheKey,
+      final String host)
       throws SQLException {
     final int tokenExpirationSec = IAM_TOKEN_EXPIRATION.getInteger(props);
     final Instant tokenExpiry = Instant.now().plus(tokenExpirationSec, ChronoUnit.SECONDS);
@@ -215,7 +219,7 @@ public class OktaAuthPlugin extends AbstractConnectionPlugin {
         this.iamTokenUtility,
         this.pluginService,
         DB_USER.getString(props),
-        hostSpec.getHost(),
+        host,
         port,
         region,
         credentialsProvider);


### PR DESCRIPTION
### Description

This PR changes the federated authentication and okta authentication plugins to use the user provided iamHost property when generating authentication tokens. Prior to this change, the URL host was being used regardless of what iamHost was set to.

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.