### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: tcort/github-action-markdown-link-check@v1
         with:
           use-quiet-mode: 'yes'
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Clone repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 50
       - name: 'Get changed files'
@@ -55,7 +55,7 @@ jobs:
         run: echo "ONLY_DOCS=false" >> $GITHUB_OUTPUT
       - name: 'Set up JDK 8'
         if: ${{steps.changed-files.outputs.ONLY_DOCS && steps.changed-files.outputs.ONLY_DOCS == 'false'}}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'corretto'
           java-version: 8
@@ -69,7 +69,7 @@ jobs:
         run: ./gradlew jacocoTestReport
       - name: 'Archive test results'
         if: ${{steps.changed-files.outputs.ONLY_DOCS && steps.changed-files.outputs.ONLY_DOCS == 'false'}}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: 'junit-report'
           path: ./wrapper/build/reports/tests/test/

--- a/.github/workflows/maven_release.yml
+++ b/.github/workflows/maven_release.yml
@@ -14,11 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Clone Repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 50
       - name: 'Set up JDK 8'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'corretto'
           java-version: 8

--- a/.github/workflows/maven_snapshot.yml
+++ b/.github/workflows/maven_snapshot.yml
@@ -16,11 +16,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Clone Repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 50
       - name: 'Set up JDK 8'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'corretto'
           java-version: 8

--- a/.github/workflows/mysql_advanced_performance.yml
+++ b/.github/workflows/mysql_advanced_performance.yml
@@ -14,11 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Clone repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 50
       - name: 'Set up JDK 8'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'corretto'
           java-version: 8
@@ -44,7 +44,7 @@ jobs:
           PG_VERSION: "default"
       - name: 'Archive Performance Results'
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: 'performance-results'
           path: ./wrapper/build/reports/tests/

--- a/.github/workflows/mysql_performance.yml
+++ b/.github/workflows/mysql_performance.yml
@@ -14,11 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Clone repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 50
       - name: 'Set up JDK 8'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'corretto'
           java-version: 8
@@ -44,7 +44,7 @@ jobs:
           PG_VERSION: "default"
       - name: 'Archive Performance Results'
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: 'performance-results'
           path: ./wrapper/build/reports/tests/

--- a/.github/workflows/pg_advanced_performance.yml
+++ b/.github/workflows/pg_advanced_performance.yml
@@ -14,11 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Clone repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 50
       - name: 'Set up JDK 8'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'corretto'
           java-version: 8
@@ -44,7 +44,7 @@ jobs:
           PG_VERSION: "default"
       - name: 'Archive Performance Results'
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: 'performance-results'
           path: ./wrapper/build/reports/tests/

--- a/.github/workflows/pg_performance.yml
+++ b/.github/workflows/pg_performance.yml
@@ -14,11 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Clone repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 50
       - name: 'Set up JDK 8'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'corretto'
           java-version: 8
@@ -44,7 +44,7 @@ jobs:
           PG_VERSION: "default"
       - name: 'Archive Performance Results'
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: 'performance-results'
           path: ./wrapper/build/reports/tests/

--- a/.github/workflows/release_draft.yml
+++ b/.github/workflows/release_draft.yml
@@ -19,11 +19,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Clone Repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 50
       - name: 'Set up JDK 8'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'corretto'
           java-version: 8

--- a/.github/workflows/run-autoscaling-tests.yml
+++ b/.github/workflows/run-autoscaling-tests.yml
@@ -17,11 +17,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Clone repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 50
       - name: 'Set up JDK 8'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'corretto'
           java-version: 8
@@ -50,14 +50,14 @@ jobs:
           ./gradlew --no-parallel --no-daemon maskJunitHtmlReport
       - name: 'Archive junit results'
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: junit-report
           path: ./wrapper/build/test-results
           retention-days: 5
       - name: 'Archive autoscaling report'
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: autoscaling-report
           path: ./wrapper/build/report

--- a/.github/workflows/run-bg-integration-tests-latest.yml
+++ b/.github/workflows/run-bg-integration-tests-latest.yml
@@ -21,11 +21,11 @@ jobs:
         testTask: [ "mysql-aurora-mariadb-driver", "mysql-aurora-mysql-driver", "mysql-rds-instance-mariadb-driver", "mysql-rds-instance-mysql-driver", "pg-aurora", "pg-rds-instance" ]
     steps:
       - name: 'Clone repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 50
       - name: 'Set up JDK 8'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'corretto'
           java-version: 8
