### PR TITLE
fix: rw plugin - retain reader reference if it is currently in use

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/ReadWriteSplittingPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/ReadWriteSplittingPlugin.java
@@ -554,24 +554,24 @@ public class ReadWriteSplittingPlugin extends AbstractConnectionPlugin
     closeWriterConnectionIfIdle(this.writerConnection);
   }
 
-  void closeReaderConnectionIfIdle(CacheItem<Connection> readerConnection) {
-    if (readerConnection == null) {
+  void closeReaderConnectionIfIdle(CacheItem<Connection> readerCacheItem) {
+    if (readerCacheItem == null) {
       return;
     }
 
     final Connection currentConnection = this.pluginService.getCurrentConnection();
-    final Connection readerConnectionCache = readerConnection.get(true);
+    final Connection readerConnection = readerCacheItem.get(true);
 
     try {
-      if (isConnectionUsable(readerConnectionCache) && readerConnectionCache != currentConnection) {
-        readerConnectionCache.close();
+      if (isConnectionUsable(readerConnection) && readerConnection != currentConnection) {
+        // readerConnection is open but is not currently in use, so we close it.
+        readerConnection.close();
+        this.readerConnection = null;
+        this.readerHostSpec = null;
       }
     } catch (SQLException e) {
       // Do nothing.
     }
-
-    this.readerConnection = null;
-    this.readerHostSpec = null;
   }
 
   void closeWriterConnectionIfIdle(final Connection internalConnection) {


### PR DESCRIPTION
fixes a bug where the readerConnection and readerHostSpec variables in the RW plugin were set to null even when the current connection was the readerConnection

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.