### PR TITLE
Set names for all internal threads

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/monitoring/ClusterTopologyMonitorImpl.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/monitoring/ClusterTopologyMonitorImpl.java
@@ -31,7 +31,6 @@ import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -55,6 +54,7 @@ import software.amazon.jdbc.util.PropertyUtils;
 import software.amazon.jdbc.util.RdsUtils;
 import software.amazon.jdbc.util.StringUtils;
 import software.amazon.jdbc.util.SynchronousExecutor;
+import software.amazon.jdbc.util.ExecutorFactory;
 import software.amazon.jdbc.util.Utils;
 
 public class ClusterTopologyMonitorImpl implements ClusterTopologyMonitor {
@@ -109,14 +109,7 @@ public class ClusterTopologyMonitorImpl implements ClusterTopologyMonitor {
   protected final AtomicReference<List<HostSpec>> nodeThreadsLatestTopology = new AtomicReference<>(null);
 
 
-  protected final ExecutorService monitorExecutor = Executors.newSingleThreadExecutor(runnableTarget -> {
-    final Thread monitoringThread = new Thread(runnableTarget);
-    monitoringThread.setDaemon(true);
-    if (!StringUtils.isNullOrEmpty(monitoringThread.getName())) {
-      monitoringThread.setName(monitoringThread.getName() + "-m");
-    }
-    return monitoringThread;
-  });
+  protected final ExecutorService monitorExecutor = ExecutorFactory.newSingleThreadExecutor("ClusterTopologyMonitorImpl#monitorExecutor");
 
   public ClusterTopologyMonitorImpl(
       final String clusterId,
@@ -473,14 +466,7 @@ public class ClusterTopologyMonitorImpl implements ClusterTopologyMonitor {
   protected void createNodeExecutorService() {
     this.nodeExecutorLock.lock();
     try {
-      this.nodeExecutorService = Executors.newCachedThreadPool(runnableTarget -> {
-        final Thread monitoringThread = new Thread(runnableTarget);
-        monitoringThread.setDaemon(true);
-        if (!StringUtils.isNullOrEmpty(monitoringThread.getName())) {
-          monitoringThread.setName(monitoringThread.getName() + "-nm");
-        }
-        return monitoringThread;
-      });
+      this.nodeExecutorService = ExecutorFactory.newCachedThreadPool("ClusterTopologyMonitorImpl#nodeExecutorService");
     } finally {
       this.nodeExecutorLock.unlock();
     }

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/OpenedConnectionTracker.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/OpenedConnectionTracker.java
@@ -29,7 +29,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 import software.amazon.jdbc.HostSpec;
@@ -38,6 +37,7 @@ import software.amazon.jdbc.util.Messages;
 import software.amazon.jdbc.util.RdsUtils;
 import software.amazon.jdbc.util.StringUtils;
 import software.amazon.jdbc.util.SynchronousExecutor;
+import software.amazon.jdbc.util.ExecutorFactory;
 import software.amazon.jdbc.util.telemetry.TelemetryContext;
 import software.amazon.jdbc.util.telemetry.TelemetryFactory;
 import software.amazon.jdbc.util.telemetry.TelemetryTraceLevel;
@@ -46,21 +46,8 @@ public class OpenedConnectionTracker {
 
   static final Map<String, Queue<WeakReference<Connection>>> openedConnections = new ConcurrentHashMap<>();
   private static final String TELEMETRY_INVALIDATE_CONNECTIONS = "invalidate connections";
-  private static final ExecutorService pruneConnectionsExecutorService =
-      Executors.newSingleThreadExecutor(
-          r -> {
-            final Thread thread = new Thread(r);
-            thread.setDaemon(true);
-            return thread;
-          });
-
-  private static final ExecutorService invalidateConnectionsExecutorService =
-      Executors.newCachedThreadPool(
-          r -> {
-            final Thread invalidateThread = new Thread(r);
-            invalidateThread.setDaemon(true);
-            return invalidateThread;
-          });
+  private static final ExecutorService pruneConnectionsExecutorService = ExecutorFactory.newSingleThreadExecutor("OpenedConnectionTracker#pruneConnectionsExecutorService");
+  private static final ExecutorService invalidateConnectionsExecutorService = ExecutorFactory.newCachedThreadPool("OpenedConnectionTracker#invalidateConnectionsExecutorService");
   private static final Executor abortConnectionExecutor = new SynchronousExecutor();
 
   private static final Logger LOGGER = Logger.getLogger(OpenedConnectionTracker.class.getName());

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/customendpoint/CustomEndpointMonitorImpl.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/customendpoint/CustomEndpointMonitorImpl.java
@@ -20,7 +20,6 @@ import static software.amazon.jdbc.plugin.customendpoint.MemberListType.STATIC_L
 
 import java.util.List;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiFunction;
@@ -36,8 +35,8 @@ import software.amazon.jdbc.AllowedAndBlockedHosts;
 import software.amazon.jdbc.HostSpec;
 import software.amazon.jdbc.PluginService;
 import software.amazon.jdbc.util.CacheMap;
+import software.amazon.jdbc.util.ExecutorFactory;
 import software.amazon.jdbc.util.Messages;
-import software.amazon.jdbc.util.StringUtils;
 import software.amazon.jdbc.util.telemetry.TelemetryCounter;
 import software.amazon.jdbc.util.telemetry.TelemetryFactory;
 
@@ -61,14 +60,7 @@ public class CustomEndpointMonitorImpl implements CustomEndpointMonitor {
   protected final long refreshRateNano;
 
   protected final PluginService pluginService;
-  protected final ExecutorService monitorExecutor = Executors.newSingleThreadExecutor(runnableTarget -> {
-    final Thread monitoringThread = new Thread(runnableTarget);
-    monitoringThread.setDaemon(true);
-    if (!StringUtils.isNullOrEmpty(monitoringThread.getName())) {
-      monitoringThread.setName(monitoringThread.getName() + "-cem");
-    }
-    return monitoringThread;
-  });
+  protected final ExecutorService monitorExecutor = ExecutorFactory.newSingleThreadExecutor("CustomEndpointMonitorImpl#monitorExecutor");
 
   private final TelemetryCounter infoChangedCounter;
 

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/MonitorConnectionContext.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/MonitorConnectionContext.java
@@ -19,10 +19,10 @@ package software.amazon.jdbc.plugin.efm;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.logging.Logger;
+import software.amazon.jdbc.util.ExecutorFactory;
 import software.amazon.jdbc.util.Messages;
 import software.amazon.jdbc.util.telemetry.TelemetryCounter;
 
@@ -33,7 +33,7 @@ import software.amazon.jdbc.util.telemetry.TelemetryCounter;
 public class MonitorConnectionContext {
 
   private static final Logger LOGGER = Logger.getLogger(MonitorConnectionContext.class.getName());
-  private static final Executor ABORT_EXECUTOR = Executors.newSingleThreadExecutor();
+  private static final Executor ABORT_EXECUTOR = ExecutorFactory.newSingleThreadExecutor("MonitorConnectionContext#ABORT_EXECUTOR");
 
   private final TelemetryCounter abortedConnectionsCounter;
 

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/MonitorServiceImpl.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/MonitorServiceImpl.java
@@ -21,12 +21,12 @@ import java.sql.Connection;
 import java.util.Collections;
 import java.util.Properties;
 import java.util.Set;
-import java.util.concurrent.Executors;
 import java.util.logging.Logger;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import software.amazon.jdbc.AwsWrapperProperty;
 import software.amazon.jdbc.HostSpec;
 import software.amazon.jdbc.PluginService;
+import software.amazon.jdbc.util.ExecutorFactory;
 import software.amazon.jdbc.util.Messages;
 import software.amazon.jdbc.util.telemetry.TelemetryCounter;
 import software.amazon.jdbc.util.telemetry.TelemetryFactory;
@@ -65,12 +65,7 @@ public class MonitorServiceImpl implements MonitorService {
                 MONITOR_DISPOSAL_TIME_MS.getLong(properties),
                 monitorService),
         () ->
-            Executors.newCachedThreadPool(
-                r -> {
-                  final Thread monitoringThread = new Thread(r);
-                  monitoringThread.setDaemon(true);
-                  return monitoringThread;
-                }));
+            ExecutorFactory.newCachedThreadPool("MonitorServiceImpl#executorServiceInitializer"));
   }
 
   MonitorServiceImpl(

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/efm2/MonitorImpl.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/efm2/MonitorImpl.java
@@ -28,7 +28,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
@@ -37,6 +36,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import software.amazon.jdbc.HostSpec;
 import software.amazon.jdbc.PluginService;
 import software.amazon.jdbc.hostavailability.HostAvailability;
+import software.amazon.jdbc.util.ExecutorFactory;
 import software.amazon.jdbc.util.Messages;
 import software.amazon.jdbc.util.PropertyUtils;
 import software.amazon.jdbc.util.StringUtils;
@@ -56,7 +56,7 @@ public class MonitorImpl implements Monitor {
   private static final long THREAD_SLEEP_NANO = TimeUnit.MILLISECONDS.toNanos(100);
   private static final String MONITORING_PROPERTY_PREFIX = "monitoring-";
 
-  protected static final Executor ABORT_EXECUTOR = Executors.newSingleThreadExecutor();
+  protected static final Executor ABORT_EXECUTOR = ExecutorFactory.newSingleThreadExecutor("MonitorImpl#ABORT_EXECUTOR");
 
   private final Queue<WeakReference<MonitorConnectionContext>> activeContexts = new ConcurrentLinkedQueue<>();
   private final Map<Long, Queue<WeakReference<MonitorConnectionContext>>> newContexts =
@@ -67,11 +67,7 @@ public class MonitorImpl implements Monitor {
   private final HostSpec hostSpec;
   private final AtomicBoolean stopped = new AtomicBoolean(false);
   private Connection monitoringConn = null;
-  private final ExecutorService threadPool = Executors.newFixedThreadPool(2, runnableTarget -> {
-    final Thread monitoringThread = new Thread(runnableTarget);
-    monitoringThread.setDaemon(true);
-    return monitoringThread;
-  });
+  private final ExecutorService threadPool = ExecutorFactory.newFixedThreadPool(2, "MonitorImpl#threadPool");
 
   private final long failureDetectionTimeNano;
   private final long failureDetectionIntervalNano;

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/efm2/MonitorServiceImpl.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/efm2/MonitorServiceImpl.java
@@ -20,13 +20,13 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Properties;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import software.amazon.jdbc.AwsWrapperProperty;
 import software.amazon.jdbc.HostSpec;
 import software.amazon.jdbc.PluginService;
+import software.amazon.jdbc.util.ExecutorFactory;
 import software.amazon.jdbc.util.Messages;
 import software.amazon.jdbc.util.SlidingExpirationCacheWithCleanupThread;
 import software.amazon.jdbc.util.telemetry.TelemetryCounter;
@@ -47,7 +47,7 @@ public class MonitorServiceImpl implements MonitorService {
 
   protected static final long CACHE_CLEANUP_NANO = TimeUnit.MINUTES.toNanos(1);
 
-  protected static final Executor ABORT_EXECUTOR = Executors.newSingleThreadExecutor();
+  protected static final Executor ABORT_EXECUTOR = ExecutorFactory.newSingleThreadExecutor("MonitorServiceImpl#ABORT_EXECUTOR");
 
   protected static final SlidingExpirationCacheWithCleanupThread<String, Monitor> monitors =
       new SlidingExpirationCacheWithCleanupThread<>(

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/failover/ClusterAwareReaderFailoverHandler.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/failover/ClusterAwareReaderFailoverHandler.java
@@ -27,7 +27,6 @@ import java.util.concurrent.CompletionService;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorCompletionService;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -36,6 +35,7 @@ import software.amazon.jdbc.HostRole;
 import software.amazon.jdbc.HostSpec;
 import software.amazon.jdbc.PluginService;
 import software.amazon.jdbc.hostavailability.HostAvailability;
+import software.amazon.jdbc.util.ExecutorFactory;
 import software.amazon.jdbc.util.Messages;
 import software.amazon.jdbc.util.PropertyUtils;
 import software.amazon.jdbc.util.Utils;
@@ -131,7 +131,7 @@ public class ClusterAwareReaderFailoverHandler implements ReaderFailoverHandler 
       return FAILED_READER_FAILOVER_RESULT;
     }
 
-    final ExecutorService executor = Executors.newSingleThreadExecutor();
+    final ExecutorService executor = ExecutorFactory.newSingleThreadExecutor("ClusterAwareReaderFailoverHandler#executor");
     final Future<ReaderFailoverResult> future = submitInternalFailoverTask(hosts, currentHost, executor);
     return getInternalFailoverResult(executor, future);
   }
@@ -287,7 +287,7 @@ public class ClusterAwareReaderFailoverHandler implements ReaderFailoverHandler 
 
   private ReaderFailoverResult getConnectionFromHostGroup(final List<HostSpec> hosts)
       throws SQLException {
-    final ExecutorService executor = Executors.newFixedThreadPool(2);
+    final ExecutorService executor = ExecutorFactory.newFixedThreadPool(2, "ClusterAwareReaderFailoverHandler#executor");
     final CompletionService<ReaderFailoverResult> completionService = new ExecutorCompletionService<>(executor);
 
     try {

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/failover/ClusterAwareWriterFailoverHandler.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/failover/ClusterAwareWriterFailoverHandler.java
@@ -26,7 +26,6 @@ import java.util.concurrent.CompletionService;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorCompletionService;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
@@ -35,6 +34,7 @@ import software.amazon.jdbc.HostRole;
 import software.amazon.jdbc.HostSpec;
 import software.amazon.jdbc.PluginService;
 import software.amazon.jdbc.hostavailability.HostAvailability;
+import software.amazon.jdbc.util.ExecutorFactory;
 import software.amazon.jdbc.util.Messages;
 import software.amazon.jdbc.util.PropertyUtils;
 import software.amazon.jdbc.util.Utils;
@@ -102,7 +102,7 @@ public class ClusterAwareWriterFailoverHandler implements WriterFailoverHandler 
     final boolean singleTask =
         this.pluginService.getDialect().getFailoverRestrictions().contains(FailoverRestriction.DISABLE_TASK_A);
 
-    final ExecutorService executorService = Executors.newFixedThreadPool(2);
+    final ExecutorService executorService = ExecutorFactory.newFixedThreadPool(2, "ClusterAwareWriterFailoverHandler#executorService");
     final CompletionService<WriterFailoverResult> completionService = new ExecutorCompletionService<>(executorService);
     submitTasks(currentTopology, executorService, completionService, singleTask);
 

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/limitless/LimitlessRouterMonitor.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/limitless/LimitlessRouterMonitor.java
@@ -21,7 +21,6 @@ import java.sql.SQLException;
 import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
@@ -33,6 +32,7 @@ import software.amazon.jdbc.util.Messages;
 import software.amazon.jdbc.util.PropertyUtils;
 import software.amazon.jdbc.util.SlidingExpirationCacheWithCleanupThread;
 import software.amazon.jdbc.util.Utils;
+import software.amazon.jdbc.util.ExecutorFactory;
 import software.amazon.jdbc.util.telemetry.TelemetryContext;
 import software.amazon.jdbc.util.telemetry.TelemetryFactory;
 import software.amazon.jdbc.util.telemetry.TelemetryTraceLevel;
@@ -53,11 +53,7 @@ public class LimitlessRouterMonitor implements AutoCloseable, Runnable {
   protected final TelemetryFactory telemetryFactory;
   protected Connection monitoringConn = null;
 
-  private final ExecutorService threadPool = Executors.newFixedThreadPool(1, runnableTarget -> {
-    final Thread monitoringThread = new Thread(runnableTarget);
-    monitoringThread.setDaemon(true);
-    return monitoringThread;
-  });
+  private final ExecutorService threadPool = ExecutorFactory.newFixedThreadPool(1, "LimitlessRouterMonitor#threadPool");
 
   private final AtomicBoolean stopped = new AtomicBoolean(false);
 

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/strategy/fastestresponse/NodeResponseTimeMonitor.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/strategy/fastestresponse/NodeResponseTimeMonitor.java
@@ -30,6 +30,7 @@ import java.util.logging.Logger;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import software.amazon.jdbc.HostSpec;
 import software.amazon.jdbc.PluginService;
+import software.amazon.jdbc.util.ExecutorFactory;
 import software.amazon.jdbc.util.Messages;
 import software.amazon.jdbc.util.PropertyUtils;
 import software.amazon.jdbc.util.StringUtils;
@@ -62,11 +63,7 @@ public class NodeResponseTimeMonitor implements AutoCloseable, Runnable {
 
   private Connection monitoringConn = null;
 
-  private final ExecutorService threadPool = Executors.newFixedThreadPool(1, runnableTarget -> {
-    final Thread monitoringThread = new Thread(runnableTarget);
-    monitoringThread.setDaemon(true);
-    return monitoringThread;
-  });
+  private final ExecutorService threadPool = ExecutorFactory.newFixedThreadPool(1, "NodeResponseTimeMonitor#threadPool");
 
   public NodeResponseTimeMonitor(
       final @NonNull PluginService pluginService,

--- a/wrapper/src/main/java/software/amazon/jdbc/states/SessionStateServiceImpl.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/states/SessionStateServiceImpl.java
@@ -22,12 +22,12 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.logging.Logger;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import software.amazon.jdbc.Driver;
 import software.amazon.jdbc.PluginService;
 import software.amazon.jdbc.PropertyDefinition;
+import software.amazon.jdbc.util.ExecutorFactory;
 import software.amazon.jdbc.util.StringUtils;
 
 public class SessionStateServiceImpl implements SessionStateService {
@@ -456,7 +456,7 @@ public class SessionStateServiceImpl implements SessionStateService {
     if (this.sessionState.networkTimeout.getValue().isPresent()) {
       this.sessionState.networkTimeout.resetPristineValue();
       this.setupPristineNetworkTimeout();
-      final ExecutorService executorService = Executors.newSingleThreadExecutor();
+      final ExecutorService executorService = ExecutorFactory.newSingleThreadExecutor("SessionStateServiceImpl#executorService");
       newConnection.setNetworkTimeout(executorService, this.sessionState.networkTimeout.getValue().get());
       executorService.shutdown();
     }
@@ -543,7 +543,7 @@ public class SessionStateServiceImpl implements SessionStateService {
 
     if (this.copySessionState.networkTimeout.canRestorePristine()) {
       try {
-        final ExecutorService executorService = Executors.newSingleThreadExecutor();
+        final ExecutorService executorService = ExecutorFactory.newSingleThreadExecutor("SessionStateServiceImpl#executorService");
         //noinspection OptionalGetWithoutIsPresent
         connection.setNetworkTimeout(executorService,
             this.copySessionState.networkTimeout.getPristineValue().get());

--- a/wrapper/src/main/java/software/amazon/jdbc/util/ExecutorFactory.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/ExecutorFactory.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.jdbc.util;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+
+public class ExecutorFactory {
+  public static ExecutorService newSingleThreadExecutor(String threadName) {
+    return Executors.newSingleThreadExecutor(getThreadFactory(threadName));
+  }
+
+  public static ExecutorService newCachedThreadPool(String threadName) {
+    return Executors.newCachedThreadPool(getThreadFactory(threadName));
+  }
+
+  public static ExecutorService newFixedThreadPool(int nThreads, String threadName) {
+    return Executors.newFixedThreadPool(nThreads, getThreadFactory(threadName));
+  }
+
+  private static ThreadFactory getThreadFactory(String threadName) {
+    return runnable -> {
+      Thread thread = new Thread(runnable, String.format("%s %s", "AWS JDBC wrapper", threadName));
+      thread.setDaemon(true);
+      return thread;
+    };
+  }
+}

--- a/wrapper/src/main/java/software/amazon/jdbc/util/SlidingExpirationCacheWithCleanupThread.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/SlidingExpirationCacheWithCleanupThread.java
@@ -27,11 +27,7 @@ public class SlidingExpirationCacheWithCleanupThread<K, V> extends SlidingExpira
   private static final Logger LOGGER =
       Logger.getLogger(SlidingExpirationCacheWithCleanupThread.class.getName());
 
-  protected final ExecutorService cleanupThreadPool = Executors.newFixedThreadPool(1, runnableTarget -> {
-    final Thread monitoringThread = new Thread(runnableTarget);
-    monitoringThread.setDaemon(true);
-    return monitoringThread;
-  });
+  protected final ExecutorService cleanupThreadPool = ExecutorFactory.newFixedThreadPool(1, "SlidingExpirationCacheWithCleanupThread#cleanupThreadPool");
   protected final ReentrantLock initLock = new ReentrantLock();
   protected boolean isInitialized = false;
 


### PR DESCRIPTION
### Summary

Implements issue https://github.com/aws/aws-advanced-jdbc-wrapper/issues/1401 to give all threads a name

### Description

- Replaced Executors.newXXX with new ExecutorFactory util which takes thread name argument 

### Additional Reviewers



### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.