### PR TITLE
fix: use assumed saml credentials to fetch region information when connecting to a GDB

### DIFF
--- a/examples/AWSDriverExample/src/main/java/software/amazon/OktaAuthPluginExample.java
+++ b/examples/AWSDriverExample/src/main/java/software/amazon/OktaAuthPluginExample.java
@@ -23,31 +23,41 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Properties;
 import software.amazon.jdbc.PropertyDefinition;
+import software.amazon.jdbc.authentication.AwsCredentialsManager;
 import software.amazon.jdbc.plugin.federatedauth.OktaAuthPlugin;
 
 public class OktaAuthPluginExample {
 
-  private static final String CONNECTION_STRING = "jdbc:aws-wrapper:postgresql://database.cluster-xyz.us-east-1.rds.amazonaws.com:5432/postgres";
+  private static final String CONNECTION_STRING = "jdbc:aws-wrapper:postgresql://gdb-test-pg.global-gvcb7gbn2rvs.global.rds.amazonaws.com:5432/postgres";
 
   public static void main(String[] args) throws SQLException {
     // Set the Okta Authentication Connection Plugin parameters and the JDBC Wrapper parameters.
     final Properties properties = new Properties();
 
-    // Enable the Okta Authentication Connection Plugin.
+    // Enable the AWS Federated Authentication Connection Plugin.
     properties.setProperty(PropertyDefinition.PLUGINS.name, "okta");
-    properties.setProperty(OktaAuthPlugin.IDP_ENDPOINT.name, "123456789.okta.com");
-    properties.setProperty(OktaAuthPlugin.APP_ID.name, "abc12345678");
-    properties.setProperty(OktaAuthPlugin.IAM_ROLE_ARN.name, "arn:aws:iam::123456789:role/OktaAccessRole");
-    properties.setProperty(OktaAuthPlugin.IAM_IDP_ARN.name, "arn:aws:iam::123456789:saml-provider/OktaSAMLIdp");
-    properties.setProperty(OktaAuthPlugin.IAM_REGION.name, "us-east-1");
-    properties.setProperty(OktaAuthPlugin.IDP_USERNAME.name, "user@example.com");
-    properties.setProperty(OktaAuthPlugin.IDP_PASSWORD.name, "abcd");
-    properties.setProperty(OktaAuthPlugin.DB_USER.name, "iamDbUser");
+
+    properties.setProperty(OktaAuthPlugin.IDP_ENDPOINT.name, "integrator-3100847.okta.com");
+    properties.setProperty(OktaAuthPlugin.APP_ID.name, "exkzvgq3f3wLAjcfx697");
+    properties.setProperty(OktaAuthPlugin.IDP_USERNAME.name, "karen.chen@improving.com");
+    properties.setProperty(OktaAuthPlugin.IDP_PASSWORD.name, "!FQJ5@Gs");
+
+    properties.setProperty(OktaAuthPlugin.IAM_ROLE_ARN.name, "arn:aws:iam::346558184882:role/OktaAccessRole");
+    properties.setProperty(OktaAuthPlugin.IAM_IDP_ARN.name, "arn:aws:iam::346558184882:saml-provider/OktaSAMLIdp");
+
+    properties.setProperty(OktaAuthPlugin.IAM_REGION.name, "us-east-2");
+    properties.setProperty(OktaAuthPlugin.DB_USER.name, "jane_doe");
+
+    properties.setProperty("wrapperDialect", "global-aurora-pg");
+    properties.setProperty("failoverMode", "writer");
+    properties.setProperty("clusterId", "test-global");
+    properties.setProperty("globalClusterInstanceHostPatterns",
+        "?.cwpu2jclcwdc.us-east-2.rds.amazonaws.com,?.crksgsebp0nr.us-west-2.rds.amazonaws.com");
 
     // Try and make a connection:
     try (final Connection conn = DriverManager.getConnection(CONNECTION_STRING, properties);
-         final Statement statement = conn.createStatement();
-         final ResultSet rs = statement.executeQuery("SELECT 1")) {
+        final Statement statement = conn.createStatement();
+        final ResultSet rs = statement.executeQuery("SELECT * FROM aurora_db_instance_identifier()")) {
       System.out.println(Util.getResult(rs));
     }
   }

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/federatedauth/SamlCredentialsProviderFactory.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/federatedauth/SamlCredentialsProviderFactory.java
@@ -26,6 +26,7 @@ import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.StsClientBuilder;
 import software.amazon.awssdk.services.sts.auth.StsAssumeRoleWithSamlCredentialsProvider;
 import software.amazon.awssdk.services.sts.model.AssumeRoleWithSamlRequest;
 
@@ -44,10 +45,9 @@ public abstract class SamlCredentialsProviderFactory implements CredentialsProvi
         .principalArn(IAM_IDP_ARN.getString(props))
         .build();
 
-    final StsClient stsClient = StsClient.builder()
-        .credentialsProvider(AnonymousCredentialsProvider.create())
-        .region(region)
-        .build();
+    final StsClientBuilder builder = StsClient.builder()
+        .credentialsProvider(AnonymousCredentialsProvider.create());
+    final StsClient stsClient = region == null ? builder.build() : builder.region(region).build();
 
     return StsAssumeRoleWithSamlCredentialsProvider.builder()
         .refreshRequest(assumeRoleWithSamlRequest)


### PR DESCRIPTION
### Summary

When connecting to a GDB endpoint, Okta/ADFS plugin were using local credentials to look up region information instead of the SAML credentials

### Description

When connecting to a GDB endpoint with the auth plugins, the wrapper couldn't extract the primary writer region information from the endpoint itself. Therefore the wrapper needs to use the RDS SDK to look up the primary region.

The original implementation creates a RDS client using the AWSCredentialsManager for Okta and ADFS plugin, this approach looks up credentials from the default credentials provider chain, instead of using the ADFS/Okta' saml credentials.

This PR fixes the region look up logic to use the correct credentials.
This does slow down the connection process as we can't take advantage of our token cache earlier.

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.