### PR TITLE
fix: use assumed saml credentials to fetch region information when connecting to GDB endpoints

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/federatedauth/FederatedAuthPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/federatedauth/FederatedAuthPlugin.java
@@ -31,7 +31,6 @@ import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.jdbc.AwsWrapperProperty;
 import software.amazon.jdbc.HostSpec;
-import software.amazon.jdbc.HostSpecBuilder;
 import software.amazon.jdbc.JdbcCallable;
 import software.amazon.jdbc.PluginService;
 import software.amazon.jdbc.PropertyDefinition;
@@ -188,7 +187,16 @@ public class FederatedAuthPlugin extends AbstractConnectionPlugin {
         this.pluginService.getDialect().getDefaultPort());
 
     final RdsUrlType type = rdsUtils.identifyRdsType(host.getHost());
-    this.regionUtils = type == RdsUrlType.RDS_GLOBAL_WRITER_CLUSTER ? new GDBRegionUtils() : new RegionUtils();
+
+    AwsCredentialsProvider credentialsProvider = null;
+    if (RdsUrlType.RDS_GLOBAL_WRITER_CLUSTER == type) {
+      // Assume a role early so we can use this credential to fetch region information.
+      credentialsProvider = this.credentialsProviderFactory.getAwsCredentialsProvider(hostSpec.getHost(), null, props);
+      this.regionUtils = new GDBRegionUtils(credentialsProvider);
+    } else {
+      this.regionUtils = new RegionUtils();
+    }
+
     final Region region = this.regionUtils.getRegion(host, props, IAM_REGION.name);
     if (region == null) {
       throw new SQLException(
@@ -212,7 +220,7 @@ public class FederatedAuthPlugin extends AbstractConnectionPlugin {
               new Object[] {tokenInfo.getToken()}));
       PropertyDefinition.PASSWORD.set(props, tokenInfo.getToken());
     } else {
-      updateAuthenticationToken(hostSpec, props, region, cacheKey, host.getHost());
+      updateAuthenticationToken(hostSpec, props, region, cacheKey, host.getHost(), credentialsProvider);
     }
 
     PropertyDefinition.USER.set(props, DB_USER.getString(props));
@@ -224,7 +232,7 @@ public class FederatedAuthPlugin extends AbstractConnectionPlugin {
           || !this.pluginService.isLoginException(exception, this.pluginService.getTargetDriverDialect())) {
         throw exception;
       }
