### PR TITLE
test: exclude limitless versions when selecting latest version for testing

### DIFF
--- a/wrapper/src/test/java/integration/util/AuroraTestUtility.java
+++ b/wrapper/src/test/java/integration/util/AuroraTestUtility.java
@@ -1415,6 +1415,7 @@ public class AuroraTestUtility {
 
   public String getLatestVersion(String engine) {
     return getEngineVersions(engine).stream()
+        .filter(version -> !version.contains("limitless"))
         .sorted(Comparator.reverseOrder())
         .findFirst()
         .orElse(null);


### PR DESCRIPTION
### Description

- our test logic executes a DescribeDbEngineVersions request to select the latest Aurora version to run integration tests against. In the past this has selected regular Aurora versions, but recently the latest version returned by the API is a limitless version. This PR fixes the problem by filtering out limitless versions. If we decide we want to test against limitless later, we should add a separate task/workflow.

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.