### PR TITLE
chore: remove pom dependencies

### DIFF
--- a/aws-advanced-jdbc-wrapper-bundle/build.gradle.kts
+++ b/aws-advanced-jdbc-wrapper-bundle/build.gradle.kts
@@ -25,8 +25,8 @@ repositories {
 
 dependencies {
     implementation("org.apache.httpcomponents:httpclient:4.5.14")
-    implementation("software.amazon.awssdk:rds:2.32.25")
-    implementation("software.amazon.awssdk:sts:2.32.25")
+    implementation("software.amazon.awssdk:rds:2.32.29")
+    implementation("software.amazon.awssdk:sts:2.32.29")
     implementation(project(":aws-advanced-jdbc-wrapper"))
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -129,6 +129,22 @@ allprojects {
                             system.set("GitHub issues")
                             url.set("https://github.com/aws/aws-advanced-jdbc-wrapper/issues")
                         }
+
+                        // Remove dependencies
+                        withXml {
+                            val sb = asString()
+                            var s = sb.toString()
+                            s = s.replace(
+                                Regex(
+                                    "<dependency>.*?</dependency>",
+                                    RegexOption.DOT_MATCHES_ALL
+                                ),
+                                ""
+                            )
+                            sb.setLength(0)
+                            sb.append(s)
+                            asNode()
+                        }
                     }
                 }
 

--- a/examples/AWSDriverExample/build.gradle.kts
+++ b/examples/AWSDriverExample/build.gradle.kts
@@ -18,9 +18,9 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-jdbc:2.7.13") // 2.7.13 is the last version compatible with Java 8
     implementation("org.postgresql:postgresql:42.7.7")
     implementation("com.mysql:mysql-connector-j:9.3.0")
-    implementation("software.amazon.awssdk:rds:2.32.25")
-    implementation("software.amazon.awssdk:secretsmanager:2.32.25")
-    implementation("software.amazon.awssdk:sts:2.32.25")
+    implementation("software.amazon.awssdk:rds:2.32.29")
+    implementation("software.amazon.awssdk:secretsmanager:2.32.29")
+    implementation("software.amazon.awssdk:sts:2.32.29")
     implementation("com.fasterxml.jackson.core:jackson-databind:2.19.0")
     implementation(project(":aws-advanced-jdbc-wrapper"))
     implementation("io.opentelemetry:opentelemetry-api:1.52.0")

--- a/examples/DBCPExample/build.gradle.kts
+++ b/examples/DBCPExample/build.gradle.kts
@@ -19,5 +19,5 @@ dependencies {
     implementation("com.mysql:mysql-connector-j:9.3.0")
     implementation(project(":aws-advanced-jdbc-wrapper"))
     implementation("org.apache.commons:commons-dbcp2:2.13.0")
-    implementation("software.amazon.awssdk:rds:2.32.25")
+    implementation("software.amazon.awssdk:rds:2.32.29")
 }

--- a/examples/SpringHibernateBalancedReaderOneDataSourceExample/build.gradle.kts
+++ b/examples/SpringHibernateBalancedReaderOneDataSourceExample/build.gradle.kts
@@ -23,6 +23,6 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.retry:spring-retry")
     implementation("org.postgresql:postgresql:42.7.7")
-    implementation("software.amazon.awssdk:rds:2.32.25")
+    implementation("software.amazon.awssdk:rds:2.32.29")
     implementation(project(":aws-advanced-jdbc-wrapper"))
 }

--- a/examples/SpringHibernateBalancedReaderTwoDataSourceExample/build.gradle.kts
+++ b/examples/SpringHibernateBalancedReaderTwoDataSourceExample/build.gradle.kts
@@ -23,6 +23,6 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.retry:spring-retry")
     implementation("org.postgresql:postgresql:42.7.7")
-    implementation("software.amazon.awssdk:rds:2.32.25")
+    implementation("software.amazon.awssdk:rds:2.32.29")
     implementation(project(":aws-advanced-jdbc-wrapper"))
 }

--- a/examples/SpringHibernateExample/build.gradle.kts
+++ b/examples/SpringHibernateExample/build.gradle.kts
@@ -23,6 +23,6 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.postgresql:postgresql:42.7.7")
-    implementation("software.amazon.awssdk:rds:2.32.25")
+    implementation("software.amazon.awssdk:rds:2.32.29")
     implementation(project(":aws-advanced-jdbc-wrapper"))
 }

