### PR TITLE
fix: Limitless plugin set round robin weights to original props used …

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/limitless/LimitlessConnectionContext.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/limitless/LimitlessConnectionContext.java
@@ -27,6 +27,7 @@ import software.amazon.jdbc.JdbcCallable;
 public class LimitlessConnectionContext {
   private HostSpec hostSpec;
   private Properties props;
+  private Properties origProps;
   private Connection connection;
   private JdbcCallable<Connection, SQLException> connectFunc;
   private List<HostSpec> limitlessRouters;
@@ -34,12 +35,14 @@ public class LimitlessConnectionContext {
   public LimitlessConnectionContext(
       final HostSpec hostSpec,
       final Properties props,
+      final Properties origProps,
       final Connection connection,
       final JdbcCallable<Connection, SQLException> connectFunc,
       final List<HostSpec> limitlessRouters
   ) {
     this.hostSpec = hostSpec;
     this.props = props;
+    this.origProps = origProps;
     this.connection = connection;
     this.connectFunc = connectFunc;
     this.limitlessRouters = limitlessRouters;
@@ -51,6 +54,10 @@ public class LimitlessConnectionContext {
 
   public Properties getProps() {
     return this.props;
+  }
+
+  public Properties getOrigProps() {
+    return this.origProps;
   }
 
   public Connection getConnection() {

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/limitless/LimitlessConnectionPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/limitless/LimitlessConnectionPlugin.java
@@ -111,13 +111,14 @@ public class LimitlessConnectionPlugin extends AbstractConnectionPlugin {
 
     final Properties copyProps = PropertyUtils.copyProperties(props);
     copyProps.setProperty(INTERNAL_CONNECT_PROPERTY_NAME, "true");
-    return connectInternal(driverProtocol, hostSpec, copyProps, isInitialConnection, connectFunc);
+    return connectInternal(driverProtocol, hostSpec, props, copyProps, isInitialConnection, connectFunc);
   }
 
   public Connection connectInternal(
       final String driverProtocol,
       final HostSpec hostSpec,
-      final Properties props,
+      final Properties origProps,
+      final Properties copyProps,
       final boolean isInitialConnection,
       final JdbcCallable<Connection, SQLException> connectFunc)
       throws SQLException {
@@ -143,7 +144,8 @@ public class LimitlessConnectionPlugin extends AbstractConnectionPlugin {
 
     final LimitlessConnectionContext context = new LimitlessConnectionContext(
         hostSpec,
-        props,
+        copyProps,
+        origProps,
         conn,
         connectFunc,
         null);

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/limitless/LimitlessRouterMonitor.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/limitless/LimitlessRouterMonitor.java
@@ -137,7 +137,6 @@ public class LimitlessRouterMonitor implements AutoCloseable, Runnable {
             newLimitlessRouters,
             TimeUnit.MILLISECONDS.toNanos(LimitlessRouterServiceImpl.MONITOR_DISPOSAL_TIME_MS.getLong(props)));
 
-        RoundRobinHostSelector.setRoundRobinHostWeightPairsProperty(this.props, newLimitlessRouters);
         LOGGER.finest(Utils.logTopology(newLimitlessRouters, "[limitlessRouterMonitor] Topology:"));
         TimeUnit.MILLISECONDS.sleep(this.intervalMs); // do not include this in the telemetry
       } catch (final InterruptedException exception) {

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/limitless/LimitlessRouterServiceImpl.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/limitless/LimitlessRouterServiceImpl.java
@@ -131,7 +131,9 @@ public class LimitlessRouterServiceImpl implements LimitlessRouterService {
       return;
     }
 
-    RoundRobinHostSelector.setRoundRobinHostWeightPairsProperty(context.getProps(), context.getLimitlessRouters());
+    RoundRobinHostSelector.setRoundRobinHostWeightPairsProperty(
+        context.getOrigProps(),
+        context.getLimitlessRouters());
     HostSpec selectedHostSpec;
     try {
       selectedHostSpec = this.pluginService.getHostSpecByStrategy(
@@ -165,7 +167,7 @@ public class LimitlessRouterServiceImpl implements LimitlessRouterService {
     }
   }
 
-  protected List<HostSpec> getLimitlessRouters(final String clusterId, final Properties props) throws SQLException {
+  protected List<HostSpec> getLimitlessRouters(final String clusterId, final Properties props) {
     final long cacheExpirationNano = TimeUnit.MILLISECONDS.toNanos(
         MONITOR_DISPOSAL_TIME_MS.getLong(props));
     return limitlessRouterCache.get(clusterId, cacheExpirationNano);

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/limitless/LimitlessRouterServiceImplTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/limitless/LimitlessRouterServiceImplTest.java
@@ -47,6 +47,7 @@ import software.amazon.jdbc.PluginService;
 import software.amazon.jdbc.RoundRobinHostSelector;
 import software.amazon.jdbc.hostavailability.HostAvailability;
 import software.amazon.jdbc.hostavailability.SimpleHostAvailabilityStrategy;
+import software.amazon.jdbc.util.PropertyUtils;
 import software.amazon.jdbc.wrapper.HighestWeightHostSelector;
 
 public class LimitlessRouterServiceImplTest {
@@ -70,6 +71,7 @@ public class LimitlessRouterServiceImplTest {
     props = new Properties();
     when(mockConnectFuncLambda.call()).thenReturn(mockConnection);
     when(mockPluginService.getHostListProvider()).thenReturn(mockHostListProvider);
+    when(mockPluginService.getProperties()).thenReturn(props);
     when(mockHostListProvider.getClusterId()).thenReturn(CLUSTER_ID);
   }
 
@@ -85,6 +87,7 @@ public class LimitlessRouterServiceImplTest {
 
     final LimitlessConnectionContext inputContext = new LimitlessConnectionContext(
         hostSpec,
+        PropertyUtils.copyProperties(props),
         props,
         null,
         mockConnectFuncLambda,
@@ -103,6 +106,7 @@ public class LimitlessRouterServiceImplTest {
     props.setProperty(LimitlessConnectionPlugin.WAIT_FOR_ROUTER_INFO.name, "false");
     final LimitlessConnectionContext inputContext = new LimitlessConnectionContext(
         hostSpec,
+        PropertyUtils.copyProperties(props),
         props,
         null,
         mockConnectFuncLambda,
@@ -132,6 +136,7 @@ public class LimitlessRouterServiceImplTest {
 
     final LimitlessConnectionContext inputContext = new LimitlessConnectionContext(
         routerList.get(1),
+        PropertyUtils.copyProperties(props),
         props,
         null,
         mockConnectFuncLambda,
@@ -163,6 +168,7 @@ public class LimitlessRouterServiceImplTest {
 
     final LimitlessConnectionContext inputContext = new LimitlessConnectionContext(
         routerList.get(1),
+        PropertyUtils.copyProperties(props),
         props,
         null,
         mockConnectFuncLambda,
@@ -199,6 +205,7 @@ public class LimitlessRouterServiceImplTest {
 
     final LimitlessConnectionContext inputContext = new LimitlessConnectionContext(
         hostSpec,
+        PropertyUtils.copyProperties(props),
         props,
         null,
         mockConnectFuncLambda,
@@ -234,6 +241,7 @@ public class LimitlessRouterServiceImplTest {
 
     final LimitlessConnectionContext inputContext = new LimitlessConnectionContext(
         hostSpec,
+        PropertyUtils.copyProperties(props),
         props,
         null,
         mockConnectFuncLambda,
@@ -267,6 +275,7 @@ public class LimitlessRouterServiceImplTest {
     final HostSpec selectedRouter = routerList.get(2);
     final LimitlessConnectionContext inputContext = new LimitlessConnectionContext(
         routerList.get(1),
+        PropertyUtils.copyProperties(props),
         props,
         null,
         mockConnectFuncLambda,
@@ -311,6 +320,7 @@ public class LimitlessRouterServiceImplTest {
 
     final LimitlessConnectionContext inputContext = new LimitlessConnectionContext(
         hostSpec,
+        PropertyUtils.copyProperties(props),
         props,
         null,
         mockConnectFuncLambda,
@@ -350,6 +360,7 @@ public class LimitlessRouterServiceImplTest {
 
     final LimitlessConnectionContext inputContext = new LimitlessConnectionContext(
         hostSpec,
+        PropertyUtils.copyProperties(props),
         props,
         null,
         mockConnectFuncLambda,
@@ -392,6 +403,7 @@ public class LimitlessRouterServiceImplTest {
 
     final LimitlessConnectionContext inputContext = new LimitlessConnectionContext(
         hostSpec,
+        PropertyUtils.copyProperties(props),
         props,
         null,
         mockConnectFuncLambda,
@@ -429,6 +441,7 @@ public class LimitlessRouterServiceImplTest {
 
     final LimitlessConnectionContext inputContext = new LimitlessConnectionContext(
         routerList.get(0),
+        PropertyUtils.copyProperties(props),
         props,
         null,
         mockConnectFuncLambda,


### PR DESCRIPTION
…by the round robin host selector, not a copy

### Summary

<!--- General summary / title -->

### Description

The RoundRobinHostSelector reads weights from the props from the plugin service. But the issue is that the Limitless plugin copies those props, setting the weights to its own copy of props which arent used by the RoundRobinHostSelector. So, the RoundRobinHostSelector will end up reading props without weights. 

This fix makes it so that when the Limitless plugin sets the round robin host weights, it sets it to the props from plugin service, which are then read by the RoundRobinHostSelector. 

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.