### PR TITLE
Remove unnecessary isClosed flag

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/failover/FailoverConnectionPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/failover/FailoverConnectionPlugin.java
@@ -271,12 +271,12 @@ public class FailoverConnectionPlugin extends AbstractConnectionPlugin {
       return result;
     }
 
-    if (this.pluginService.getCurrentConnection().isClosed() && !allowedOnClosedConnection(methodName)) {
-      try {
+    try {
+      if (this.pluginService.getCurrentConnection().isClosed() && !allowedOnClosedConnection(methodName)) {
         invalidInvocationOnClosedConnection();
-      } catch (final SQLException ex) {
-        throw WrapperUtils.wrapExceptionIfNeeded(exceptionClass, ex);
       }
+    } catch (final SQLException ex) {
+      throw WrapperUtils.wrapExceptionIfNeeded(exceptionClass, ex);
     }
 
     T result = null;


### PR DESCRIPTION
### Summary

Remove unnecessary isClosed flag because it wasn't being set anywhere.

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.