### PR TITLE
fix: add writer custom endpoint type

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/customendpoint/CustomEndpointRoleType.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/customendpoint/CustomEndpointRoleType.java
@@ -17,10 +17,10 @@
 package software.amazon.jdbc.plugin.customendpoint;
 
 /**
- * Enum representing the possible roles of instances specified by a custom endpoint. Note that, currently, it is not
- * possible to create a WRITER custom endpoint.
+ * Enum representing the possible roles of instances specified by a custom endpoint.
  */
 public enum CustomEndpointRoleType {
   ANY, // Instances in the custom endpoint may be either a writer or a reader.
+  WRITER, // Instance in the custom endpoint is always the writer.
   READER // Instances in the custom endpoint are always readers.
 }


### PR DESCRIPTION
### Summary

The AWS Java SDK may return WRITER:
https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/rds/model/CreateDbClusterEndpointResponse.html#customEndpointType()

### Description

<!--- Details of what you changed -->

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.