### PR TITLE
Update integration testing guide with clean-up step.

### DIFF
--- a/docs/development-guide/IntegrationTests.md
+++ b/docs/development-guide/IntegrationTests.md
@@ -69,3 +69,15 @@ cmd /c ./gradlew --no-parallel --no-daemon test-all-environments
 ```
 
 Test results can be found at `wrapper/build/report/index.html`.
+
+If you encounter unexplained build issues/errors, or after major project structure changes, try running the following to perform a clean build:
+
+macOS:
+```bash
+./gradlew clean
+```
+
+Windows:
+```bash
+cmd /c ./gradlew clean
+```


### PR DESCRIPTION
### Summary

Current integration tests guide doesn't include how to do a clean rebuild so that new code changes don't get picked up by the next test runs. This change adds the clean-up step so that next test run will pick up the new changes. 

### Description

Update integration testing guide with clean-up step.

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.