### PR TITLE
fix: wait timeout for custom endpoint info

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/customendpoint/CustomEndpointMonitorImpl.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/customendpoint/CustomEndpointMonitorImpl.java
@@ -218,9 +218,11 @@ public class CustomEndpointMonitorImpl extends AbstractMonitor implements Custom
 
   protected void sleep(long durationNano) throws InterruptedException {
     long endNano = System.nanoTime() + durationNano;
+    // Choose the minimum between 500ms and the durationNano passed in, in case durationNano is less than 500ms.
+    long waitDurationMs = Math.min(500, TimeUnit.NANOSECONDS.toMillis(durationNano));
     while (!this.refreshRequired.get() && System.nanoTime() < endNano && !this.stop.get()) {
       synchronized (this.refreshRequired) {
-        this.refreshRequired.wait(500);
+        this.refreshRequired.wait(waitDurationMs);
       }
     }
   }

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/customendpoint/CustomEndpointMonitorImplTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/customendpoint/CustomEndpointMonitorImplTest.java
@@ -48,13 +48,11 @@ import software.amazon.jdbc.HostSpec;
 import software.amazon.jdbc.HostSpecBuilder;
 import software.amazon.jdbc.hostavailability.HostAvailabilityStrategy;
 import software.amazon.jdbc.hostavailability.SimpleHostAvailabilityStrategy;
-import software.amazon.jdbc.util.monitoring.MonitorService;
 import software.amazon.jdbc.util.storage.StorageService;
 import software.amazon.jdbc.util.telemetry.TelemetryCounter;
 import software.amazon.jdbc.util.telemetry.TelemetryFactory;
 
 public class CustomEndpointMonitorImplTest {
-  @Mock private MonitorService mockMonitorService;
   @Mock private StorageService mockStorageService;
   @Mock private BiFunction<HostSpec, Region, RdsClient> mockRdsClientFunc;
   @Mock private RdsClient mockRdsClient;


### PR DESCRIPTION
### Description

- Before these changes, the custom endpoint plugin would throw an exception after 5 minutes when the custom endpoint info expired. This occurred because the main thread waits 5 seconds for the info to be replaced, but the monitor thread waits ~30s between iterations
- This PR fixes this problem by introducing a synchronizing lock object and changing the monitor thread's wait to use `Object.wait` instead of `TimeUnit.sleep`. Now, when a request for custom endpoint comes in but the info does not exist or is expired, the monitoring thread will be woken up via `Object.notifyAll`

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.