### PR TITLE
do not consider XX000 errors as network-related errors

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/exceptions/PgExceptionHandler.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/exceptions/PgExceptionHandler.java
@@ -30,8 +30,7 @@ public class PgExceptionHandler extends AbstractPgExceptionHandler {
       "58", // system error (backend)
       "08", // connection error
       "99", // unexpected error
-      "F0", // configuration file error (backend)
-      "XX" // internal error (backend)
+      "F0" // configuration file error (backend)
   );
 
   private static final List<String> ACCESS_ERRORS = Arrays.asList(


### PR DESCRIPTION
### Summary

Do not consider "XX" errors as network-related errors.
https://github.com/aws/aws-advanced-jdbc-wrapper/issues/1453

### Additional Reviewers

@karenc-bq 

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.