### PR TITLE
clean up connections in a separate thread

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/AuroraConnectionTrackerPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/AuroraConnectionTrackerPlugin.java
@@ -40,8 +40,7 @@ import software.amazon.jdbc.util.RdsUrlType;
 import software.amazon.jdbc.util.RdsUtils;
 import software.amazon.jdbc.util.SubscribedMethodHelper;
 
-public class AuroraConnectionTrackerPlugin extends AbstractConnectionPlugin implements
-    CanReleaseResources {
+public class AuroraConnectionTrackerPlugin extends AbstractConnectionPlugin {
 
   private static final Logger LOGGER = Logger.getLogger(AuroraConnectionTrackerPlugin.class.getName());
 
@@ -193,11 +192,6 @@ public class AuroraConnectionTrackerPlugin extends AbstractConnectionPlugin impl
         this.needUpdateCurrentWriter = true;
       }
     }
-  }
-
-  @Override
-  public void releaseResources() {
-    tracker.pruneNullConnections();
   }
 
   private HostSpec getWriter(final @NonNull List<HostSpec> hosts) {


### PR DESCRIPTION
### Summary

Clean up tracked connections in a background thread
https://github.com/aws/aws-advanced-jdbc-wrapper/issues/1390

### Additional Reviewers

@karenc-bq 

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.