### PR TITLE
fix: isValidTimeout potentially rounded down to 0

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/efm2/HostMonitorImpl.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/efm2/HostMonitorImpl.java
@@ -52,6 +52,7 @@ public class HostMonitorImpl extends AbstractMonitor implements HostMonitor {
   private static final long THREAD_SLEEP_NANO = TimeUnit.MILLISECONDS.toNanos(100);
   private static final long TERMINATION_TIMEOUT_SEC = 30;
   private static final String MONITORING_PROPERTY_PREFIX = "monitoring-";
+  private static final int MIN_VALIDITY_CHECK_TIMEOUT_SEC = 1;
 
   protected static final Executor ABORT_EXECUTOR =
       ExecutorFactory.newSingleThreadExecutor("abort");
@@ -324,7 +325,7 @@ public class HostMonitorImpl extends AbstractMonitor implements HostMonitor {
       final int validTimeout = (int) TimeUnit.NANOSECONDS.toSeconds(
           this.failureDetectionIntervalNano - THREAD_SLEEP_NANO) / 2;
       // validTimeout could get rounded down to 0.
-      return this.monitoringConn.isValid(Math.max(1, validTimeout));
+      return this.monitoringConn.isValid(Math.max(MIN_VALIDITY_CHECK_TIMEOUT_SEC, validTimeout));
     } catch (final SQLException sqlEx) {
       return false;
     } finally {


### PR DESCRIPTION
### Summary

`isValidTimeout` could potentially rounded down, causing the monitoring connections to send a isValid request without any timeout.
### Description

<!--- Details of what you changed -->

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.