### PR TITLE
Fixed OpenTelemetry instrument name max length

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/util/telemetry/OpenTelemetryFactory.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/telemetry/OpenTelemetryFactory.java
@@ -29,9 +29,9 @@ public class OpenTelemetryFactory implements TelemetryFactory {
    * Max allowed name length for counters and gauges.
    *
    * @see
-   * <a href="https://opentelemetry.io/docs/specs/otel/metrics/api/#:~:text=It%20can%20have%20a%20maximum%20length%20of%2063%20characters">More details</a>
+   * <a href="https://opentelemetry.io/docs/specs/otel/metrics/api/#instrument-name-syntax">More details</a>
    */
-  private static final int NAME_MAX_LENGTH = 63;
+  private static final int NAME_MAX_LENGTH = 255;
 
   private static Tracer tracer;
   private static Meter meter;


### PR DESCRIPTION
### Summary

Fixed OpenTelemetry instrument name max length

### Description

OT Instrument name max length was not updated to new value from spec when in changed in 2023.

https://opentelemetry.io/docs/specs/otel/metrics/api/#instrument-name-syntax 


### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.