### PR TITLE
add support of the following domains: eu, au, uk

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/util/RdsUtils.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/RdsUtils.java
@@ -79,7 +79,7 @@ public class RdsUtils {
           "^(?<instance>.+)\\."
               + "(?<dns>proxy-|cluster-|cluster-ro-|cluster-custom-|shardgrp-)?"
               + "(?<domain>[a-zA-Z0-9]+\\.(?<region>[a-zA-Z0-9\\-]+)"
-              + "\\.rds\\.amazonaws\\.com\\.?)$",
+              + "\\.(rds|rds-fips)\\.amazonaws\\.(com|au|eu|uk)\\.?)$",
           Pattern.CASE_INSENSITIVE);
 
   private static final Pattern AURORA_CLUSTER_PATTERN =
@@ -87,20 +87,21 @@ public class RdsUtils {
           "^(?<instance>.+)\\."
               + "(?<dns>cluster-|cluster-ro-)+"
               + "(?<domain>[a-zA-Z0-9]+\\.(?<region>[a-zA-Z0-9\\-]+)"
-              + "\\.rds\\.amazonaws\\.com\\.?)$",
+              + "\\.(rds|rds-fips)\\.amazonaws\\.(com|au|eu|uk)\\.?)$",
           Pattern.CASE_INSENSITIVE);
   private static final Pattern AURORA_LIMITLESS_CLUSTER_PATTERN =
       Pattern.compile(
           "(?<instance>.+)\\."
               + "(?<dns>shardgrp-)+"
               + "(?<domain>[a-zA-Z0-9]+\\.(?<region>[a-zA-Z0-9\\-]+)"
-              + "\\.rds\\.(amazonaws\\.com\\.?|amazonaws\\.com\\.cn\\.?|sc2s\\.sgov\\.gov\\.?|c2s\\.ic\\.gov\\.?))$",
+              + "\\.(rds|rds-fips)\\.(amazonaws\\.com\\.?|amazonaws\\.eu\\.?|amazonaws\\.au\\.?|amazonaws\\.uk\\.?"
+              + "|amazonaws\\.com\\.cn\\.?|sc2s\\.sgov\\.gov\\.?|c2s\\.ic\\.gov\\.?))$",
           Pattern.CASE_INSENSITIVE);
   private static final Pattern AURORA_CHINA_DNS_PATTERN =
       Pattern.compile(
           "^(?<instance>.+)\\."
               + "(?<dns>proxy-|cluster-|cluster-ro-|cluster-custom-|shardgrp-)?"
-              + "(?<domain>[a-zA-Z0-9]+\\.rds\\.(?<region>[a-zA-Z0-9\\-]+)"
+              + "(?<domain>[a-zA-Z0-9]+\\.(rds|rds-fips)\\.(?<region>[a-zA-Z0-9\\-]+)"
               + "\\.amazonaws\\.com\\.cn\\.?)$",
           Pattern.CASE_INSENSITIVE);
 
