### PR TITLE
[DO NOT MERGE] Dual implementation of LazyCleaner one for Java 11 and up and one for Java 8

### DIFF
--- a/wrapper/build.gradle.kts
+++ b/wrapper/build.gradle.kts
@@ -163,7 +163,7 @@ fun CopySpec.addMultiReleaseContents() {
 // Add java11 compiled classes to the main JAR
 tasks.jar {
     dependsOn(tasks.named(java11.compileJavaTaskName))
-    
+
     // Add multi-release content after bnd processing
     doLast {
         val java11Dir = java11.output.classesDirs.files.first()
@@ -175,7 +175,7 @@ tasks.jar {
             }
         }
     }
-    
+
     manifest {
         attributes["Multi-Release"] = "true"
     }

--- a/wrapper/src/main/java/software/amazon/jdbc/util/LazyCleaner.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/LazyCleaner.java
@@ -17,14 +17,33 @@
 package software.amazon.jdbc.util;
 
 public interface LazyCleaner {
-  
-  interface Cleanable {
-    void clean() throws Exception;
+
+  /**
+   * Cleanable interface for objects that can be manually cleaned.
+   *
+   * @param <T> the type of exception that can be thrown during cleanup
+   */
+  interface Cleanable<T extends Throwable> {
+    void clean() throws T;
   }
-  
-  interface CleaningAction {
-    void onClean(boolean leak) throws Exception;
+
+  /**
+   * CleaningAction interface for cleanup actions that are notified whether cleanup
+   * occurred due to a leak (automatic) or manual cleanup.
+   *
+   * @param <T> the type of exception that can be thrown during cleanup
+   */
+  interface CleaningAction<T extends Throwable> {
+    void onClean(boolean leak) throws T;
   }
-  
-  Cleanable register(Object obj, CleaningAction action);
+
+  /**
+   * Registers an object for cleanup when it becomes phantom reachable.
+   *
+   * @param obj the object to monitor for cleanup (should not be the same as action)
+   * @param action the action to perform when the object becomes unreachable
+   * @param <T> the type of exception that can be thrown during cleanup
+   * @return a Cleanable that can be used to manually trigger cleanup
+   */
+  <T extends Throwable> Cleanable<T> register(Object obj, CleaningAction<T> action);
 }

--- a/wrapper/src/test/java/software/amazon/jdbc/util/LazyCleanerImplTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/util/LazyCleanerImplTest.java
@@ -61,7 +61,11 @@ public class LazyCleanerImplTest {
 
     assertTrue(t.isThreadRunning(), "cleanup thread should be running, and it should wait for the leaks");
 
-    cleaners.get(1).clean();
+    try {
+      cleaners.get(1).clean();
+    } catch (Throwable e) {
+      // Expected for test
+    }
     list.set(0, null);
     System.gc();
     System.gc();
@@ -97,7 +101,11 @@ public class LazyCleanerImplTest {
 
     assertTrue(t.isThreadRunning(), "cleanup thread should be running when there are objects to monitor");
 
-    cleanable.clean();
+    try {
+      cleanable.clean();
+    } catch (Throwable e) {
+      // Expected for test
+    }
     assertTrue(cleaned.get(), "Object should be cleaned after manual clean");
 
     list.clear();


### PR DESCRIPTION
 Java 11 uses Cleaner from the JDK


### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.