--- a/examples/SpringTxFailoverExample/README.md
+++ b/examples/SpringTxFailoverExample/README.md
@@ -102,7 +102,7 @@ dependencies {
 	implementation("org.springframework.retry:spring-retry:1.3.4")
 	implementation("org.springframework:spring-aspects:5.3.29")
 	implementation("org.postgresql:postgresql:42.5.4")
-	implementation("software.amazon.awssdk:rds:2.32.21")
+	implementation("software.amazon.awssdk:rds:2.32.29")
 	implementation("software.amazon.jdbc:aws-advanced-jdbc-wrapper:latest")
 }
 ```

--- a/examples/SpringWildflyExample/spring/build.gradle.kts
+++ b/examples/SpringWildflyExample/spring/build.gradle.kts
@@ -24,6 +24,6 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     runtimeOnly("org.springframework.boot:spring-boot-devtools")
     implementation("org.postgresql:postgresql:42.7.7")
-    implementation("software.amazon.awssdk:rds:2.32.25")
+    implementation("software.amazon.awssdk:rds:2.32.29")
     implementation(project(":aws-advanced-jdbc-wrapper"))
 }

--- a/wrapper/build.gradle.kts
+++ b/wrapper/build.gradle.kts
@@ -32,20 +32,19 @@ if (useJacoco) {
 }
 
 dependencies {
-    implementation("org.checkerframework:checker-qual:3.49.5")
+    compileOnly("org.checkerframework:checker-qual:3.49.5")
     compileOnly("org.apache.httpcomponents:httpclient:4.5.14")
-    compileOnly("software.amazon.awssdk:rds:2.32.25")
-    compileOnly("software.amazon.awssdk:auth:2.32.25") // Required for IAM (light implementation)
-    compileOnly("software.amazon.awssdk:http-client-spi:2.32.25") // Required for IAM (light implementation)
-    compileOnly("software.amazon.awssdk:sts:2.32.25")
+    compileOnly("software.amazon.awssdk:rds:2.32.29")
+    compileOnly("software.amazon.awssdk:auth:2.32.29") // Required for IAM (light implementation)
+    compileOnly("software.amazon.awssdk:http-client-spi:2.32.29") // Required for IAM (light implementation)
+    compileOnly("software.amazon.awssdk:sts:2.32.29")
     compileOnly("com.zaxxer:HikariCP:4.0.3") // Version 4.+ is compatible with Java 8
     compileOnly("com.mchange:c3p0:0.11.0")
-    compileOnly("software.amazon.awssdk:secretsmanager:2.32.25")
+    compileOnly("software.amazon.awssdk:secretsmanager:2.32.29")
     compileOnly("com.fasterxml.jackson.core:jackson-databind:2.19.0")
     compileOnly("com.mysql:mysql-connector-j:9.3.0")
     compileOnly("org.postgresql:postgresql:42.7.7")
     compileOnly("org.mariadb.jdbc:mariadb-java-client:3.5.3")
-    compileOnly("org.osgi:org.osgi.core:6.0.0")
     compileOnly("org.osgi:org.osgi.core:6.0.0")
     compileOnly("com.amazonaws:aws-xray-recorder-sdk-core:2.18.2")
     compileOnly("io.opentelemetry:opentelemetry-api:1.52.0")
@@ -54,6 +53,7 @@ dependencies {
     compileOnly("org.jsoup:jsoup:1.21.1")
     compileOnly("org.jetbrains.kotlin:kotlin-stdlib:2.1.21")
 
+    testImplementation("org.checkerframework:checker-qual:3.49.5")
     testImplementation("org.junit.platform:junit-platform-commons:1.13.4")
     testImplementation("org.junit.platform:junit-platform-engine:1.13.3")
     testImplementation("org.junit.platform:junit-platform-launcher:1.13.4")
@@ -70,12 +70,12 @@ dependencies {
     testImplementation("com.mchange:c3p0:0.11.0")
     testImplementation("org.springframework.boot:spring-boot-starter-jdbc:2.7.13") // 2.7.13 is the last version compatible with Java 8
     testImplementation("org.mockito:mockito-inline:4.11.0") // 4.11.0 is the last version compatible with Java 8
-    testImplementation("software.amazon.awssdk:rds:2.32.25")
-    testImplementation("software.amazon.awssdk:auth:2.32.25") // Required for IAM (light implementation)
-    testImplementation("software.amazon.awssdk:http-client-spi:2.32.25") // Required for IAM (light implementation)
-    testImplementation("software.amazon.awssdk:ec2:2.32.25")
-    testImplementation("software.amazon.awssdk:secretsmanager:2.32.25")
-    testImplementation("software.amazon.awssdk:sts:2.32.25")
+    testImplementation("software.amazon.awssdk:rds:2.32.29", )
+    testImplementation("software.amazon.awssdk:auth:2.32.29") // Required for IAM (light implementation)
+    testImplementation("software.amazon.awssdk:http-client-spi:2.32.29") // Required for IAM (light implementation)
+    testImplementation("software.amazon.awssdk:ec2:2.32.29")
+    testImplementation("software.amazon.awssdk:secretsmanager:2.32.29")
+    testImplementation("software.amazon.awssdk:sts:2.32.29")
     // Note: all org.testcontainers dependencies should have the same version
     testImplementation("org.testcontainers:testcontainers:1.21.2")
     testImplementation("org.testcontainers:mysql:1.21.2")

--- a/wrapper/src/test/build.gradle.kts
+++ b/wrapper/src/test/build.gradle.kts
@@ -41,9 +41,9 @@ dependencies {
     testImplementation("com.zaxxer:HikariCP:4.0.3") // Version 4.+ is compatible with Java 8
     testImplementation("org.springframework.boot:spring-boot-starter-jdbc:2.7.13") // 2.7.13 is the last version compatible with Java 8
     testImplementation("org.mockito:mockito-inline:4.11.0") // 4.11.0 is the last version compatible with Java 8
-    testImplementation("software.amazon.awssdk:ec2:2.32.21")
-    testImplementation("software.amazon.awssdk:rds:2.32.21")
-    testImplementation("software.amazon.awssdk:sts:2.32.21")
+    testImplementation("software.amazon.awssdk:ec2:2.32.29")
+    testImplementation("software.amazon.awssdk:rds:2.32.29")
+    testImplementation("software.amazon.awssdk:sts:2.32.29")
     // Note: all org.testcontainers dependencies should have the same version
     testImplementation("org.testcontainers:testcontainers:1.20.4")
     testImplementation("org.testcontainers:mysql:1.20.4")


### PR DESCRIPTION
### Summary

- upgrade AWS SDK to 2.32.29
- remove pom dependencies

### Additional Reviewers

@karenc-bq 

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.