### PR TITLE
test: fix test_pooledConnection_differentUsers

### DIFF
--- a/wrapper/src/test/java/integration/container/tests/BasicConnectivityTests.java
+++ b/wrapper/src/test/java/integration/container/tests/BasicConnectivityTests.java
@@ -289,6 +289,11 @@ public class BasicConnectivityTests {
     props.setProperty(PropertyDefinition.USER.name, username);
     props.setProperty(PropertyDefinition.PASSWORD.name, password);
 
+    if (testDriver == TestDriver.MARIADB) {
+      // If this property is true the driver will still be able to connect, causing the test to fail.
+      props.setProperty("allowPublicKeyRetrieval", "false");
+    }
+
     LOGGER.finest("Connecting to " + url);
 
     assertThrows(

--- a/wrapper/src/test/java/integration/container/tests/ReadWriteSplittingTests.java
+++ b/wrapper/src/test/java/integration/container/tests/ReadWriteSplittingTests.java
@@ -826,6 +826,10 @@ public class ReadWriteSplittingTests {
     String limitedUserNewDb = "limited_user_db";
     limitedUserProps.setProperty(PropertyDefinition.USER.name, limitedUserName);
     limitedUserProps.setProperty(PropertyDefinition.PASSWORD.name, limitedUserPassword);
+    // This property is required when using limited_user with the mariadb driver against multi-az mysql version 8.4,
+    // or you will get the error "RSA public key is not available client side". The mariadb driver may not fully support
+    // all aspects of mysql 8.4's SSL mechanisms, which is why this property is only required for newer mysql versions.
+    limitedUserProps.setProperty("allowPublicKeyRetrieval", "true");
 
     Properties wrongUserRightPasswordProps = getProps();
     wrongUserRightPasswordProps.setProperty(PropertyDefinition.USER.name, "bogus_user");

--- a/wrapper/src/test/java/integration/container/tests/ReadWriteSplittingTests.java
+++ b/wrapper/src/test/java/integration/container/tests/ReadWriteSplittingTests.java
@@ -826,10 +826,6 @@ public class ReadWriteSplittingTests {
     String limitedUserNewDb = "limited_user_db";
     limitedUserProps.setProperty(PropertyDefinition.USER.name, limitedUserName);
     limitedUserProps.setProperty(PropertyDefinition.PASSWORD.name, limitedUserPassword);
-    // This property is required when using limited_user with the mariadb driver against multi-az mysql version 8.4,
-    // or you will get the error "RSA public key is not available client side". The mariadb driver may not fully support
-    // all aspects of mysql 8.4's SSL mechanisms, which is why this property is only required for newer mysql versions.
-    limitedUserProps.setProperty("allowPublicKeyRetrieval", "true");
 
     Properties wrongUserRightPasswordProps = getProps();
     wrongUserRightPasswordProps.setProperty(PropertyDefinition.USER.name, "bogus_user");


### PR DESCRIPTION
### Description

test_pooledConnection_differentUsers was failing on multi-az mysql-latest with MariaDB. When trying to connect with the limited user the test was throwing the error "RSA public key is not available client side". Presumably this is because of some changes in the newest version of rds-mysql. The advice on this error message from stackoverflow was to set allowPublicKeyRetrieval to true.

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.