### PR TITLE
fix: retry network and readonly errors

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/AuroraInitialConnectionStrategyPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/AuroraInitialConnectionStrategyPlugin.java
@@ -223,6 +223,13 @@ public class AuroraInitialConnectionStrategyPlugin extends AbstractConnectionPlu
           if (writerCandidate != null) {
             this.pluginService.setAvailability(writerCandidate.asAliases(), HostAvailability.NOT_AVAILABLE);
           }
+
+          if (this.pluginService.isNetworkException(ex, this.pluginService.getTargetDriverDialect())
+              || this.pluginService.isReadOnlyConnectionException(ex, this.pluginService.getTargetDriverDialect())) {
+            // Retry connection.
+            continue;
+          }
+
           throw ex;
         }
       } catch (Throwable ex) {


### PR DESCRIPTION
### Summary

Fixes #1628 

### Description

Aurora Initial Connection Strategy Plugin was incorrectly propagating network errors instead of retrying. This PR catches for those type of exceptions as well as incorrect read only connections and retry connection attemptions.

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.