### PR TITLE
fix: change the storage type for multi-az clusters

### DIFF
--- a/wrapper/src/test/java/integration/util/AuroraTestUtility.java
+++ b/wrapper/src/test/java/integration/util/AuroraTestUtility.java
@@ -114,8 +114,8 @@ public class AuroraTestUtility {
   private static final Logger LOGGER = Logger.getLogger(AuroraTestUtility.class.getName());
   private static final String DUPLICATE_IP_ERROR_CODE = "InvalidPermission.Duplicate";
   private static final String DEFAULT_SECURITY_GROUP = "default";
-  private static final String DEFAULT_STORAGE_TYPE = "io1";
-  private static final int DEFAULT_IOPS = 1000;
+  private static final String DEFAULT_STORAGE_TYPE = "gp3";
+  private static final int DEFAULT_IOPS = 64000;
   private static final int MULTI_AZ_SIZE = 3;
   private static final Random rand = new Random();
 
@@ -361,7 +361,7 @@ public class AuroraTestUtility {
             .tags(testRunnerTag);
 
     clusterBuilder =
-        clusterBuilder.allocatedStorage(100)
+        clusterBuilder.allocatedStorage(400)
             .dbClusterInstanceClass(instanceClass)
             .storageType(DEFAULT_STORAGE_TYPE)
             .iops(DEFAULT_IOPS);


### PR DESCRIPTION
### Summary

The original storage type io1 only supports two availability zones. When creating 3-instance multi-az rds clusters we need 3 availability zones.

### Description

<!--- Details of what you changed -->

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.