### PR TITLE
docs: clarify support for blue/green deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,14 +129,15 @@ The development team is aware of these limitations and is working to improve the
 > [!WARNING]\
 > **Blue/Green Support Behaviour and Version Compatibility**
 > 
-> The AWS Advanced JDBC Wrapper now includes enhanced full support for Blue/Green Deployments. This support requires a minimum database version, for RDS and Aurora PostgreSQL, that includes a specific metadata table. This constraint **does not** apply to RDS MySQL and Aurora MySQL.
+> The AWS Advanced JDBC Wrapper now includes enhanced full support for Blue/Green Deployments. This support requires a minimum database version that includes a specific metadata table. This constraint **does not** apply to RDS MySQL.
 >
 > If your database version does **not** support this table, the driver will automatically detect its absence and fallback to its previous behaviour. In this fallback mode, Blue/Green handling is subject to the same limitations listed above.
 >
 > **No action is required** if your database does not include the new metadata table -- the driver will continue to operate as before. If you have questions or encounter issues, please open an issue in this repository.
 >
-> Supported RDS PostgreSQL Versions: `rds_tools v1.7 (17.1, 16.5, 15.9, 14.14, 13.17, 12.21)`.<br>
-> Supported Aurora PostgreSQL Versions: Engine Release `17.5, 16.9, 15.13, 14.18, 13.21`.
+> Supported RDS PostgreSQL Versions: `rds_tools v1.7 (17.1, 16.5, 15.9, 14.14, 13.17, 12.21)` and above.<br>
+> Supported Aurora PostgreSQL Versions: Engine Release `17.5, 16.9, 15.13, 14.18, 13.21` and above.<br>
+> Supported Aurora MySQL Versions: Engine Release `3.07` and above.
 
 [^1]: Aurora MySQL requires v3.07 or later.
 

--- a/docs/using-the-jdbc-driver/using-plugins/UsingTheFailoverPlugin.md
+++ b/docs/using-the-jdbc-driver/using-plugins/UsingTheFailoverPlugin.md
@@ -106,14 +106,3 @@ public class HikariCPSQLException implements SQLExceptionOverride {
     }
 }
 ```
-
-### Blue/Green Deployments
-Although the AWS Advanced JDBC Wrapper is not compatible with [AWS Blue/Green Deployments](https://docs.aws.amazon.com/whitepapers/latest/overview-deployment-options/bluegreen-deployments.html) and does not officially support them, the combination of the AWS Advanced JDBC Wrapper and the Failover Plugin has been validated for use with clusters that employ Blue/Green Deployments. While general basic connectivity to both Blue and Green clusters is always in place, some failover cases are not fully supported.
-
-The current limitations are:
-- After a Blue/Green switchover, the wrapper may not be able to properly detect the new topology and handle failover, as there are discrepancies between the metadata and the available endpoints.
-- The specific version requirements for Aurora MySQL versus Aurora PostgreSQL may vary, as the internal systems used by the wrapper can differ[^1].
-
-The development team is aware of these limitations and is working to improve the wrapper's awareness and handling of Blue/Green switchovers. In the meantime, users can consider utilizing the `enableGreenNodeReplacement` configuration parameter, which allows the driver to override incorrect topology metadata and try to connect to available new Blue endpoints.
-
-[^1]: Aurora MySQL requires v3.07 or later.


### PR DESCRIPTION
### Summary

Clarifies support for blue/green deployments by specifying minimum versions.

### Description

Clarifies support for blue/green deployments by specifying minimum versions.

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.