-      updateAuthenticationToken(hostSpec, props, region, cacheKey, host.getHost());
+      updateAuthenticationToken(hostSpec, props, region, cacheKey, host.getHost(), credentialsProvider);
       return connectFunc.call();
     } catch (final Exception exception) {
       LOGGER.warning(
@@ -240,7 +248,8 @@ public class FederatedAuthPlugin extends AbstractConnectionPlugin {
       final Properties props,
       final Region region,
       final String cacheKey,
-      final String host)
+      final String host,
+      AwsCredentialsProvider credentialsProvider)
       throws SQLException {
     final int tokenExpirationSec = IAM_TOKEN_EXPIRATION.getInteger(props);
     final Instant tokenExpiry = Instant.now().plus(tokenExpirationSec, ChronoUnit.SECONDS);
@@ -248,8 +257,12 @@ public class FederatedAuthPlugin extends AbstractConnectionPlugin {
         StringUtils.isNullOrEmpty(IAM_DEFAULT_PORT.getString(props)) ? 0 : IAM_DEFAULT_PORT.getInteger(props),
         hostSpec,
         this.pluginService.getDialect().getDefaultPort());
-    final AwsCredentialsProvider credentialsProvider =
-        this.credentialsProviderFactory.getAwsCredentialsProvider(hostSpec.getHost(), region, props);
+
+    if (credentialsProvider == null) {
+      credentialsProvider =
+          this.credentialsProviderFactory.getAwsCredentialsProvider(hostSpec.getHost(), region, props);
+    }
+
     if (this.fetchTokenCounter != null) {
       this.fetchTokenCounter.inc();
     }
@@ -263,7 +276,7 @@ public class FederatedAuthPlugin extends AbstractConnectionPlugin {
         credentialsProvider);
     LOGGER.finest(
         () -> Messages.get(
-            "AuthenticationToken.useCachedToken",
+            "AuthenticationToken.generatedNewToken",
             new Object[] {token}));
     PropertyDefinition.PASSWORD.set(props, token);
     FederatedAuthCacheHolder.tokenCache.put(

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/federatedauth/OktaAuthPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/federatedauth/OktaAuthPlugin.java
@@ -32,6 +32,7 @@ import software.amazon.jdbc.HostSpec;
 import software.amazon.jdbc.JdbcCallable;
 import software.amazon.jdbc.PluginService;
 import software.amazon.jdbc.PropertyDefinition;
+import software.amazon.jdbc.authentication.AwsCredentialsManager;
 import software.amazon.jdbc.plugin.AbstractConnectionPlugin;
 import software.amazon.jdbc.plugin.TokenInfo;
 import software.amazon.jdbc.plugin.iam.IamTokenUtility;
@@ -159,12 +160,20 @@ public class OktaAuthPlugin extends AbstractConnectionPlugin {
         this.pluginService.getDialect().getDefaultPort());
 
     final RdsUrlType type = rdsUtils.identifyRdsType(host.getHost());
-    this.regionUtils = type == RdsUrlType.RDS_GLOBAL_WRITER_CLUSTER ? new GDBRegionUtils() : new RegionUtils();
+
+    AwsCredentialsProvider credentialsProvider = null;
+    if (RdsUrlType.RDS_GLOBAL_WRITER_CLUSTER == type) {
+      credentialsProvider =
+          this.credentialsProviderFactory.getAwsCredentialsProvider(hostSpec.getHost(), null, props);
+      this.regionUtils = new GDBRegionUtils(credentialsProvider);
+    } else {
+      this.regionUtils = new RegionUtils();
+    }
 
     final Region region = this.regionUtils.getRegion(host, props, IAM_REGION.name);
     if (region == null) {
       throw new SQLException(
-          Messages.get("OktaAuthPlugin.unableToDetermineRegion", new Object[]{ IAM_REGION.name }));
+          Messages.get("OktaAuthPlugin.unableToDetermineRegion", new Object[] {IAM_REGION.name}));
     }
 
     final String cacheKey = IamAuthUtils.getCacheKey(
@@ -184,7 +193,7 @@ public class OktaAuthPlugin extends AbstractConnectionPlugin {
               new Object[] {tokenInfo.getToken()}));
       PropertyDefinition.PASSWORD.set(props, tokenInfo.getToken());
     } else {
-      updateAuthenticationToken(hostSpec, props, region, cacheKey, host.getHost());
+      updateAuthenticationToken(hostSpec, props, region, cacheKey, host.getHost(), credentialsProvider);
     }
 
     PropertyDefinition.USER.set(props, DB_USER.getString(props));
@@ -196,7 +205,7 @@ public class OktaAuthPlugin extends AbstractConnectionPlugin {
           || !this.pluginService.isLoginException(exception, this.pluginService.getTargetDriverDialect())) {
         throw exception;
       }
-      updateAuthenticationToken(hostSpec, props, region, cacheKey, host.getHost());
+      updateAuthenticationToken(hostSpec, props, region, cacheKey, host.getHost(), credentialsProvider);
       return connectFunc.call();
     } catch (final Exception exception) {
       LOGGER.warning(
@@ -212,7 +221,8 @@ public class OktaAuthPlugin extends AbstractConnectionPlugin {
       final Properties props,
       final Region region,
       final String cacheKey,
-      final String host)
+      final String host,
+      AwsCredentialsProvider credentialsProvider)
       throws SQLException {
     final int tokenExpirationSec = IAM_TOKEN_EXPIRATION.getInteger(props);
     final Instant tokenExpiry = Instant.now().plus(tokenExpirationSec, ChronoUnit.SECONDS);
@@ -220,8 +230,12 @@ public class OktaAuthPlugin extends AbstractConnectionPlugin {
         StringUtils.isNullOrEmpty(IAM_DEFAULT_PORT.getString(props)) ? 0 : IAM_DEFAULT_PORT.getInteger(props),
         hostSpec,
         this.pluginService.getDialect().getDefaultPort());
-    final AwsCredentialsProvider credentialsProvider =
-        this.credentialsProviderFactory.getAwsCredentialsProvider(hostSpec.getHost(), region, props);
+    if (credentialsProvider == null) {
+      // Assume a role early so we can use this credential to fetch region information.
+      credentialsProvider = this.credentialsProviderFactory.getAwsCredentialsProvider(hostSpec.getHost(), region,
+          props);
+    }
+
     if (this.fetchTokenCounter != null) {
       this.fetchTokenCounter.inc();
     }
@@ -235,7 +249,7 @@ public class OktaAuthPlugin extends AbstractConnectionPlugin {
         credentialsProvider);
     LOGGER.finest(
         () -> Messages.get(
-            "AuthenticationToken.useCachedToken",
+            "AuthenticationToken.generatedNewToken",
             new Object[] {token}));
     PropertyDefinition.PASSWORD.set(props, token);
     OktaAuthCacheHolder.tokenCache.put(

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/federatedauth/SamlCredentialsProviderFactory.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/federatedauth/SamlCredentialsProviderFactory.java
@@ -26,6 +26,7 @@ import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.StsClientBuilder;
 import software.amazon.awssdk.services.sts.auth.StsAssumeRoleWithSamlCredentialsProvider;
 import software.amazon.awssdk.services.sts.model.AssumeRoleWithSamlRequest;
 
@@ -44,10 +45,9 @@ public abstract class SamlCredentialsProviderFactory implements CredentialsProvi
         .principalArn(IAM_IDP_ARN.getString(props))
         .build();
 
-    final StsClient stsClient = StsClient.builder()
-        .credentialsProvider(AnonymousCredentialsProvider.create())
-        .region(region)
-        .build();
+    final StsClientBuilder builder = StsClient.builder()
+        .credentialsProvider(AnonymousCredentialsProvider.create());
+    final StsClient stsClient = region == null ? builder.build() : builder.region(region).build();
 
     return StsAssumeRoleWithSamlCredentialsProvider.builder()
         .refreshRequest(assumeRoleWithSamlRequest)

--- a/wrapper/src/main/java/software/amazon/jdbc/util/GDBRegionUtils.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/GDBRegionUtils.java
@@ -53,6 +53,11 @@ public class GDBRegionUtils extends RegionUtils {
 
   @Override
   public @Nullable Region getRegion(HostSpec hostSpec, Properties props, String propKey) {
+    Region region = this.getRegion(props, propKey);
+    if (region != null) {
+      return region;
+    }
+
     final String clusterId = rdsUtils.getRdsClusterId(hostSpec.getHost());
     final String writerClusterArn = findWriterClusterArn(hostSpec, props, clusterId);
 


### PR DESCRIPTION
### Summary

When connecting to a GDB endpoint, Okta/ADFS plugin were using local credentials to look up region information instead of the SAML credentials

### Description

When connecting to a GDB endpoint with the auth plugins, the wrapper couldn't extract the primary writer region information from the endpoint itself. Therefore the wrapper needs to use the RDS SDK to look up the primary region.

The original implementation creates a RDS client using the AWSCredentialsManager for Okta and ADFS plugin, this approach looks up credentials from the default credentials provider chain, instead of using the ADFS/Okta' saml credentials.

This PR fixes the region look up logic to use the correct credentials.
This does slow down the connection process as we can't take advantage of our token cache earlier.

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.