@@ -54,14 +54,14 @@ jobs:
           ./gradlew --no-parallel --no-daemon maskJunitHtmlReport
       - name: Archive junit results for ${{ matrix.testTask }}
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: junit-report-latest-${{ matrix.testTask }}
           path: ./wrapper/build/test-results
           retention-days: 5
       - name: Archive html summary report for ${{ matrix.testTask }}
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: html-summary-report-latest-${{ matrix.testTask }}
           path: ./wrapper/build/report

--- a/.github/workflows/run-hibernate-orm-tests.yml
+++ b/.github/workflows/run-hibernate-orm-tests.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Clone repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 50
       - name: 'Get changed files'
@@ -34,7 +34,7 @@ jobs:
         if: ${{steps.changed-files-specific.outputs.doc_only_changed == 'false' && steps.changed-files-specific.outputs.doc_only_modified == 'false'}}
         run: echo "ONLY_DOCS=false" >> $GITHUB_OUTPUT
       - name: 'Set up JDK 8'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'corretto'
           java-version: 8
@@ -47,21 +47,21 @@ jobs:
           ./gradlew --no-parallel --no-daemon maskJunitHtmlReport
       - name: 'Archive junit results'
         if: ${{steps.changed-files.outputs.ONLY_DOCS && steps.changed-files.outputs.ONLY_DOCS == 'false' && !cancelled()}}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: junit-report
           path: ./wrapper/build/test-results
           retention-days: 5
       - name: 'Archive html summary report'
         if: ${{steps.changed-files.outputs.ONLY_DOCS && steps.changed-files.outputs.ONLY_DOCS == 'false' && !cancelled()}}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: html-summary-report
           path: ./wrapper/build/report
           retention-days: 5
       - name: 'Archive container reports'
         if: ${{steps.changed-files.outputs.ONLY_DOCS && steps.changed-files.outputs.ONLY_DOCS == 'false' && !cancelled()}}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: container-reports
           path: ./wrapper/build/test-results/*.tar.gz

--- a/.github/workflows/run-integration-tests-codebuild.yml
+++ b/.github/workflows/run-integration-tests-codebuild.yml
@@ -21,11 +21,11 @@ jobs:
     environment: ${{ matrix.environment }}_integ
     steps:
       - name: 'Clone repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
       - name: 'Set up JDK 8'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'corretto'
           java-version: 8
@@ -52,14 +52,14 @@ jobs:
           PG_VERSION: "latest"
       - name: 'Archive junit results ${{ matrix.engine_version }}'
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: junit-report-${{ matrix.engine_version }}
           path: ./wrapper/build/test-results
           retention-days: 5
       - name: 'Archive html summary report ${{ matrix.engine_version }}'
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: html-summary-report-${{ matrix.engine_version }}
           path: ./wrapper/build/report

--- a/.github/workflows/run-integration-tests-default.yml
+++ b/.github/workflows/run-integration-tests-default.yml
@@ -21,11 +21,11 @@ jobs:
         dbEngine: [ "mysql-aurora", "mysql-multi-az", "pg-aurora", "pg-multi-az" ]
     steps:
       - name: 'Clone repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 50
       - name: 'Set up JDK 8'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'corretto'
           java-version: 8
@@ -54,14 +54,14 @@ jobs:
           ./gradlew --no-parallel --no-daemon maskJunitHtmlReport
       - name: Archive junit results for ${{ matrix.dbEngine }}
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: junit-report-default-${{ matrix.dbEngine }}
           path: ./wrapper/build/test-results
           retention-days: 5
       - name: Archive html summary report for ${{ matrix.dbEngine }}
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: html-summary-report-default-${{ matrix.dbEngine }}
           path: ./wrapper/build/report

--- a/.github/workflows/run-integration-tests-latest.yml
+++ b/.github/workflows/run-integration-tests-latest.yml
@@ -21,11 +21,11 @@ jobs:
         dbEngine: [ "mysql-aurora", "mysql-multi-az", "pg-aurora", "pg-multi-az" ]
     steps:
       - name: 'Clone repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 50
       - name: 'Set up JDK 8'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'corretto'
           java-version: 8
@@ -54,14 +54,14 @@ jobs:
           ./gradlew --no-parallel --no-daemon maskJunitHtmlReport
       - name: Archive junit results for ${{ matrix.dbEngine }}
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: junit-report-latest-${{ matrix.dbEngine }}
           path: ./wrapper/build/test-results
           retention-days: 5
       - name: Archive html summary report for ${{ matrix.dbEngine }}
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: html-summary-report-latest-${{ matrix.dbEngine }}
           path: ./wrapper/build/report

--- a/.github/workflows/run-metrics-latest.yml
+++ b/.github/workflows/run-metrics-latest.yml
@@ -19,11 +19,11 @@ jobs:
         dbEngine: [ "mysql-aurora", "mysql-multi-az", "pg-aurora", "pg-multi-az" ]
     steps:
       - name: 'Clone repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 50
       - name: 'Set up JDK 8'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'corretto'
           java-version: 8
@@ -52,21 +52,21 @@ jobs:
           ./gradlew --no-parallel --no-daemon maskJunitHtmlReport
       - name: Archive junit results for ${{ matrix.dbEngine }}
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: junit-report-latest-${{ matrix.dbEngine }}
           path: ./wrapper/build/test-results
           retention-days: 5
       - name: Archive html summary report for ${{ matrix.dbEngine }}
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: html-summary-report-latest-${{ matrix.dbEngine }}
           path: ./wrapper/build/report
           retention-days: 5
       - name: Archive metrics for ${{ matrix.dbEngine }}
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: metrics-latest-${{ matrix.dbEngine }}
           path: ./wrapper/build/reports/tests

--- a/.github/workflows/run-standard-integration-tests.yml
+++ b/.github/workflows/run-standard-integration-tests.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Clone repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 50
       - name: 'Get changed files'
@@ -41,7 +41,7 @@ jobs:
         run: echo "ONLY_DOCS=false" >> $GITHUB_OUTPUT
       - name: 'Set up JDK 8'
         if: ${{steps.changed-files.outputs.ONLY_DOCS && steps.changed-files.outputs.ONLY_DOCS == 'false'}}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'corretto'
           java-version: 8
@@ -54,14 +54,14 @@ jobs:
           ./gradlew --no-parallel --no-daemon maskJunitHtmlReport
       - name: 'Archive junit results'
         if: ${{steps.changed-files.outputs.ONLY_DOCS && steps.changed-files.outputs.ONLY_DOCS == 'false' && !cancelled()}}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: junit-report
           path: ./wrapper/build/test-results
           retention-days: 5
       - name: 'Archive html summary report'
         if: ${{steps.changed-files.outputs.ONLY_DOCS && steps.changed-files.outputs.ONLY_DOCS == 'false' && !cancelled()}}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: html-summary-report
           path: ./wrapper/build/report


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions to ensure compatibility with Node 24, as Node 20 will reach end-of-life in April 2026.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/checkout` | [`v4`](https://github.com/actions/checkout/releases/tag/v4) | [`v6`](https://github.com/actions/checkout/releases/tag/v6) | [Release](https://github.com/actions/checkout/releases/tag/v6) | main.yml, maven_release.yml, maven_snapshot.yml, mysql_advanced_performance.yml, mysql_performance.yml, pg_advanced_performance.yml, pg_performance.yml, release_draft.yml, run-autoscaling-tests.yml, run-bg-integration-tests-latest.yml, run-hibernate-orm-tests.yml, run-integration-tests-codebuild.yml, run-integration-tests-default.yml, run-integration-tests-latest.yml, run-metrics-latest.yml, run-standard-integration-tests.yml |
| `actions/setup-java` | [`v4`](https://github.com/actions/setup-java/releases/tag/v4) | [`v5`](https://github.com/actions/setup-java/releases/tag/v5) | [Release](https://github.com/actions/setup-java/releases/tag/v5) | main.yml, maven_release.yml, maven_snapshot.yml, mysql_advanced_performance.yml, mysql_performance.yml, pg_advanced_performance.yml, pg_performance.yml, release_draft.yml, run-autoscaling-tests.yml, run-bg-integration-tests-latest.yml, run-hibernate-orm-tests.yml, run-integration-tests-codebuild.yml, run-integration-tests-default.yml, run-integration-tests-latest.yml, run-metrics-latest.yml, run-standard-integration-tests.yml |
| `actions/upload-artifact` | [`v4`](https://github.com/actions/upload-artifact/releases/tag/v4) | [`v6`](https://github.com/actions/upload-artifact/releases/tag/v6) | [Release](https://github.com/actions/upload-artifact/releases/tag/v6) | main.yml, mysql_advanced_performance.yml, mysql_performance.yml, pg_advanced_performance.yml, pg_performance.yml, run-autoscaling-tests.yml, run-bg-integration-tests-latest.yml, run-hibernate-orm-tests.yml, run-integration-tests-codebuild.yml, run-integration-tests-default.yml, run-integration-tests-latest.yml, run-metrics-latest.yml, run-standard-integration-tests.yml |

## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will begin using Node 24 by default starting March 4th, 2026.

### Why this matters

- **Node 20 EOL**: April 2026
- **Node 24 default**: March 4th, 2026
- **Action**: Update to latest action versions that support Node 24

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
