### PR TITLE
fix: update closedExplicitly flag

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/failover2/FailoverConnectionPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/failover2/FailoverConnectionPlugin.java
@@ -206,7 +206,8 @@ public class FailoverConnectionPlugin extends AbstractConnectionPlugin {
     }
 
     if (canDirectExecute(methodName)) {
-      if (JdbcMethod.CONNECTION_CLOSE.methodName.equals(methodName)) {
+      if (JdbcMethod.CONNECTION_CLOSE.methodName.equals(methodName)
+          || JdbcMethod.CONNECTION_ABORT.methodName.equals(methodName)) {
         this.closedExplicitly = true;
       }
       return jdbcMethodFunc.call();


### PR DESCRIPTION
### Summary

The closedExplicitly flag is never set. Update failover plugin to update the flag when the closed method is called.

### Description

<!--- Details of what you changed -->

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.