### PR TITLE
perf: cache efm2 monitor key for better performance

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/efm2/HostMonitorService.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/efm2/HostMonitorService.java
@@ -30,10 +30,7 @@ public interface HostMonitorService {
   HostMonitorConnectionContext startMonitoring(
       Connection connectionToAbort,
       HostSpec hostSpec,
-      Properties properties,
-      int failureDetectionTimeMillis,
-      int failureDetectionIntervalMillis,
-      int failureDetectionCount) throws SQLException;
+      Properties properties) throws SQLException;
 
   /**
    * Stop monitoring for a connection represented by the given {@link HostMonitorConnectionContext}.

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/efm2/HostMonitoringConnectionPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/efm2/HostMonitoringConnectionPlugin.java
@@ -148,11 +148,6 @@ public class HostMonitoringConnectionPlugin extends AbstractConnectionPlugin
       return jdbcMethodFunc.call();
     }
 
-    final int failureDetectionTimeMillis = FAILURE_DETECTION_TIME.getInteger(this.properties);
-    final int failureDetectionIntervalMillis =
-        FAILURE_DETECTION_INTERVAL.getInteger(this.properties);
-    final int failureDetectionCount = FAILURE_DETECTION_COUNT.getInteger(this.properties);
-
     initMonitorService();
 
     T result;
@@ -167,14 +162,10 @@ public class HostMonitoringConnectionPlugin extends AbstractConnectionPlugin
       final HostSpec monitoringHostSpec = this.getMonitoringHostSpec();
 
       try {
-        monitorContext =
-            this.monitorService.startMonitoring(
-                this.pluginService.getCurrentConnection(), // abort this connection if needed
-                monitoringHostSpec,
-                this.properties,
-                failureDetectionTimeMillis,
-                failureDetectionIntervalMillis,
-                failureDetectionCount);
+        monitorContext = this.monitorService.startMonitoring(
+            this.pluginService.getCurrentConnection(), // abort this connection if needed
+            monitoringHostSpec,
+            this.properties);
       } catch (SQLException e) {
         throw WrapperUtils.wrapExceptionIfNeeded(exceptionClass, e);
       }


### PR DESCRIPTION
### Summary

Cache efm2 monitor key for better performance. Apply the same fix to 3.x 
https://github.com/aws/aws-advanced-jdbc-wrapper/pull/1640

### Additional Reviewers

@aaron-congo 

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.