### PR TITLE
fix: initialize failover2 topology monitors after dialect is updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Abort interrupts running queries ([PR #1182](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/1182))
 - Use the AwsCredentialsProviderHandler from the ConfigurationProfile when it is defined ([PR #1183](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/1183)).
 - Use iamHost property in federated auth and okta plugins ([PR #1191](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/1191))
+- Initialize failover2 topology monitors after dialect is updated ([PR #1196](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/1196))
 
 ## [2.5.2] - 2024-11-4
 ### :bug: Fixed

--- a/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/monitoring/MonitoringRdsHostListProvider.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/monitoring/MonitoringRdsHostListProvider.java
@@ -109,7 +109,6 @@ public class MonitoringRdsHostListProvider extends RdsHostListProvider
   @Override
   protected void init() throws SQLException {
     super.init();
-    this.initMonitor();
   }
 
   protected ClusterTopologyMonitor initMonitor() {


### PR DESCRIPTION
### Description

- a bug was occurring when using the failover2 plugin with a multi-az cluster URL. The bug was that regular monitors (ClusterTopologyMonitorImpl) were incorrectly being used instead of multi-az monitors (MultiAZClusterTopologyMonitorImpl). This caused regular topology queries to be executed by the monitor instead of multi-az topology queries, leading to the error `Unknown table 'REPLICA_HOST_STATUS' in information_schema`.
- The reason why regular monitors were incorrectly used is that the monitor type depends on the database dialect, and the dialect starts with a default value of Aurora before connecting, and then is updated to a value of multi-az after connecting. The logic to create the monitor was triggered before the dialect was updated, incorrectly resulting in regular monitors. This PR fixes the issue by delaying monitor creation until after the dialect has been updated.

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.