### PR TITLE
chore: verify provider ordering in connection provider manager

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/ConnectionPluginManager.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/ConnectionPluginManager.java
@@ -628,6 +628,10 @@ public class ConnectionPluginManager implements CanReleaseResources, Wrapper {
     return this.defaultConnProvider;
   }
 
+  public ConnectionProvider getEffectiveConnProvider() {
+    return this.effectiveConnProvider;
+  }
+
   private interface PluginPipeline<T, E extends Exception> {
 
     T call(final @NonNull ConnectionPlugin plugin, final @Nullable JdbcCallable<T, E> jdbcMethodFunc) throws E;

--- a/wrapper/src/main/java/software/amazon/jdbc/PluginService.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/PluginService.java
@@ -227,7 +227,10 @@ public interface PluginService extends ExceptionHandler {
 
   HostSpecBuilder getHostSpecBuilder();
 
+  @Deprecated
   ConnectionProvider getConnectionProvider();
+
+  boolean isPooledConnectionProvider(HostSpec host, Properties props);
 
   String getDriverProtocol();
 

--- a/wrapper/src/main/java/software/amazon/jdbc/PluginServiceImpl.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/PluginServiceImpl.java
@@ -80,6 +80,7 @@ public class PluginServiceImpl implements PluginService, CanReleaseResources,
   protected Dialect dialect;
   protected TargetDriverDialect targetDriverDialect;
   protected @Nullable final ConfigurationProfile configurationProfile;
+  protected final ConnectionProviderManager connectionProviderManager;
 
   protected final SessionStateService sessionStateService;
 
@@ -140,6 +141,9 @@ public class PluginServiceImpl implements PluginService, CanReleaseResources,
     this.exceptionManager = exceptionManager;
     this.dialectProvider = dialectProvider != null ? dialectProvider : new DialectManager(this);
     this.targetDriverDialect = targetDriverDialect;
+    this.connectionProviderManager = new ConnectionProviderManager(
+        this.pluginManager.getDefaultConnProvider(),
+        this.pluginManager.getEffectiveConnProvider());
 
     this.sessionStateService = sessionStateService != null
         ? sessionStateService
@@ -235,8 +239,15 @@ public class PluginServiceImpl implements PluginService, CanReleaseResources,
   }
 
   @Override
+  @Deprecated
   public ConnectionProvider getConnectionProvider() {
     return this.pluginManager.defaultConnProvider;
+  }
+
+  public boolean isPooledConnectionProvider(HostSpec host, Properties props) {
+    final ConnectionProvider connectionProvider =
+        this.connectionProviderManager.getConnectionProvider(this.driverProtocol, host, props);
+    return (connectionProvider instanceof PooledConnectionProvider);
   }
 
   @Override

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/efm/ConcurrencyTests.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/efm/ConcurrencyTests.java
@@ -639,6 +639,11 @@ public class ConcurrencyTests {
     }
 
     @Override
+    public boolean isPooledConnectionProvider(HostSpec host, Properties props) {
+      return false;
+    }
+
+    @Override
     public String getDriverProtocol() {
       return null;
     }

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/readwritesplitting/ReadWriteSplittingPluginTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/readwritesplitting/ReadWriteSplittingPluginTest.java
@@ -560,13 +560,7 @@ public class ReadWriteSplittingPluginTest {
         .when(this.mockPluginService).getCurrentHostSpec();
     doReturn(mockReaderConn1).when(mockPluginService).connect(readerHostSpec1, null);
     when(mockPluginService.getDriverProtocol()).thenReturn("jdbc:postgresql://");
-
-    final HikariPooledConnectionProvider connProvider =
-        new HikariPooledConnectionProvider(
-            ReadWriteSplittingPluginTest::getHikariConfig,
-            ReadWriteSplittingPluginTest::getPoolKey
-        );
-    when(mockPluginService.getConnectionProvider()).thenReturn(connProvider);
+    when(mockPluginService.isPooledConnectionProvider(any(), any())).thenReturn(true);
 
     final ReadWriteSplittingPlugin plugin = new ReadWriteSplittingPlugin(
         mockPluginService,
@@ -592,13 +586,7 @@ public class ReadWriteSplittingPluginTest {
         .when(this.mockPluginService).getCurrentHostSpec();
     doReturn(mockWriterConn).when(mockPluginService).connect(writerHostSpec, null);
     when(mockPluginService.getDriverProtocol()).thenReturn("jdbc:postgresql://");
-
-    final HikariPooledConnectionProvider connProvider =
-        new HikariPooledConnectionProvider(
-            ReadWriteSplittingPluginTest::getHikariConfig,
-            ReadWriteSplittingPluginTest::getPoolKey
-        );
-    when(mockPluginService.getConnectionProvider()).thenReturn(connProvider);
+    when(mockPluginService.isPooledConnectionProvider(any(), any())).thenReturn(true);
 
     final ReadWriteSplittingPlugin plugin = new ReadWriteSplittingPlugin(
         mockPluginService,


### PR DESCRIPTION
### Summary

chore: verify provider ordering in connection provider manager

- Added effective connection provider to `ConnectionProviderManager`
- Allow `ReadWriteSplittingPlugin` to determine a proper connection provider type.

### Additional Reviewers

@karenc-bq 
@aaron-congo 
@aaronchung-bitquill 

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.