### PR TITLE
refactor: simplify method to check if plugin exists

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/PluginService.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/PluginService.java
@@ -248,5 +248,5 @@ public interface PluginService extends ExceptionHandler {
 
   @NonNull SessionStateService getSessionStateService();
 
-  <T> T getPlugin(final Class<T> pluginClazz);
+  <T> boolean hasPlugin(final Class<T> pluginClazz);
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/PluginServiceImpl.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/PluginServiceImpl.java
@@ -778,14 +778,15 @@ public class PluginServiceImpl implements PluginService, CanReleaseResources,
     return this.sessionStateService;
   }
 
-  public <T> T getPlugin(final Class<T> pluginClazz) {
+  public <T> boolean hasPlugin(final Class<T> pluginClazz) {
     for (ConnectionPlugin p : this.pluginManager.plugins) {
       if (pluginClazz.isAssignableFrom(p.getClass())) {
-        return pluginClazz.cast(p);
+        return true;
       }
     }
-    return null;
+    return false;
   }
+
 
   public static void clearCache() {
     hostAvailabilityExpiringCache.clear();

--- a/wrapper/src/main/java/software/amazon/jdbc/dialect/AuroraMysqlDialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/dialect/AuroraMysqlDialect.java
@@ -82,10 +82,7 @@ public class AuroraMysqlDialect extends MysqlDialect {
   @Override
   public HostListProviderSupplier getHostListProvider() {
     return (properties, initialUrl, hostListProviderService, pluginService) -> {
-
-      final FailoverConnectionPlugin failover2Plugin = pluginService.getPlugin(FailoverConnectionPlugin.class);
-
-      if (failover2Plugin != null) {
+      if (pluginService.hasPlugin(FailoverConnectionPlugin.class)) {
         return new MonitoringRdsHostListProvider(
             properties,
             initialUrl,

--- a/wrapper/src/main/java/software/amazon/jdbc/dialect/AuroraPgDialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/dialect/AuroraPgDialect.java
@@ -128,10 +128,7 @@ public class AuroraPgDialect extends PgDialect implements AuroraLimitlessDialect
   @Override
   public HostListProviderSupplier getHostListProvider() {
     return (properties, initialUrl, hostListProviderService, pluginService) -> {
-
-      final FailoverConnectionPlugin failover2Plugin = pluginService.getPlugin(FailoverConnectionPlugin.class);
-
-      if (failover2Plugin != null) {
+      if (pluginService.hasPlugin(FailoverConnectionPlugin.class)) {
         return new MonitoringRdsHostListProvider(
             properties,
             initialUrl,

--- a/wrapper/src/main/java/software/amazon/jdbc/dialect/RdsMultiAzDbClusterMysqlDialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/dialect/RdsMultiAzDbClusterMysqlDialect.java
@@ -98,9 +98,7 @@ public class RdsMultiAzDbClusterMysqlDialect extends MysqlDialect {
   public HostListProviderSupplier getHostListProvider() {
     return (properties, initialUrl, hostListProviderService, pluginService) -> {
 
-      final FailoverConnectionPlugin failover2Plugin = pluginService.getPlugin(FailoverConnectionPlugin.class);
-
-      if (failover2Plugin != null) {
+      if (pluginService.hasPlugin(FailoverConnectionPlugin.class)) {
         return new MonitoringRdsMultiAzHostListProvider(
             properties,
             initialUrl,

--- a/wrapper/src/main/java/software/amazon/jdbc/dialect/RdsMultiAzDbClusterPgDialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/dialect/RdsMultiAzDbClusterPgDialect.java
@@ -114,9 +114,7 @@ public class RdsMultiAzDbClusterPgDialect extends PgDialect {
   public HostListProviderSupplier getHostListProvider() {
     return (properties, initialUrl, hostListProviderService, pluginService) -> {
 
-      final FailoverConnectionPlugin failover2Plugin = pluginService.getPlugin(FailoverConnectionPlugin.class);
-
-      if (failover2Plugin != null) {
+      if (pluginService.hasPlugin(FailoverConnectionPlugin.class)) {
         return new MonitoringRdsMultiAzHostListProvider(
             properties,
             initialUrl,

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/efm/ConcurrencyTests.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/efm/ConcurrencyTests.java
@@ -594,8 +594,8 @@ public class ConcurrencyTests {
     }
 
     @Override
-    public <T> T getPlugin(Class<T> pluginClazz) {
-      return null;
+    public <T> boolean hasPlugin(Class<T> pluginClazz) {
+      return false;
     }
 
     @Override


### PR DESCRIPTION
### Summary

PluginService has a `getPlugin` method. We only use this method to check if a plugin exists and create a host list provider accordingly.
We can simplify it to a boolean check and skip the casting, passing classes around and null checks.

### Description

<!--- Details of what you changed -->

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.