### PR TITLE
fix: avoid encoding MariaDB connection properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/#semantic-versioning-200).
 
+### :bug: Fixed
+- Avoid encoding MariaDB connection properties ([PR #1236](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/1236)).
+
 ## [2.5.4] - 2024-12-23
 ### :bug: Fixed
 - Avoid setting ignoreNewTopologyRequestsEndTimeNano on initial connection ([PR #1221](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/1221)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/#semantic-versioning-200).
 
 ### :bug: Fixed
-- Avoid encoding MariaDB connection properties ([PR #1236](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/1236)).
+- Avoid encoding MariaDB connection properties ([PR #1237](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/1237)).
 
 ## [2.5.4] - 2024-12-23
 ### :bug: Fixed

--- a/wrapper/src/main/java/software/amazon/jdbc/util/ConnectionUrlBuilder.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/ConnectionUrlBuilder.java
@@ -16,9 +16,6 @@
 
 package software.amazon.jdbc.util;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.util.Enumeration;
 import java.util.Properties;
@@ -95,16 +92,10 @@ public class ConnectionUrlBuilder {
           queryBuilder.append("&");
         }
         final String propertyValue = copy.getProperty(propertyName);
-        try {
-          queryBuilder
-              .append(propertyName)
-              .append("=")
-              .append(URLEncoder.encode(propertyValue, StandardCharsets.UTF_8.toString()));
-        } catch (final UnsupportedEncodingException e) {
-          throw new SQLException(
-              Messages.get("ConnectionUrlBuilder.failureEncodingConnectionUrl"),
-              e);
-        }
+        queryBuilder
+            .append(propertyName)
+            .append("=")
+            .append(propertyValue);
       }
     }
 

--- a/wrapper/src/main/resources/aws_advanced_jdbc_wrapper_messages.properties
+++ b/wrapper/src/main/resources/aws_advanced_jdbc_wrapper_messages.properties
@@ -102,7 +102,6 @@ ConnectionProvider.unsupportedHostSpecSelectorStrategy=Unsupported host selectio
 
 # Connection Url Builder
 ConnectionUrlBuilder.missingJdbcProtocol=Missing JDBC protocol and/or host name. Could not construct URL.
-ConnectionUrlBuilder.failureEncodingConnectionUrl=Failed to encode connectionURL properties.
 
 # Connection Url Parser
 ConnectionUrlParser.protocolNotFound=Url should contain a driver protocol. Protocol is not found in url: ''{0}''


### PR DESCRIPTION
### Description

- fixes #1222 
- before these changes, we encoded the property values passed to the buildUrl function. This function is only actually called when using a MariaDB data source. We do not encode MySQL or Postgres driver/datasource connections, and we do not encode MariaDB driver connections. Encoding the property values for MariaDB changes the intended values for the properties and can cause connection failures (see the linked issue above). I believe this encoding was originally intended to be used with MySQL and/or Postgres, but did not end up being used in those scenarios and isn't required for them either. This PR removes the call to encode the property values.

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.