@@ -108,7 +109,7 @@ public class RdsUtils {
       Pattern.compile(
           "^(?<instance>.+)\\."
               + "(?<dns>cluster-|cluster-ro-)+"
-              + "(?<domain>[a-zA-Z0-9]+\\.rds\\.(?<region>[a-zA-Z0-9\\-]+)"
+              + "(?<domain>[a-zA-Z0-9]+\\.(rds|rds-fips)\\.(?<region>[a-zA-Z0-9\\-]+)"
               + "\\.amazonaws\\.com\\.cn\\.?)$",
           Pattern.CASE_INSENSITIVE);
 
@@ -117,7 +118,7 @@ public class RdsUtils {
           "^(?<instance>.+)\\."
               + "(?<dns>proxy-|cluster-|cluster-ro-|cluster-custom-|shardgrp-)?"
               + "(?<domain>[a-zA-Z0-9]+\\.(?<region>[a-zA-Z0-9\\-]+)"
-              + "\\.rds\\.amazonaws\\.com\\.cn\\.?)$",
+              + "\\.(rds|rds-fips)\\.amazonaws\\.com\\.cn\\.?)$",
           Pattern.CASE_INSENSITIVE);
 
   private static final Pattern AURORA_OLD_CHINA_CLUSTER_PATTERN =
@@ -125,14 +126,14 @@ public class RdsUtils {
           "^(?<instance>.+)\\."
               + "(?<dns>cluster-|cluster-ro-)+"
               + "(?<domain>[a-zA-Z0-9]+\\.(?<region>[a-zA-Z0-9\\-]+)"
-              + "\\.rds\\.amazonaws\\.com\\.cn\\.?)$",
+              + "\\.(rds|rds-fips)\\.amazonaws\\.com\\.cn\\.?)$",
           Pattern.CASE_INSENSITIVE);
 
   private static final Pattern AURORA_GOV_DNS_PATTERN =
       Pattern.compile(
           "^(?<instance>.+)\\."
               + "(?<dns>proxy-|cluster-|cluster-ro-|cluster-custom-|shardgrp-)?"
-              + "(?<domain>[a-zA-Z0-9]+\\.rds\\.(?<region>[a-zA-Z0-9\\-]+)"
+              + "(?<domain>[a-zA-Z0-9]+\\.(rds|rds-fips)\\.(?<region>[a-zA-Z0-9\\-]+)"
               + "\\.(amazonaws\\.com\\.?|c2s\\.ic\\.gov\\.?|sc2s\\.sgov\\.gov\\.?))$",
           Pattern.CASE_INSENSITIVE);
 
@@ -140,14 +141,14 @@ public class RdsUtils {
       Pattern.compile(
           "^(?<instance>.+)\\."
               + "(?<dns>cluster-|cluster-ro-)+"
-              + "(?<domain>[a-zA-Z0-9]+\\.rds\\.(?<region>[a-zA-Z0-9\\-]+)"
+              + "(?<domain>[a-zA-Z0-9]+\\.(rds|rds-fips)\\.(?<region>[a-zA-Z0-9\\-]+)"
               + "\\.(amazonaws\\.com\\.?|c2s\\.ic\\.gov\\.?|sc2s\\.sgov\\.gov\\.?))$",
           Pattern.CASE_INSENSITIVE);
 
   private static final Pattern ELB_PATTERN =
       Pattern.compile(
           "^(?<instance>.+)\\.elb\\."
-              + "((?<region>[a-zA-Z0-9\\-]+)\\.amazonaws\\.com\\.?)$",
+              + "((?<region>[a-zA-Z0-9\\-]+)\\.amazonaws\\.(com|au|eu|uk)\\.?)$",
           Pattern.CASE_INSENSITIVE);
 
   private static final Pattern IP_V4 =

--- a/wrapper/src/test/java/software/amazon/jdbc/util/RdsUtilsTests.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/util/RdsUtilsTests.java
@@ -42,6 +42,9 @@ public class RdsUtilsTests {
   private static final String usEastRegionLimitlessDbShardGroup =
       "database-test-name.shardgrp-XYZ.us-east-2.rds.amazonaws.com";
 
+  private static final String euRedshift =
+      "redshift-test-name.XYZ.eusc-de-east-1.rds.amazonaws.eu";
+
   private static final String chinaRegionCluster =
       "database-test-name.cluster-XYZ.rds.cn-northwest-1.amazonaws.com.cn";
   private static final String chinaRegionClusterTrailingDot =
@@ -133,6 +136,7 @@ public class RdsUtilsTests {
     assertFalse(target.isRdsDns(usEastRegionElbUrl));
     assertFalse(target.isRdsDns(usEastRegionElbUrlTrailingDot));
     assertTrue(target.isRdsDns(usEastRegionLimitlessDbShardGroup));
+    assertTrue(target.isRdsDns(euRedshift));
 
     assertTrue(target.isRdsDns(chinaRegionCluster));
     assertTrue(target.isRdsDns(chinaRegionClusterTrailingDot));
@@ -210,6 +214,9 @@ public class RdsUtilsTests {
     assertEquals(oldChinaExpectedHostPattern, target.getRdsInstanceHostPattern(oldChinaRegionProxy));
     assertEquals(oldChinaExpectedHostPattern, target.getRdsInstanceHostPattern(oldChinaRegionCustomDomain));
     assertEquals(oldChinaExpectedHostPattern, target.getRdsInstanceHostPattern(oldChinaRegionLimitlessDbShardGroup));
+
+    final String euRedshiftExpectedHostPattern = "?.XYZ.eusc-de-east-1.rds.amazonaws.eu";
+    assertEquals(euRedshiftExpectedHostPattern, target.getRdsInstanceHostPattern(euRedshift));
   }
 
   @Test
@@ -221,6 +228,7 @@ public class RdsUtilsTests {
     assertFalse(target.isRdsClusterDns(usEastRegionCustomDomain));
     assertFalse(target.isRdsClusterDns(usEastRegionElbUrl));
     assertFalse(target.isRdsClusterDns(usEastRegionLimitlessDbShardGroup));
+    assertFalse(target.isRdsClusterDns(euRedshift));
 
     assertTrue(target.isRdsClusterDns(usIsobEastRegionCluster));
     assertTrue(target.isRdsClusterDns(usIsobEastRegionClusterReadOnly));
@@ -260,6 +268,7 @@ public class RdsUtilsTests {
     assertFalse(target.isWriterClusterDns(usEastRegionCustomDomain));
     assertFalse(target.isWriterClusterDns(usEastRegionElbUrl));
     assertFalse(target.isWriterClusterDns(usEastRegionLimitlessDbShardGroup));
+    assertFalse(target.isWriterClusterDns(euRedshift));
 
     assertTrue(target.isWriterClusterDns(usIsobEastRegionCluster));
     assertFalse(target.isWriterClusterDns(usIsobEastRegionClusterReadOnly));
@@ -299,6 +308,7 @@ public class RdsUtilsTests {
     assertFalse(target.isReaderClusterDns(usEastRegionCustomDomain));
     assertFalse(target.isReaderClusterDns(usEastRegionElbUrl));
     assertFalse(target.isReaderClusterDns(usEastRegionLimitlessDbShardGroup));
+    assertFalse(target.isReaderClusterDns(euRedshift));
 
     assertFalse(target.isReaderClusterDns(usIsobEastRegionCluster));
     assertTrue(target.isReaderClusterDns(usIsobEastRegionClusterReadOnly));
@@ -338,6 +348,7 @@ public class RdsUtilsTests {
     assertFalse(target.isLimitlessDbShardGroupDns(usEastRegionCustomDomain));
     assertFalse(target.isLimitlessDbShardGroupDns(usEastRegionElbUrl));
     assertTrue(target.isLimitlessDbShardGroupDns(usEastRegionLimitlessDbShardGroup));
+    assertFalse(target.isLimitlessDbShardGroupDns(euRedshift));
 
     assertFalse(target.isLimitlessDbShardGroupDns(usIsobEastRegionCluster));
     assertFalse(target.isLimitlessDbShardGroupDns(usIsobEastRegionClusterReadOnly));
@@ -412,6 +423,9 @@ public class RdsUtilsTests {
     assertEquals(chinaExpectedHostPattern, target.getRdsRegion(oldChinaRegionProxy));
     assertEquals(chinaExpectedHostPattern, target.getRdsRegion(oldChinaRegionCustomDomain));
     assertEquals(chinaExpectedHostPattern, target.getRdsRegion(oldChinaRegionLimitlessDbShardGroup));
+
+    final String euRedshiftExpectedHostPattern = "eusc-de-east-1";
+    assertEquals(euRedshiftExpectedHostPattern, target.getRdsRegion(euRedshift));
   }
 
   @Test


### PR DESCRIPTION
### Summary

- add support of the following domains: `eu`, `au`, `uk`
- add support of `rds-fips` subdomains

https://github.com/aws/aws-advanced-jdbc-wrapper/issues/1585

### Additional Reviewers

@karenc-bq 

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.