### PR TITLE
fix: incorrect default timeout settings for PG

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/bluegreen/BlueGreenStatusProvider.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/bluegreen/BlueGreenStatusProvider.java
@@ -78,8 +78,8 @@ public class BlueGreenStatusProvider {
       "High Blue/Green Deployment status checking interval (in msec).");
 
   private static final String MONITORING_PROPERTY_PREFIX = "blue-green-monitoring-";
-  private static final String DEFAULT_CONNECT_TIMEOUT_MS = String.valueOf(TimeUnit.SECONDS.toMillis(10));
-  private static final String DEFAULT_SOCKET_TIMEOUT_MS = String.valueOf(TimeUnit.SECONDS.toMillis(10));
+  private static final long DEFAULT_CONNECT_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(10);
+  private static final long DEFAULT_SOCKET_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(10);
 
   public static final AwsWrapperProperty BG_SWITCHOVER_TIMEOUT_MS = new AwsWrapperProperty(
       "bgSwitchoverTimeoutMs", "180000", // 3min
@@ -189,8 +189,14 @@ public class BlueGreenStatusProvider {
               monitoringConnProperties.remove(p);
             });
 
-    monitoringConnProperties.putIfAbsent(PropertyDefinition.CONNECT_TIMEOUT.name, DEFAULT_CONNECT_TIMEOUT_MS);
-    monitoringConnProperties.putIfAbsent(PropertyDefinition.SOCKET_TIMEOUT.name, DEFAULT_SOCKET_TIMEOUT_MS);
+    this.pluginService.getTargetDriverDialect().setConnectTimeoutMs(
+        monitoringConnProperties,
+        PropertyDefinition.CONNECT_TIMEOUT.name,
+        DEFAULT_CONNECT_TIMEOUT_MS);
+    this.pluginService.getTargetDriverDialect().setSocketTimeoutMs(
+        monitoringConnProperties,
+        PropertyDefinition.SOCKET_TIMEOUT.name,
+        DEFAULT_SOCKET_TIMEOUT_MS);
 
     return monitoringConnProperties;
   }

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/bluegreen/BlueGreenStatusProvider.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/bluegreen/BlueGreenStatusProvider.java
@@ -41,7 +41,6 @@ import software.amazon.jdbc.HostRole;
 import software.amazon.jdbc.HostSpec;
 import software.amazon.jdbc.HostSpecBuilder;
 import software.amazon.jdbc.PluginService;
-import software.amazon.jdbc.PropertyDefinition;
 import software.amazon.jdbc.dialect.BlueGreenDialect;
 import software.amazon.jdbc.dialect.Dialect;
 import software.amazon.jdbc.hostavailability.SimpleHostAvailabilityStrategy;
@@ -189,14 +188,10 @@ public class BlueGreenStatusProvider {
               monitoringConnProperties.remove(p);
             });
 
-    this.pluginService.getTargetDriverDialect().setConnectTimeoutMs(
-        monitoringConnProperties,
-        PropertyDefinition.CONNECT_TIMEOUT.name,
-        DEFAULT_CONNECT_TIMEOUT_MS);
-    this.pluginService.getTargetDriverDialect().setSocketTimeoutMs(
-        monitoringConnProperties,
-        PropertyDefinition.SOCKET_TIMEOUT.name,
-        DEFAULT_SOCKET_TIMEOUT_MS);
+    this.pluginService
+        .getTargetDriverDialect()
+        .setConnectTimeoutMs(monitoringConnProperties, DEFAULT_CONNECT_TIMEOUT_MS);
+    this.pluginService.getTargetDriverDialect().setSocketTimeoutMs(monitoringConnProperties, DEFAULT_SOCKET_TIMEOUT_MS);
 
     return monitoringConnProperties;
   }

--- a/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/GenericTargetDriverDialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/GenericTargetDriverDialect.java
@@ -261,4 +261,14 @@ public class GenericTargetDriverDialect implements TargetDriverDialect {
         ? NETWORK_BOUND_METHODS_FOR_ENTIRE_RESULTSET
         : NETWORK_BOUND_METHODS;
   }
+
+  @Override
+  public void setConnectTimeoutMs(Properties props, String propertyKey, long milliseconds) {
+    props.setProperty(propertyKey, String.valueOf(milliseconds));
+  }
+
+  @Override
+  public void setSocketTimeoutMs(Properties props, String propertyKey, long milliseconds) {
+    props.setProperty(propertyKey, String.valueOf(milliseconds));
+  }
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/GenericTargetDriverDialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/GenericTargetDriverDialect.java
@@ -26,6 +26,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 import javax.sql.DataSource;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -263,12 +264,12 @@ public class GenericTargetDriverDialect implements TargetDriverDialect {
   }
 
   @Override
