### PR TITLE
chore: clean up test environment before each run

### DIFF
--- a/.github/workflows/run-integration-tests-default.yml
+++ b/.github/workflows/run-integration-tests-default.yml
@@ -65,3 +65,12 @@ jobs:
           name: html-summary-report-default-${{ matrix.dbEngine }}
           path: ./wrapper/build/report
           retention-days: 5
+      - name: Get Github Action IP
+        if: always()
+        id: ip
+        uses: haythem/public-ip@v1.3
+
+      - name: Remove Github Action IP
+        if: always()
+        run: |
+          aws ec2 revoke-security-group-ingress --group-name default --protocol all --port 0-65535 --cidr ${{ steps.ip.outputs.ipv4 }}/32

--- a/.github/workflows/run-integration-tests-latest.yml
+++ b/.github/workflows/run-integration-tests-latest.yml
@@ -65,3 +65,12 @@ jobs:
           name: html-summary-report-latest-${{ matrix.dbEngine }}
           path: ./wrapper/build/report
           retention-days: 5
+      - name: Get Github Action IP
+        if: always()
+        id: ip
+        uses: haythem/public-ip@v1.3
+
+      - name: Remove Github Action IP
+        if: always()
+        run: |
+          aws ec2 revoke-security-group-ingress --group-name default --protocol all --port 0-65535 --cidr ${{ steps.ip.outputs.ipv4 }}/32


### PR DESCRIPTION
### Summary

clean up test environment before each run:
- delete outdated test clusters
- delete outdated test DB instances
- remove outdated security group rules

### Additional Reviewers

@karenc-bq 
@aaron-congo 

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.