### PR TITLE
fix: IAM related plugins unable to parse the correct region from global cluster endpoints

### DIFF
--- a/docs/using-the-jdbc-driver/GlobalDatabases.md
+++ b/docs/using-the-jdbc-driver/GlobalDatabases.md
@@ -128,4 +128,5 @@ For detailed compatibility information, see:
 
 - [Failover Plugin v2](./using-plugins/UsingTheFailover2Plugin.md)
 - [Aurora Initial Connection Strategy Plugin](./using-plugins/UsingTheAuroraInitialConnectionStrategyPlugin.md)
+- [IAM Authentication Plugin](./using-plugins/UsingTheIamAuthenticationPlugin.md)
 - [Database Dialects](./DatabaseDialects.md)

--- a/docs/using-the-jdbc-driver/using-plugins/UsingTheFederatedAuthPlugin.md
+++ b/docs/using-the-jdbc-driver/using-plugins/UsingTheFederatedAuthPlugin.md
@@ -17,7 +17,7 @@ In the case of AD FS, the user signs into the AD FS sign in page. This generates
   - [AWS Java SDK RDS v2.7.x](https://central.sonatype.com/artifact/software.amazon.awssdk/rds)
   - [AWS Java SDK STS v2.7.x](https://central.sonatype.com/artifact/software.amazon.awssdk/sts)
 - Note: The above dependencies may have transitive dependencies that are also required (ex. AWS Java SDK RDS requires [AWS Java SDK Core](https://central.sonatype.com/artifact/software.amazon.awssdk/aws-core/)). If you are not using a package manager such as Maven or Gradle, please refer to Maven Central to determine these transitive dependencies.
-- This plugin does not create or modify any ADFS or IAM resources, therefore all permissions and policies must be correctly configured before using this plugin.
+- This plugin does not create or modify any ADFS or IAM resources, therefore all permissions and policies must be correctly configured before using this plugin. If you plan on using [Amazon Aurora Global Databases](https://aws.amazon.com/rds/aurora/global-database/) with this plugin, please see the [Using Federated Authentication with Global Databases](#using-federated-authentication-with-global-databases) section as well.
 
 > [!NOTE]\
 > Since [AWS Java SDK RDS v2.x](https://central.sonatype.com/artifact/software.amazon.awssdk/rds) size is around 5.4Mb (22Mb including all RDS SDK dependencies), some users may experience difficulties using the plugin due to limited available disk size.
@@ -78,3 +78,28 @@ Note: AWS IAM database authentication is needed to use the Federated Authenticat
 
 ## Sample code
 [FederatedAuthPluginExample.java](../../../examples/AWSDriverExample/src/main/java/software/amazon/FederatedAuthPluginExample.java)
+
+## Using Federated Authentication with Global Databases
+
+When using Federated authentication with [Amazon Aurora Global Databases](https://aws.amazon.com/rds/aurora/global-database/), the IAM user or role requires the additional `rds:DescribeGlobalClusters` permission. This permission allows the driver to resolve the Global Database endpoint to the appropriate regional cluster for IAM token generation.
+
+Example IAM policy:
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "rds-db:connect",
+                "rds:DescribeGlobalClusters"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+
+```
+
+> [!NOTE]
+> [AWS Java SDK RDS v2.x](https://central.sonatype.com/artifact/software.amazon.awssdk/rds) is **required** when using this plugin with Global databases.

--- a/docs/using-the-jdbc-driver/using-plugins/UsingTheIamAuthenticationPlugin.md
+++ b/docs/using-the-jdbc-driver/using-plugins/UsingTheIamAuthenticationPlugin.md
@@ -13,7 +13,7 @@ AWS Identity and Access Management (IAM) grants users access control across all 
 > Note: AWS Java SDK RDS may have transitive dependencies that are also required (ex. [AWS Java SDK Core](https://central.sonatype.com/artifact/software.amazon.awssdk/aws-core/)). If you are not using a package manager such as Maven or Gradle, please refer to Maven Central to determine these transitive dependencies.
 >
 > Since [AWS Java SDK RDS v2.x](https://central.sonatype.com/artifact/software.amazon.awssdk/rds) size is around 5.4Mb (22Mb including all RDS SDK dependencies), some users may experience difficulties using the plugin due to limited available disk size.
-> In such cases, the [AWS Java SDK RDS v2.x](https://central.sonatype.com/artifact/software.amazon.awssdk/rds) dependency may be replaced with just two dependencies which have a smaller footprint (around 300Kb in total):
+> In such cases, the [AWS Java SDK RDS v2.x](https://central.sonatype.com/artifact/software.amazon.awssdk/rds) dependency may be replaced with just two dependencies which have a smaller footprint (around 300Kb in total)<sup>1</sup>:
 > - [software.amazon.awssdk:http-client-spi](https://central.sonatype.com/artifact/software.amazon.awssdk/http-client-spi)
 > - [software.amazon.awssdk:auth](https://central.sonatype.com/artifact/software.amazon.awssdk/auth)
 >
@@ -57,3 +57,31 @@ IAM database authentication use is limited to certain database engines. For more
 [AwsIamAuthenticationPostgresqlExample.java](../../../examples/AWSDriverExample/src/main/java/software/amazon/AwsIamAuthenticationPostgresqlExample.java)<br>
 [AwsIamAuthenticationMysqlExample.java](../../../examples/AWSDriverExample/src/main/java/software/amazon/AwsIamAuthenticationMysqlExample.java)<br>
 [AwsIamAuthenticationMariadbExample.java](../../../examples/AWSDriverExample/src/main/java/software/amazon/AwsIamAuthenticationMariadbExample.java)
+
+## Using IAM Authentication with Global Databases
+
+When using IAM authentication with [Amazon Aurora Global Databases](https://aws.amazon.com/rds/aurora/global-database/), the IAM user or role requires the additional `rds:DescribeGlobalClusters` permission. This permission allows the driver to resolve the Global Database endpoint to the appropriate regional cluster for IAM token generation.
+
+Example IAM policy:
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "rds-db:connect",
+                "rds:DescribeGlobalClusters"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+
+```
+
+> [!NOTE]
+> [AWS Java SDK RDS v2.x](https://central.sonatype.com/artifact/software.amazon.awssdk/rds) is **required** when using this plugin with Global databases.
+
+---
+<sup>1</sup> Note: The smaller dependencies cannot be used with Global databases, which require the full [AWS Java SDK RDS v2.x](https://central.sonatype.com/artifact/software.amazon.awssdk/rds) dependency.

--- a/docs/using-the-jdbc-driver/using-plugins/UsingTheOktaAuthPlugin.md
+++ b/docs/using-the-jdbc-driver/using-plugins/UsingTheOktaAuthPlugin.md
@@ -18,7 +18,7 @@ In the case of AD FS, the user signs into the AD FS sign in page. This generates
   - [jsoup](https://central.sonatype.com/artifact/org.jsoup/jsoup)
   - [Jackson Databind](https://central.sonatype.com/artifact/com.fasterxml.jackson.core/jackson-databind)
 - Note: The above dependencies may have transitive dependencies that are also required (ex. AWS Java SDK RDS requires [AWS Java SDK Core](https://central.sonatype.com/artifact/software.amazon.awssdk/aws-core/)). If you are not using a package manager such as Maven or Gradle, please refer to Maven Central to determine these transitive dependencies. 
-- This plugin does not create or modify any Okta or IAM resources. Okta must be federated into to your AWS IAM account before using this plugin. You can follow Okta's [integration guide](https://help.okta.com/en-us/content/topics/deploymentguides/aws/aws-deployment.htm).
+- This plugin does not create or modify any Okta or IAM resources. Okta must be federated into to your AWS IAM account before using this plugin. You can follow Okta's [integration guide](https://help.okta.com/en-us/content/topics/deploymentguides/aws/aws-deployment.htm). In addition, all permissions and policies must be correctly configured before using this plugin. If you plan on using [Amazon Aurora Global Databases](https://aws.amazon.com/rds/aurora/global-database/) with this plugin, please see the [Using Okta Authentication with Global Databases](#using-okta-authentication-with-global-databases) section as well.
 
 > [!NOTE]\
 > Since [AWS Java SDK RDS v2.x](https://central.sonatype.com/artifact/software.amazon.awssdk/rds) size is around 5.4Mb (22Mb including all RDS SDK dependencies), some users may experience difficulties using the plugin due to limited available disk size.
@@ -66,3 +66,28 @@ Verify plugin compatibility within your driver configuration using the [compatib
 
 ## Sample code
 [OktaAuthPluginExample.java](../../../examples/AWSDriverExample/src/main/java/software/amazon/OktaAuthPluginExample.java)
+
+## Using Okta Authentication with Global Databases
+
+When using Okta authentication with [Amazon Aurora Global Databases](https://aws.amazon.com/rds/aurora/global-database/), the IAM user or role requires the additional `rds:DescribeGlobalClusters` permission. This permission allows the driver to resolve the Global Database endpoint to the appropriate regional cluster for IAM token generation.
+
+Example IAM policy:
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "rds-db:connect",
+                "rds:DescribeGlobalClusters"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+
+```
+
+> [!NOTE]
+> [AWS Java SDK RDS v2.x](https://central.sonatype.com/artifact/software.amazon.awssdk/rds) is **required** when using this plugin with Global databases.

--- a/wrapper/src/main/java/software/amazon/jdbc/util/GDBRegionUtils.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/GDBRegionUtils.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.jdbc.util;
+
+import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.rds.RdsClient;
+import software.amazon.awssdk.services.rds.model.DescribeGlobalClustersRequest;
+import software.amazon.awssdk.services.rds.model.GlobalClusterMember;
+import software.amazon.jdbc.HostSpec;
+import software.amazon.jdbc.authentication.AwsCredentialsManager;
+
+public class GDBRegionUtils extends RegionUtils {
+
+  private static final Pattern GDB_CLUSTER_ARN_PATTERN =
+      Pattern.compile("^arn:aws:rds:(?<region>[^:\\n]*):[^:\\n]*:([^:/\\n]*[:/])?(.*)$");
+  private static final String REGION_GROUP = "region";
+
+  static {
+    try {
+      Class.forName("software.amazon.awssdk.services.rds.RdsClient");
+    } catch (ClassNotFoundException e) {
+      throw new RuntimeException(Messages.get("AuthenticationToken.rdsSdkNotInClasspath"), e);
+    }
+  }
+
+  @Override
+  public @Nullable Region getRegion(HostSpec hostSpec, Properties props, String propKey) {
+    final String clusterId = rdsUtils.getRdsClusterId(hostSpec.getHost());
+    final String writerClusterArn = findWriterClusterArn(hostSpec, props, clusterId);
+
+    if (StringUtils.isNullOrEmpty(writerClusterArn)) {
+      return null;
+    }
+
+    return getRegionFromClusterArn(writerClusterArn);
+  }
+
+  private String findWriterClusterArn(final HostSpec hostSpec, final Properties props,
+      final String globalClusterIdentifier) {
+    try (RdsClient rdsClient = RdsClient.builder()
+        .credentialsProvider(AwsCredentialsManager.getProvider(hostSpec, props))
+        .build()) {
+      final DescribeGlobalClustersRequest request = DescribeGlobalClustersRequest.builder()
+          .globalClusterIdentifier(globalClusterIdentifier)
+          .build();
+
+      return rdsClient.describeGlobalClusters(request)
+          .globalClusters()
+          .stream()
+          .flatMap(cluster -> cluster.globalClusterMembers().stream())
+          .filter(GlobalClusterMember::isWriter)
+          .map(GlobalClusterMember::dbClusterArn)
+          .findFirst()
+          .orElse(null);
+    }
+  }
+
+  private Region getRegionFromClusterArn(String clusterArn) {
+    Matcher matcher = GDB_CLUSTER_ARN_PATTERN.matcher(clusterArn);
+    return matcher.matches() ? Region.of(matcher.group(REGION_GROUP)) : null;
+  }
+}

--- a/wrapper/src/main/java/software/amazon/jdbc/util/IamAuthUtils.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/IamAuthUtils.java
@@ -20,7 +20,9 @@ import java.util.logging.Logger;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.jdbc.HostSpec;
+import software.amazon.jdbc.HostSpecBuilder;
 import software.amazon.jdbc.PluginService;
+import software.amazon.jdbc.hostavailability.SimpleHostAvailabilityStrategy;
 import software.amazon.jdbc.plugin.iam.IamTokenUtility;
 import software.amazon.jdbc.plugin.iam.LightRdsUtility;
 import software.amazon.jdbc.plugin.iam.RegularRdsUtility;
@@ -33,11 +35,11 @@ public class IamAuthUtils {
   private static final Logger LOGGER = Logger.getLogger(IamAuthUtils.class.getName());
   private static final String TELEMETRY_FETCH_TOKEN = "fetch authentication token";
 
-  public static String getIamHost(final String iamHost, final HostSpec hostSpec) {
+  public static HostSpec getIamHost(final String iamHost, final HostSpec hostSpec) {
     if (!StringUtils.isNullOrEmpty(iamHost)) {
-      return iamHost;
+      return new HostSpecBuilder(hostSpec.getHostAvailabilityStrategy()).copyFrom(hostSpec).host(iamHost).build();
     }
-    return hostSpec.getHost();
+    return hostSpec;
   }
 
   public static int getIamPort(final int iamDefaultPort, final HostSpec hostSpec, final int dialectDefaultPort) {

--- a/wrapper/src/main/java/software/amazon/jdbc/util/RdsUtils.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/RdsUtils.java
@@ -512,7 +512,7 @@ public class RdsUtils {
 
     try {
       return matcher.group(groupName);
-    } catch (IllegalStateException e) {
+    } catch (IllegalStateException | IllegalArgumentException e) {
       return null;
     }
   }

--- a/wrapper/src/main/java/software/amazon/jdbc/util/RegionUtils.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/RegionUtils.java
@@ -19,6 +19,7 @@ package software.amazon.jdbc.util;
 import java.util.Properties;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.jdbc.HostSpec;
 
 public class RegionUtils {
   protected static final RdsUtils rdsUtils = new RdsUtils();
@@ -37,6 +38,21 @@ public class RegionUtils {
   public Region getRegion(String host, Properties props, String propKey) {
     Region region = getRegion(props, propKey);
     return region != null ? region : getRegionFromHost(host);
+  }
+
+  /**
+   * Determines the AWS region from the given parameters. If the region is defined in the properties, that region will
+   * be used. Otherwise, attempts to determine the region from the passed in host.
+   *
+   * @param hostSpec    The hostSpec from which to extract the region if it is not defined in the properties.
+   * @param props   The connection properties for the connection being established.
+   * @param propKey The key name of the region property.
+   * @return The AWS region defined by the properties or extracted from the host, or null if the region was not
+   *     defined in the properties and could not be determined from the {@code host}.
+   */
+  @Nullable
+  public Region getRegion(HostSpec hostSpec, Properties props, String propKey) {
+    return getRegion(hostSpec.getHost(), props, propKey);
   }
 
   /**

--- a/wrapper/src/main/resources/aws_advanced_jdbc_wrapper_messages.properties
+++ b/wrapper/src/main/resources/aws_advanced_jdbc_wrapper_messages.properties
@@ -32,6 +32,7 @@ AuroraPgDialect.auroraUtils=auroraUtils: {0}
 AuthenticationToken.useCachedToken=Use cached authentication token = ''{0}''
 AuthenticationToken.generatedNewToken=Generated new authentication token = ''{0}''
 AuthenticationToken.javaSdkNotInClasspath=Required dependency 'AWS Java SDK RDS v2.x' is not on the classpath.
+AuthenticationToken.rdsSdkNotInClasspath=Required dependency 'AWS Java SDK RDS v2.x' is not on the classpath. Only the full RDS SDK is supported when using Global databases.
 
 RdsHostListProvider.clusterInstanceHostPatternNotSupportedForRDSProxy=An RDS Proxy url can''t be used as the 'clusterInstanceHostPattern' configuration setting.
 RdsHostListProvider.clusterInstanceHostPatternNotSupportedForRdsCustom=A custom RDS url can''t be used as the 'clusterInstanceHostPattern' configuration setting.


### PR DESCRIPTION
### Summary

Plugins utilizing IAM authentication tokens weren't supported for global clusters due to not being able to fetch the correct primary cluster region.
This change uses the RDS SDK to determine primary cluster, and generate IAM auth token for that region.

### Description

<!--- Details of what you changed -->

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.