### PR TITLE
fix: correct variable in telemetry metrics backend error message

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/util/telemetry/DefaultTelemetryFactory.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/telemetry/DefaultTelemetryFactory.java
@@ -61,7 +61,7 @@ public class DefaultTelemetryFactory implements TelemetryFactory {
         this.metricsTelemetryFactory = null;
       } else {
         throw new RuntimeException(
-            telemetryTracesBackend + " is not a valid metrics backend. Available options: OTLP, NONE.");
+            telemetryMetricsBackend + " is not a valid metrics backend. Available options: OTLP, NONE.");
       }
     } else {
       this.metricsTelemetryFactory = null;


### PR DESCRIPTION
Use `telemetryMetricsBackend` instead of `telemetryTracesBackend` in the RuntimeException when an invalid metrics backend is configured.

### Summary

Fix incorrect variable in telemetry metrics backend error message

### Description

Fixed a bug in `DefaultTelemetryFactory` where the error message for invalid metrics backend configuration was displaying the wrong variable value. 

**Issue:** When an invalid `telemetryMetricsBackend` value was provided, the RuntimeException incorrectly showed the `telemetryTracesBackend` value in the error message, making it confusing for users to identify which configuration was actually invalid.

**Fix:** Changed line 64 to use `telemetryMetricsBackend` instead of `telemetryTracesBackend` in the exception message.

**Before:**
```java
throw new RuntimeException(
    telemetryTracesBackend + " is not a valid metrics backend. Available options: OTLP, NONE.");
```

**After:**
```java
throw new RuntimeException(
    telemetryMetricsBackend + " is not a valid metrics backend. Available options: OTLP, NONE.");
```

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.