### PR TITLE
Update AuroraInitialConnectionStrategyPlugin.java

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/AuroraInitialConnectionStrategyPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/AuroraInitialConnectionStrategyPlugin.java
@@ -234,6 +234,7 @@ public class AuroraInitialConnectionStrategyPlugin extends AbstractConnectionPlu
           if (writerCandidate != null) {
             this.pluginService.setAvailability(writerCandidate.asAliases(), HostAvailability.NOT_AVAILABLE);
           }
+          this.delay(retryDelayMs);
         }
       } catch (Throwable ex) {
         this.closeConnection(writerCandidateConn);
@@ -334,6 +335,7 @@ public class AuroraInitialConnectionStrategyPlugin extends AbstractConnectionPlu
           if (readerCandidate != null) {
             this.pluginService.setAvailability(readerCandidate.asAliases(), HostAvailability.NOT_AVAILABLE);
           }
+          this.delay(retryDelayMs);
         }
       } catch (Throwable ex) {
         this.closeConnection(readerCandidateConn);


### PR DESCRIPTION
Avoid indefinite loops in case of non-login SQLException

### Summary

There are some race conditions during failover (both regional and across AZs) that make get `getVerifiedWriterConnection` method go in infinite loop without delays causing Postgres JDBC Driver spawning thousands of connection threads. This ultimately shuts up CPU and memory consumption causing the service reboot. 

### Description

Added sleep to slow down the loop.

### Additional Reviewers
N/A

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
yes