### PR TITLE
fix issue with blue/green metadata for PG databases

### DIFF
--- a/wrapper/src/test/java/integration/container/tests/hibernate/HibernateTests.java
+++ b/wrapper/src/test/java/integration/container/tests/hibernate/HibernateTests.java
@@ -57,6 +57,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
     TestEnvironmentFeatures.PERFORMANCE,
     TestEnvironmentFeatures.RUN_HIBERNATE_TESTS_ONLY,
     TestEnvironmentFeatures.RUN_AUTOSCALING_TESTS_ONLY,
+    TestEnvironmentFeatures.BLUE_GREEN_DEPLOYMENT,
     TestEnvironmentFeatures.RUN_DB_METRICS_ONLY})
 @MakeSureFirstInstanceWriter
 @Order(21)

--- a/wrapper/src/test/java/integration/util/AuroraTestUtility.java
+++ b/wrapper/src/test/java/integration/util/AuroraTestUtility.java
@@ -1048,6 +1048,9 @@ public class AuroraTestUtility {
   public String getAuroraParameterGroupFamily(String engine, String engineVersion) {
     switch (engine) {
       case "aurora-postgresql":
+        if (StringUtils.isNullOrEmpty(engineVersion) || engineVersion.startsWith("17.")) {
+          return "aurora-postgresql17";
+        }
         return "aurora-postgresql16";
       case "aurora-mysql":
         if (StringUtils.isNullOrEmpty(engineVersion) || engineVersion.contains("8.0")) {


### PR DESCRIPTION
### Summary

Fix issue with blue/green metadata for PG databases after switchover is completed

### Additional Reviewers

@karenc-bq 
@sophia-bq 

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.