### PR TITLE
docs: clarify RDS Proxy compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ Visit [this page](./docs/using-the-jdbc-driver/SupportForRDSMultiAzDBCluster.md)
 
 The AWS JDBC Driver also works with RDS provided databases that are not Aurora.
 
+### RDS Proxy
+
+There are limitations with the AWS JDBC Driver and RDS Proxy. This is currently intended, by design, since the main reason is that RDS Proxy transparently re-routes requests to a single database instance. RDS Proxy decides which database instance is used based on many criteria (on a per-request basis). Due to this, functionality like Failover, Enhanced Host Monitoring, and Read/Write Splitting is not compatible since the driver relies on cluster topology and RDS Proxy handles this automatically.
+
+However, the driver can still be used to handle authentication workflows. For more information regarding compatibility, please refer to the specific plugin documentation.
+
 Visit [this page](./docs/using-the-jdbc-driver/UsingTheJdbcDriver.md#using-the-aws-jdbc-driver-with-plain-rds-databases) for more details.
 
 ## Getting Started


### PR DESCRIPTION
### Summary

Clarify compatibility with RDS Proxy and the driver. In summary, plugins that actively manage connections to the DB will not be compatible with RDS Proxy. This is intended because of how RDS Proxy operates.

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.