-  public void setConnectTimeoutMs(Properties props, String propertyKey, long milliseconds) {
-    props.setProperty(propertyKey, String.valueOf(milliseconds));
+  public void setConnectTimeoutMs(Properties props, long milliseconds) {
+    PropertyDefinition.CONNECT_TIMEOUT.set(props, String.valueOf(milliseconds));
   }
 
   @Override
-  public void setSocketTimeoutMs(Properties props, String propertyKey, long milliseconds) {
-    props.setProperty(propertyKey, String.valueOf(milliseconds));
+  public void setSocketTimeoutMs(Properties props, long milliseconds) {
+    PropertyDefinition.SOCKET_TIMEOUT.set(props, String.valueOf(milliseconds));
   }
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/PgTargetDriverDialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/PgTargetDriverDialect.java
@@ -167,14 +167,14 @@ public class PgTargetDriverDialect extends GenericTargetDriverDialect {
   }
 
   @Override
-  public void setConnectTimeoutMs(Properties props, String propertyKey, long milliseconds) {
+  public void setConnectTimeoutMs(Properties props, long milliseconds) {
     // PGJDBC uses seconds for its connect timeout setting.
-    props.setProperty(propertyKey, String.valueOf(TimeUnit.MILLISECONDS.toSeconds(milliseconds)));
+    PropertyDefinition.CONNECT_TIMEOUT.set(props, String.valueOf(TimeUnit.MILLISECONDS.toSeconds(milliseconds)));
   }
 
   @Override
-  public void setSocketTimeoutMs(Properties props, String propertyKey, long milliseconds) {
+  public void setSocketTimeoutMs(Properties props, long milliseconds) {
     // PGJDBC uses seconds for its socket timeout setting.
-    props.setProperty(propertyKey, String.valueOf(TimeUnit.MILLISECONDS.toSeconds(milliseconds)));
+    PropertyDefinition.SOCKET_TIMEOUT.set(props, String.valueOf(TimeUnit.MILLISECONDS.toSeconds(milliseconds)));
   }
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/PgTargetDriverDialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/PgTargetDriverDialect.java
@@ -165,4 +165,16 @@ public class PgTargetDriverDialect extends GenericTargetDriverDialect {
   public Set<String> getAllowedOnConnectionMethodNames() {
     return PG_ALLOWED_ON_CLOSED_METHOD_NAMES;
   }
+
+  @Override
+  public void setConnectTimeoutMs(Properties props, String propertyKey, long milliseconds) {
+    // PGJDBC uses seconds for its connect timeout setting.
+    props.setProperty(propertyKey, String.valueOf(TimeUnit.MILLISECONDS.toSeconds(milliseconds)));
+  }
+
+  @Override
+  public void setSocketTimeoutMs(Properties props, String propertyKey, long milliseconds) {
+    // PGJDBC uses seconds for its socket timeout setting.
+    props.setProperty(propertyKey, String.valueOf(TimeUnit.MILLISECONDS.toSeconds(milliseconds)));
+  }
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/TargetDriverDialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/TargetDriverDialect.java
@@ -46,10 +46,9 @@ public interface TargetDriverDialect {
   void registerDriver() throws SQLException;
 
   /**
-   * Attempts to communicate to a database node in order to measure network latency.
-   * Some database protocols may not support the simplest "ping" packet. In this case,
-   * it's recommended to execute a simple connection validation, or the simplest SQL
-   * query like "SELECT 1".
+   * Attempts to communicate to a database node in order to measure network latency. Some database protocols may not
+   * support the simplest "ping" packet. In this case, it's recommended to execute a simple connection validation, or
+   * the simplest SQL query like "SELECT 1".
    *
    * @param connection The database connection to a node to ping.
    * @return True, if operation is succeeded. False, otherwise.
@@ -61,4 +60,8 @@ public interface TargetDriverDialect {
   String getSQLState(final Throwable throwable);
 
   Set<String> getNetworkBoundMethodNames(final @Nullable Properties properties);
+
+  void setConnectTimeoutMs(final Properties props, final String propertyKey, final long milliseconds);
+
+  void setSocketTimeoutMs(final Properties props, final String propertyKey, final long milliseconds);
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/TargetDriverDialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/TargetDriverDialect.java
@@ -61,7 +61,7 @@ public interface TargetDriverDialect {
 
   Set<String> getNetworkBoundMethodNames(final @Nullable Properties properties);
 
-  void setConnectTimeoutMs(final Properties props, final String propertyKey, final long milliseconds);
+  void setConnectTimeoutMs(final Properties props, final long milliseconds);
 
-  void setSocketTimeoutMs(final Properties props, final String propertyKey, final long milliseconds);
+  void setSocketTimeoutMs(final Properties props, final long milliseconds);
 }


### PR DESCRIPTION
### Summary

PGJDBC uses seconds for network timeouts but default timeouts were passed as milliseconds

### Description

<!--- Details of what you changed -->

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.