### PR TITLE
chore: use a context pool to reduce memory allocation overhead in efm plugins

### DIFF
--- a/docs/using-the-jdbc-driver/using-plugins/UsingTheHostMonitoringPlugin.md
+++ b/docs/using-the-jdbc-driver/using-plugins/UsingTheHostMonitoringPlugin.md
@@ -98,3 +98,25 @@ The `efm2` plugin is designed to address [some of the issues](https://github.com
 - Reviewed and simplified monitoring logic
 
 Verify plugin compatibility within your driver configuration using the [compatibility guide](../Compatibility.md).
+
+## Context Pool Configuration
+
+The Host Monitoring plugins use an internal context pool to manage monitoring connection contexts. The pool behavior can be configured using the following JVM system properties:
+
+| System Property                      | Type    | Required | Description                                                                                                                                                                                                     | Default Value |
+|--------------------------------------|---------|:--------:|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
+| `efm.contextPool.maxIdleCount`       | Integer |    No    | Maximum number of idle connection contexts to keep in the pool. Must be at least 1.                                                                                                                             | `30`          |
+| `efm.contextPool.lazyInitialization` | Boolean |    No    | When `true`, idle contexts are created on-demand as needed, unitil `maxIdleCount` is reached. When `false`, the pool is pre-populated with idle contexts (determined by the `maxIdleCount` setting) at startup. | `false`       |
+
+These properties can be set via JVM arguments:
+
+```bash
+java -Defm.contextPool.maxIdleCount=50 -Defm.contextPool.lazyInitialization=true -jar your-application.jar
+```
+
+Or programmatically before establishing connections:
+
+```java
+System.setProperty("efm.contextPool.maxIdleCount", "50");
+System.setProperty("efm.contextPool.lazyInitialization", "true");
+```

--- a/docs/using-the-jdbc-driver/using-plugins/UsingTheHostMonitoringPlugin.md
+++ b/docs/using-the-jdbc-driver/using-plugins/UsingTheHostMonitoringPlugin.md
@@ -105,18 +105,20 @@ The Host Monitoring plugins use an internal context pool to manage monitoring co
 
 | System Property                      | Type    | Required | Description                                                                                                                                                                                                     | Default Value |
 |--------------------------------------|---------|:--------:|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
-| `efm.contextPool.maxIdleCount`       | Integer |    No    | Maximum number of idle connection contexts to keep in the pool. Must be at least 1.                                                                                                                             | `30`          |
-| `efm.contextPool.lazyInitialization` | Boolean |    No    | When `true`, idle contexts are created on-demand as needed, unitil `maxIdleCount` is reached. When `false`, the pool is pre-populated with idle contexts (determined by the `maxIdleCount` setting) at startup. | `false`       |
+| `efm.contextPool.enabled`            | Boolean |    No    | When `true`, contexts are pooled and reused to reduce allocation overhead. When `false`, a new context instance is created on each acquire call.                                                                | `true`        |
+| `efm.contextPool.maxIdleCount`       | Integer |    No    | Maximum number of idle connection contexts to keep in the pool. Must be at least 1. Only applies when pooling is enabled.                                                                                       | `30`          |
+| `efm.contextPool.lazyInitialization` | Boolean |    No    | When `true`, idle contexts are created on-demand as needed, until `maxIdleCount` is reached. When `false`, the pool is pre-populated with idle contexts (determined by the `maxIdleCount` setting) at startup. Only applies when pooling is enabled. | `false`       |
 
 These properties can be set via JVM arguments:
 
 ```bash
-java -Defm.contextPool.maxIdleCount=50 -Defm.contextPool.lazyInitialization=true -jar your-application.jar
+java -Defm.contextPool.enabled=true -Defm.contextPool.maxIdleCount=50 -Defm.contextPool.lazyInitialization=true -jar your-application.jar
 ```
 
 Or programmatically before establishing connections:
 
 ```java
+System.setProperty("efm.contextPool.enabled", "true");
 System.setProperty("efm.contextPool.maxIdleCount", "50");
 System.setProperty("efm.contextPool.lazyInitialization", "true");
 ```

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/base/ConnectionContext.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/base/ConnectionContext.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.jdbc.plugin.efm.base;
+
+import java.sql.Connection;
+
+/**
+ * Interface for connection context that manages connection state and health monitoring.
+ */
+public interface ConnectionContext {
+
+  /**
+   * Check if the database node is unhealthy.
+   *
+   * @return true if the node is unhealthy, false otherwise
+   */
+  boolean isNodeUnhealthy();
+
+  /**
+   * Set the health status of the database node.
+   *
+   * @param nodeUnhealthy true if the node is unhealthy, false otherwise
+   */
+  void setNodeUnhealthy(final boolean nodeUnhealthy);
+
+  /**
+   * Check if the connection should be aborted due to node failure.
+   *
+   * @return true if the connection should be aborted, false otherwise
+   */
+  boolean shouldAbort();
+
+  /**
+   * Mark this context as inactive and release any connection references.
+   */
+  void setInactive();
+
+  /**
+   * Get the connection associated with this context.
+   *
+   * @return the connection, or null if not available
+   */
+  Connection getConnection();
+
+  /**
+   * Check if this context is currently active.
+   *
+   * @return true if active, false otherwise
+   */
+  boolean isActive();
+
+}

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/base/ConnectionContextService.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/base/ConnectionContextService.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.jdbc.plugin.efm.base;
+
+import java.util.function.Consumer;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * Service for managing a pool of reusable connection contexts to reduce memory allocation overhead.
+ * This service provides efficient context lifecycle management through pooling, minimizing the cost
+ * of repeated allocations during monitoring operations.
+ */
+public interface ConnectionContextService {
+
+  /**
+   * Acquire a connection context from the pool. If the pool is empty, a new context is created.
+   *
+   * @param <T> the type of connection context
+   * @param contextClass the class type of the connection context to acquire
+   * @return a connection context ready for use
+   */
+  <T extends ConnectionContext> T acquire(@NonNull Class<T> contextClass);
+
+  /**
+   * Acquire a connection context from the pool with optional initialization. If the pool is empty,
+   * a new context is created. The initializer is invoked on the context before returning it.
+   *
+   * @param <T> the type of connection context
+   * @param contextClass the class type of the connection context to acquire
+   * @param initializer optional consumer to initialize the context before use; may be null
+   * @return a connection context ready for use
+   */
+  <T extends ConnectionContext> T acquire(@NonNull Class<T> contextClass, @Nullable Consumer<T> initializer);
+
+  /**
+   * Release a connection context back to the pool for reuse. The context is reset and made
+   * available for subsequent acquire operations.
+   *
+   * @param context the context to release
+   * @return true if the context was successfully released, false otherwise
+   */
+  boolean release(ConnectionContext context);
+}

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/base/ConnectionContextService.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/base/ConnectionContextService.java
@@ -21,14 +21,29 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
- * Service for managing a pool of reusable connection contexts to reduce memory allocation overhead.
- * This service provides efficient context lifecycle management through pooling, minimizing the cost
- * of repeated allocations during monitoring operations.
+ * Service for managing connection contexts used during host monitoring.
+ *
+ * <p>Implementing classes may choose to use pooling to reduce memory allocation overhead,
+ * or may create new context instances on each acquire call (non-pooled). The choice of
+ * implementation affects memory usage and allocation patterns:
+ *
+ * <ul>
+ *   <li><b>Pooled implementations</b> reuse context objects to minimize garbage collection
+ *       pressure and allocation overhead. Released contexts are returned to the pool for
+ *       subsequent reuse.</li>
+ *   <li><b>Non-pooled implementations</b> create a new context instance on each acquire call.
+ *       The release operation may simply mark the context as inactive without retaining it.</li>
+ * </ul>
+ *
+ * <p>The Host Monitoring Plugins use a pooled connection context service by default.
+ *
+ * @see PoolConnectionContextServiceImpl
  */
 public interface ConnectionContextService {
 
   /**
-   * Acquire a connection context from the pool. If the pool is empty, a new context is created.
+   * Acquire a connection context. Depending on the implementation, this may return a context
+   * from a pool or create a new instance.
    *
    * @param <T> the type of connection context
    * @param contextClass the class type of the connection context to acquire
@@ -37,8 +52,9 @@ public interface ConnectionContextService {
   <T extends ConnectionContext> T acquire(@NonNull Class<T> contextClass);
 
   /**
-   * Acquire a connection context from the pool with optional initialization. If the pool is empty,
-   * a new context is created. The initializer is invoked on the context before returning it.
+   * Acquire a connection context with optional initialization. Depending on the implementation,
+   * this may return a context from a pool or create a new instance. The initializer is invoked
+   * on the context before returning it.
    *
    * @param <T> the type of connection context
    * @param contextClass the class type of the connection context to acquire
@@ -48,8 +64,9 @@ public interface ConnectionContextService {
   <T extends ConnectionContext> T acquire(@NonNull Class<T> contextClass, @Nullable Consumer<T> initializer);
 
   /**
-   * Release a connection context back to the pool for reuse. The context is reset and made
-   * available for subsequent acquire operations.
+   * Release a connection context. For pooled implementations, the context is reset and made
+   * available for subsequent acquire operations. For non-pooled implementations, the context
+   * may simply be marked as inactive.
    *
    * @param context the context to release
    * @return true if the context was successfully released, false otherwise

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/base/ConnectionContextServiceFactory.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/base/ConnectionContextServiceFactory.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.jdbc.plugin.efm.base;
+
+/**
+ * Factory for creating {@link ConnectionContextService} instances based on system configuration.
+ *
+ * <p>The factory reads the system property {@value #POOLING_ENABLED_PROPERTY} to determine
+ * which implementation to create:
+ * <ul>
+ *   <li>{@code true} (default): Creates a {@link PoolConnectionContextServiceImpl} that pools
+ *       and reuses context objects</li>
+ *   <li>{@code false}: Creates a {@link SimpleConnectionContextServiceImpl} that creates new
+ *       context instances on each acquire call</li>
+ * </ul>
+ */
+public final class ConnectionContextServiceFactory {
+
+  public static final String POOLING_ENABLED_PROPERTY = "efm.contextPool.enabled";
+  private static final boolean DEFAULT_POOLING_ENABLED = true;
+
+  private ConnectionContextServiceFactory() { }
+
+  public static ConnectionContextService getInstance() {
+    final boolean poolingEnabled = Boolean.parseBoolean(
+        System.getProperty(POOLING_ENABLED_PROPERTY, String.valueOf(DEFAULT_POOLING_ENABLED)));
+
+    if (poolingEnabled) {
+      return new PoolConnectionContextServiceImpl();
+    }
+    return new SimpleConnectionContextServiceImpl();
+  }
+}

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/base/ConnectionContextServiceImpl.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/base/ConnectionContextServiceImpl.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.jdbc.plugin.efm.base;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import java.util.logging.Logger;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import software.amazon.jdbc.plugin.efm.v1.HostMonitorConnectionContextV1;
+import software.amazon.jdbc.plugin.efm.v2.HostMonitorConnectionContextV2;
+import software.amazon.jdbc.util.Messages;
+
+public class ConnectionContextServiceImpl implements ConnectionContextService {
+
+  private static final Logger LOGGER = Logger.getLogger(ConnectionContextServiceImpl.class.getName());
+
+  protected static final Map<Class<? extends ConnectionContext>, Supplier<ConnectionContext>> defaultSuppliers;
+  protected static final int DEFAULT_MAX_IDLE_COUNT = 30;
+  protected static final boolean DEFAULT_LAZY_INITIALIZATION = true;
+  protected static final String MAX_IDLE_COUNT_PROPERTY = "efm.contextPool.maxIdleCount";
+  protected static final String LAZY_INIT_PROPERTY = "efm.contextPool.lazyInitialization";
+  protected static final Map<Class<? extends ConnectionContext>, ContextPool> contextPoolMap =
+      new ConcurrentHashMap<>();
+  protected final int maxIdleCount;
+  protected final boolean lazyInitialization;
+
+  static {
+    Map<Class<? extends ConnectionContext>, Supplier<ConnectionContext>> suppliers = new HashMap<>();
+    suppliers.put(HostMonitorConnectionContextV1.class, HostMonitorConnectionContextV1::new);
+    suppliers.put(HostMonitorConnectionContextV2.class, HostMonitorConnectionContextV2::new);
+    defaultSuppliers = Collections.unmodifiableMap(suppliers);
+  }
+
+  public ConnectionContextServiceImpl() {
+    maxIdleCount = Integer.parseInt(
+        System.getProperty(MAX_IDLE_COUNT_PROPERTY,
+            String.valueOf(DEFAULT_MAX_IDLE_COUNT)));
+    lazyInitialization = Boolean.parseBoolean(
+        System.getProperty(LAZY_INIT_PROPERTY,
+            String.valueOf(DEFAULT_LAZY_INITIALIZATION)));
+
+    if (maxIdleCount < 1) {
+      final String errMsg = Messages.get(
+          "ConnectionContextServiceImpl.invalidMaxIdleCount",
+          new Object[] {maxIdleCount, DEFAULT_MAX_IDLE_COUNT});
+      LOGGER.warning(errMsg);
+      throw new IllegalArgumentException(errMsg);
+    }
+  }
+
+  @Override
+  public <T extends ConnectionContext> T acquire(@NotNull Class<T> contextClass) {
+    return this.acquire(contextClass, null);
+  }
+
+  @Override
+  public <T extends ConnectionContext> T acquire(
+      @NotNull Class<T> contextClass,
+      @Nullable Consumer<T> initializer) {
+    final Supplier<ConnectionContext> supplier = defaultSuppliers.get(contextClass);
+    final ContextPool contextPool = contextPoolMap.computeIfAbsent(
+        contextClass,
+        ctxClass -> new ContextPoolImpl(maxIdleCount, lazyInitialization, supplier));
+
+    final T context = (T) contextPool.acquire();
+    if (initializer != null) {
+      initializer.accept(context);
+    }
+    return context;
+  }
+
+  @Override
+  public boolean release(ConnectionContext context) {
+    if (context == null) {
+      return false;
+    }
+    final ContextPool contextPool = contextPoolMap.get(context.getClass());
+    if (contextPool != null) {
+      return contextPool.release(context);
+    }
+    return false;
+  }
+
+  public static void clear() {
+    contextPoolMap.values().forEach(ContextPool::clearPool);
+    contextPoolMap.clear();
+  }
+}

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/base/ContextPool.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/base/ContextPool.java
@@ -16,14 +16,35 @@
 
 package software.amazon.jdbc.plugin.efm.base;
 
-import software.amazon.jdbc.util.events.EventSubscriber;
-import software.amazon.jdbc.util.monitoring.Monitor;
-
 /**
- * Interface for monitors. This class uses background threads to monitor servers with one or more
- * connections for more efficient failure detection during method execution.
+ * Pool for managing reusable connection context objects.
  */
-public interface HostMonitor extends AutoCloseable, Monitor, Runnable, EventSubscriber {
+public interface ContextPool {
 
-  void startMonitoring(ConnectionContext context);
+  /**
+   * Acquire a connection context from the pool.
+   *
+   * @return a connection context
+   */
+  ConnectionContext acquire();
+
+  /**
+   * Release a connection context back to the pool.
+   *
+   * @param context the context to release
+   * @return true if successfully released, false otherwise
+   */
+  boolean release(ConnectionContext context);
+
+  /**
+   * Get the current size of the pool.
+   *
+   * @return the number of contexts in the pool
+   */
+  int size();
+
+  /**
+   * Clear all contexts from the pool.
+   */
+  void clearPool();
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/base/ContextPoolImpl.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/base/ContextPoolImpl.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.jdbc.plugin.efm.base;
+
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Supplier;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import software.amazon.jdbc.util.telemetry.NullTelemetryFactory;
+import software.amazon.jdbc.util.telemetry.TelemetryFactory;
+import software.amazon.jdbc.util.telemetry.TelemetryGauge;
+
+public class ContextPoolImpl implements ContextPool {
+
+  private static final TelemetryFactory NULL_TELEMETRY_FACTORY = new NullTelemetryFactory();
+
+  private final Queue<ConnectionContext> contextQueue = new ConcurrentLinkedDeque<>();
+  private final Supplier<ConnectionContext> contextSupplier;
+  private final int maxIdleCount;
+  private final boolean lazyInitialization;
+  private final ReentrantLock lock = new ReentrantLock();
+  private volatile boolean initialized = false;
+  private final TelemetryGauge poolSizeGauge;
+
+  public ContextPoolImpl(int maxIdleCount, Supplier<ConnectionContext> contextSupplier) {
+    this(maxIdleCount, false, contextSupplier, NULL_TELEMETRY_FACTORY);
+  }
+
+  public ContextPoolImpl(int maxIdleCount, boolean lazyInitialization, Supplier<ConnectionContext> contextSupplier) {
+    this(maxIdleCount, lazyInitialization, contextSupplier, NULL_TELEMETRY_FACTORY);
+  }
+
+  public ContextPoolImpl(
+      int maxIdleCount,
+      boolean lazyInitialization,
+      Supplier<ConnectionContext> contextSupplier,
+      TelemetryFactory telemetryFactory) {
+    this.contextSupplier = contextSupplier;
+    this.maxIdleCount = maxIdleCount;
+    this.lazyInitialization = lazyInitialization;
+    this.poolSizeGauge = telemetryFactory.createGauge("efm.contextPool.size", () -> (long) contextQueue.size());
+  }
+
+  private void initializePool(final int contextCount) {
+    if (!initialized) {
+      lock.lock();
+      try {
+        if (!initialized) {
+          // Initialize with an extra context to be used right away
+          int i = 0;
+          while (i++ < contextCount && contextQueue.size() < maxIdleCount) {
+            contextQueue.add(contextSupplier.get());
+          }
+          initialized = contextQueue.size() >= maxIdleCount;
+        }
+      } finally {
+        lock.unlock();
+      }
+    }
+  }
+
+  @Override
+  public ConnectionContext acquire() {
+    if (!lazyInitialization) {
+      // Initialize all contexts right away.
+      initializePool(maxIdleCount);
+    }
+
+    ConnectionContext context = contextQueue.poll();
+
+    if (context == null) {
+      context = contextSupplier.get();
+    }
+    
+    this.modifyPoolSize();
+
+    return context;
+  }
+
+  private void modifyPoolSize() {
+    lock.lock();
+    try {
+      if (contextQueue.size() < maxIdleCount) {
+        // Expand pool using lazy initialization.
+        // Add at most two idle contexts every acquire call until maxIdleCount has been reached.
+        initializePool(2);
+      } else if (contextQueue.size() > maxIdleCount) {
+        // Shrink pool if over capacity.
+        ConnectionContext extra = contextQueue.poll();
+        if (extra != null) {
+          extra.setInactive();
+        }
+      }
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  @Override
+  public boolean release(final ConnectionContext context) {
+    if (context == null) {
+      return false;
+    }
+
+    context.setInactive();
+
+    lock.lock();
+    try {
+      if (contextQueue.size() < maxIdleCount) {
+        // Only return to the pool if pool still has capacity.
+        contextQueue.add(context);
+        return true;
+      }
+    } finally {
+      lock.unlock();
+    }
+
+    return false;
+  }
+
+  @Override
+  public int size() {
+    return contextQueue.size();
+  }
+
+  @Override
+  public void clearPool() {
+    lock.lock();
+    try {
+      ConnectionContext context;
+      while ((context = contextQueue.poll()) != null) {
+        context.setInactive();
+      }
+      contextQueue.clear();
+    } finally {
+      lock.unlock();
+      this.initialized = false;
+    }
+  }
+}

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/base/ContextPoolImpl.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/base/ContextPoolImpl.java
@@ -117,8 +117,6 @@ public class ContextPoolImpl implements ContextPool {
       return false;
     }
 
-    context.setInactive();
-
     lock.lock();
     try {
       if (contextQueue.size() < maxIdleCount) {

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/base/HostMonitorConnectionContext.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/base/HostMonitorConnectionContext.java
@@ -22,22 +22,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-public abstract class HostMonitorConnectionContext {
+public abstract class HostMonitorConnectionContext implements ConnectionContext {
 
   protected final AtomicReference<WeakReference<Connection>> connectionToAbortRef = new AtomicReference<>(null);
   protected final AtomicBoolean nodeUnhealthy = new AtomicBoolean(false);
-
-  public HostMonitorConnectionContext() {
-  }
-
-  /**
-   * Constructor.
-   *
-   * @param connectionToAbort A reference to the connection associated with this context that will be aborted.
-   */
-  public HostMonitorConnectionContext(final Connection connectionToAbort) {
-    this.connectionToAbortRef.set(new WeakReference<>(connectionToAbort));
-  }
 
   public boolean isNodeUnhealthy() {
     return this.nodeUnhealthy.get();

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/base/HostMonitorService.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/base/HostMonitorService.java
@@ -19,9 +19,7 @@ package software.amazon.jdbc.plugin.efm.base;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Properties;
-import java.util.Set;
 import software.amazon.jdbc.HostSpec;
-import software.amazon.jdbc.cleanup.CanReleaseResources;
 
 /**
  * Interface for monitor services. This class implements ways to start and stop monitoring servers
@@ -29,7 +27,7 @@ import software.amazon.jdbc.cleanup.CanReleaseResources;
  */
 public interface HostMonitorService {
 
-  HostMonitorConnectionContext startMonitoring(
+  ConnectionContext startMonitoring(
       Connection connectionToAbort,
       HostSpec hostSpec,
       Properties properties) throws SQLException;
@@ -40,5 +38,5 @@ public interface HostMonitorService {
    *
    * @param context The {@link HostMonitorConnectionContext} representing a connection.
    */
-  void stopMonitoring(HostMonitorConnectionContext context);
+  void stopMonitoring(ConnectionContext context);
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/base/HostMonitoringConnectionBasePlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/base/HostMonitoringConnectionBasePlugin.java
@@ -39,7 +39,6 @@ import software.amazon.jdbc.PropertyDefinition;
 import software.amazon.jdbc.cleanup.CanReleaseResources;
 import software.amazon.jdbc.hostavailability.HostAvailability;
 import software.amazon.jdbc.plugin.AbstractConnectionPlugin;
-import software.amazon.jdbc.plugin.efm.v2.HostMonitorV2Impl;
 import software.amazon.jdbc.util.FullServicesContainer;
 import software.amazon.jdbc.util.Messages;
 import software.amazon.jdbc.util.Pair;
@@ -101,7 +100,7 @@ public abstract class HostMonitoringConnectionBasePlugin extends AbstractConnect
   /**
    * Initialize the node monitoring plugin.
    *
-   * @param serviceContainer The service container for the services required by this class.
+   * @param servicesContainer The service container for the services required by this class.
    * @param properties        The property set used to initialize the active connection.
    * @param monitorServiceSupplier A supplier for creating a {@link HostMonitorService} instance.
    * @param rdsHelper        The RDS helper class to identify RDS instances.
@@ -123,7 +122,8 @@ public abstract class HostMonitoringConnectionBasePlugin extends AbstractConnect
       methods.addAll(this.pluginService.getTargetDriverDialect().getNetworkBoundMethodNames(this.properties));
     }
     this.subscribedMethods = Collections.unmodifiableSet(methods);
-    servicesContainer.setConnectionContextService(new ConnectionContextServiceImpl());
+
+    servicesContainer.setConnectionContextService(ConnectionContextServiceFactory.getInstance());
   }
 
   @Override

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/base/HostMonitoringConnectionBasePlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/base/HostMonitoringConnectionBasePlugin.java
@@ -107,11 +107,11 @@ public abstract class HostMonitoringConnectionBasePlugin extends AbstractConnect
    * @param rdsHelper        The RDS helper class to identify RDS instances.
    */
   protected HostMonitoringConnectionBasePlugin(
-      final @NonNull FullServicesContainer serviceContainer,
+      final @NonNull FullServicesContainer servicesContainer,
       final @NonNull Properties properties,
       final @NonNull Supplier<HostMonitorService> monitorServiceSupplier,
       final RdsUtils rdsHelper) {
-    this.pluginService = serviceContainer.getPluginService();
+    this.pluginService = servicesContainer.getPluginService();
     this.properties = properties;
     this.monitorServiceSupplier = monitorServiceSupplier;
     this.rdsHelper = rdsHelper;
@@ -123,6 +123,7 @@ public abstract class HostMonitoringConnectionBasePlugin extends AbstractConnect
       methods.addAll(this.pluginService.getTargetDriverDialect().getNetworkBoundMethodNames(this.properties));
     }
     this.subscribedMethods = Collections.unmodifiableSet(methods);
+    servicesContainer.setConnectionContextService(new ConnectionContextServiceImpl());
   }
 
   @Override
@@ -131,7 +132,8 @@ public abstract class HostMonitoringConnectionBasePlugin extends AbstractConnect
   }
 
   /**
-   * Executes the given SQL function with {@link HostMonitorV2Impl} if connection monitoring is enabled.
+   * Executes the given SQL function with {@link software.amazon.jdbc.plugin.efm.v2.HostMonitorV2Impl}
+   * if connection monitoring is enabled.
    * Otherwise, executes the SQL function directly.
    */
   @Override
@@ -151,7 +153,7 @@ public abstract class HostMonitoringConnectionBasePlugin extends AbstractConnect
     initMonitorService();
 
     T result;
-    HostMonitorConnectionContext monitorContext = null;
+    ConnectionContext monitorContext = null;
 
     final HostSpec monitoringHostSpec = this.getMonitoringHostSpec();
     try {

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/base/PoolConnectionContextServiceImpl.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/base/PoolConnectionContextServiceImpl.java
@@ -29,12 +29,12 @@ import software.amazon.jdbc.plugin.efm.v1.HostMonitorConnectionContextV1;
 import software.amazon.jdbc.plugin.efm.v2.HostMonitorConnectionContextV2;
 import software.amazon.jdbc.util.Messages;
 
-public class ConnectionContextServiceImpl implements ConnectionContextService {
+public class PoolConnectionContextServiceImpl implements ConnectionContextService {
 
-  private static final Logger LOGGER = Logger.getLogger(ConnectionContextServiceImpl.class.getName());
+  private static final Logger LOGGER = Logger.getLogger(PoolConnectionContextServiceImpl.class.getName());
 
   protected static final Map<Class<? extends ConnectionContext>, Supplier<ConnectionContext>> defaultSuppliers;
-  protected static final int DEFAULT_MAX_IDLE_COUNT = 30;
+  protected static final int DEFAULT_MAX_IDLE_COUNT = 5;
   protected static final boolean DEFAULT_LAZY_INITIALIZATION = true;
   protected static final String MAX_IDLE_COUNT_PROPERTY = "efm.contextPool.maxIdleCount";
   protected static final String LAZY_INIT_PROPERTY = "efm.contextPool.lazyInitialization";
@@ -50,7 +50,7 @@ public class ConnectionContextServiceImpl implements ConnectionContextService {
     defaultSuppliers = Collections.unmodifiableMap(suppliers);
   }
 
-  public ConnectionContextServiceImpl() {
+  public PoolConnectionContextServiceImpl() {
     maxIdleCount = Integer.parseInt(
         System.getProperty(MAX_IDLE_COUNT_PROPERTY,
             String.valueOf(DEFAULT_MAX_IDLE_COUNT)));
@@ -77,11 +77,16 @@ public class ConnectionContextServiceImpl implements ConnectionContextService {
       @NotNull Class<T> contextClass,
       @Nullable Consumer<T> initializer) {
     final Supplier<ConnectionContext> supplier = defaultSuppliers.get(contextClass);
+    if (supplier == null) {
+      throw new IllegalArgumentException(
+          Messages.get("ConnectionContextService.noSupplierRegistered",
+              new Object[] {contextClass.getName()}));
+    }
     final ContextPool contextPool = contextPoolMap.computeIfAbsent(
         contextClass,
         ctxClass -> new ContextPoolImpl(maxIdleCount, lazyInitialization, supplier));
 
-    final T context = (T) contextPool.acquire();
+    final T context = contextClass.cast(contextPool.acquire());
     if (initializer != null) {
       initializer.accept(context);
     }
@@ -95,6 +100,7 @@ public class ConnectionContextServiceImpl implements ConnectionContextService {
     }
     final ContextPool contextPool = contextPoolMap.get(context.getClass());
     if (contextPool != null) {
+      context.setInactive();
       return contextPool.release(context);
     }
     return false;

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/base/SimpleConnectionContextServiceImpl.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/base/SimpleConnectionContextServiceImpl.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.jdbc.plugin.efm.base;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import software.amazon.jdbc.plugin.efm.v1.HostMonitorConnectionContextV1;
+import software.amazon.jdbc.plugin.efm.v2.HostMonitorConnectionContextV2;
+import software.amazon.jdbc.util.Messages;
+
+/**
+ * A non-pooled implementation of {@link ConnectionContextService} that creates a new context
+ * instance on each acquire call.
+ */
+public class SimpleConnectionContextServiceImpl implements ConnectionContextService {
+
+  protected static final Map<Class<? extends ConnectionContext>, Supplier<ConnectionContext>> defaultSuppliers;
+
+  static {
+    Map<Class<? extends ConnectionContext>, Supplier<ConnectionContext>> suppliers = new HashMap<>();
+    suppliers.put(HostMonitorConnectionContextV1.class, HostMonitorConnectionContextV1::new);
+    suppliers.put(HostMonitorConnectionContextV2.class, HostMonitorConnectionContextV2::new);
+    defaultSuppliers = Collections.unmodifiableMap(suppliers);
+  }
+
+  @Override
+  public <T extends ConnectionContext> T acquire(@NonNull Class<T> contextClass) {
+    return this.acquire(contextClass, null);
+  }
+
+  @Override
+  public <T extends ConnectionContext> T acquire(
+      @NonNull Class<T> contextClass,
+      @Nullable Consumer<T> initializer) {
+    final Supplier<ConnectionContext> supplier = defaultSuppliers.get(contextClass);
+    if (supplier == null) {
+      throw new IllegalArgumentException(
+          Messages.get("ConnectionContextService.noSupplierRegistered",
+              new Object[] {contextClass.getName()}));
+    }
+
+    final T context = contextClass.cast(supplier.get());
+    if (initializer != null) {
+      initializer.accept(context);
+    }
+    return context;
+  }
+
+  @Override
+  public boolean release(ConnectionContext context) {
+    if (context == null) {
+      return false;
+    }
+    context.setInactive();
+    return true;
+  }
+}

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/v1/HostMonitorConnectionContextV1.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/v1/HostMonitorConnectionContextV1.java
@@ -52,38 +52,7 @@ public class HostMonitorConnectionContextV1 extends HostMonitorConnectionContext
 
   private final ResourceLock lock = new ResourceLock();
 
-  public HostMonitorConnectionContextV1() {
-  }
-
-  public HostMonitorConnectionContextV1(Connection connectionToAbort) {
-    super(connectionToAbort);
-  }
-
-  /**
-   * Constructor.
-   *
-   * @param connectionToAbort              A reference to the connection associated with this context that will
-   *                                       be aborted in case of server failure.
-   * @param failureDetectionTimeMillis     Grace period after which node monitoring starts.
-   * @param failureDetectionIntervalMillis Interval between each failed connection check.
-   * @param failureDetectionCount          Number of failed connection checks before considering database
-   *                                       node as unhealthy.
-   * @param abortedConnectionsCounter Aborted connection telemetry counter.
-   */
-  public HostMonitorConnectionContextV1(
-      final Connection connectionToAbort,
-      final long failureDetectionTimeMillis,
-      final long failureDetectionIntervalMillis,
-      final long failureDetectionCount,
-      TelemetryCounter abortedConnectionsCounter) {
-    super(connectionToAbort);
-    this.failureDetectionTimeMillis = failureDetectionTimeMillis;
-    this.failureDetectionIntervalMillis = failureDetectionIntervalMillis;
-    this.failureDetectionCount = failureDetectionCount;
-    this.abortedConnectionsCounter = abortedConnectionsCounter;
-  }
-
-  public void initContext(final Connection connectionToAbort,
+  public void init(final Connection connectionToAbort,
       final long failureDetectionTimeMillis,
       final long failureDetectionIntervalMillis,
       final long failureDetectionCount,
@@ -144,6 +113,7 @@ public class HostMonitorConnectionContextV1 extends HostMonitorConnectionContext
 
   public void setInactive() {
     this.activeContext = false;
+    this.connectionToAbortRef.set(null);
   }
 
   public void abortConnection() {

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/v1/HostMonitorConnectionContextV1.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/v1/HostMonitorConnectionContextV1.java
@@ -59,10 +59,13 @@ public class HostMonitorConnectionContextV1 extends HostMonitorConnectionContext
       TelemetryCounter abortedConnectionsCounter) {
     this.connectionToAbortRef.set(new WeakReference<>(connectionToAbort));
     this.nodeUnhealthy.set(false);
+    this.activeContext = true;
     this.failureDetectionTimeMillis = failureDetectionTimeMillis;
     this.failureDetectionIntervalMillis = failureDetectionIntervalMillis;
     this.failureDetectionCount = failureDetectionCount;
     this.abortedConnectionsCounter = abortedConnectionsCounter;
+    this.failureCount = 0;
+    this.invalidNodeStartTimeNano = 0;
   }
 
   void setStartMonitorTimeNano(final long startMonitorTimeNano) {

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/v1/HostMonitorServiceV1Impl.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/v1/HostMonitorServiceV1Impl.java
@@ -33,9 +33,11 @@ import software.amazon.jdbc.AwsWrapperProperty;
 import software.amazon.jdbc.HostSpec;
 import software.amazon.jdbc.PluginService;
 import software.amazon.jdbc.PropertyDefinition;
+import software.amazon.jdbc.plugin.efm.base.ConnectionContext;
+import software.amazon.jdbc.plugin.efm.base.ConnectionContextService;
 import software.amazon.jdbc.plugin.efm.base.HostMonitor;
-import software.amazon.jdbc.plugin.efm.base.HostMonitorConnectionContext;
 import software.amazon.jdbc.plugin.efm.base.HostMonitorService;
+import software.amazon.jdbc.plugin.efm.v2.HostMonitorConnectionContextV2;
 import software.amazon.jdbc.util.CoreServicesContainer;
 import software.amazon.jdbc.util.ExecutorFactory;
 import software.amazon.jdbc.util.FullServicesContainer;
@@ -60,6 +62,7 @@ public class HostMonitorServiceV1Impl implements HostMonitorService, StateSnapsh
 
   protected final FullServicesContainer serviceContainer;
   protected final PluginService pluginService;
+  protected final ConnectionContextService connectionContextService;
   protected final MonitorService coreMonitorService;
   protected final TelemetryFactory telemetryFactory;
   protected final TelemetryCounter abortedConnectionsCounter;
@@ -75,6 +78,7 @@ public class HostMonitorServiceV1Impl implements HostMonitorService, StateSnapsh
     this.serviceContainer = serviceContainer;
     this.coreMonitorService = serviceContainer.getMonitorService();
     this.pluginService = serviceContainer.getPluginService();
+    this.connectionContextService = serviceContainer.getConnectionContextService();
     this.telemetryFactory = serviceContainer.getTelemetryFactory();
     this.abortedConnectionsCounter = telemetryFactory.createCounter("efm.connections.aborted");
 
@@ -95,27 +99,29 @@ public class HostMonitorServiceV1Impl implements HostMonitorService, StateSnapsh
   }
 
   @Override
-  public HostMonitorConnectionContext startMonitoring(
+  public ConnectionContext startMonitoring(
       Connection connectionToAbort,
       HostSpec hostSpec,
       Properties properties) throws SQLException {
 
     final HostMonitor monitor = this.getMonitor(hostSpec, properties);
-    final HostMonitorConnectionContextV1 context = new HostMonitorConnectionContextV1(
+    final ConnectionContext context = this.connectionContextService.acquire(
+        HostMonitorConnectionContextV1.class,
+        (connectionContext) -> connectionContext.init(
         connectionToAbort,
         this.failureDetectionTimeMillis,
         this.failureDetectionIntervalMillis,
         this.failureDetectionCount,
-        this.abortedConnectionsCounter);
+        this.abortedConnectionsCounter));
     monitor.startMonitoring(context);
     return context;
   }
 
   @Override
-  public void stopMonitoring(@NonNull final HostMonitorConnectionContext context) {
+  public void stopMonitoring(final @NonNull ConnectionContext context) {
     if (context.shouldAbort()) {
       final Connection connectionToAbort = context.getConnection();
-      context.setInactive();
+      this.connectionContextService.release(context);
       if (connectionToAbort != null) {
         try {
           connectionToAbort.abort(ABORT_EXECUTOR);
@@ -128,18 +134,18 @@ public class HostMonitorServiceV1Impl implements HostMonitorService, StateSnapsh
           LOGGER.finest(
               () -> Messages.get(
                   "HostMonitorConnectionContext.exceptionAbortingConnection",
-                  new Object[]{sqlEx.getMessage()}));
+                  new Object[] {sqlEx.getMessage()}));
         }
       }
     } else {
-      context.setInactive();
+      this.connectionContextService.release(context);
     }
   }
 
   /**
    * Get or create a {@link HostMonitorV1Impl} for a server.
    *
-   * @param hostSpec Information such as hostname of the server.
+   * @param hostSpec   Information such as hostname of the server.
    * @param properties The user configuration for the current connection.
    * @return A {@link HostMonitorV1Impl} object associated with a specific server.
    * @throws SQLException if there's errors getting or creating a monitor

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/v1/HostMonitorV1Impl.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/v1/HostMonitorV1Impl.java
@@ -31,8 +31,8 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import software.amazon.jdbc.AtomicConnection;
 import software.amazon.jdbc.HostSpec;
 import software.amazon.jdbc.PropertyDefinition;
+import software.amazon.jdbc.plugin.efm.base.ConnectionContext;
 import software.amazon.jdbc.plugin.efm.base.HostMonitor;
-import software.amazon.jdbc.plugin.efm.base.HostMonitorConnectionContext;
 import software.amazon.jdbc.plugin.efm.v2.HostMonitorV2Impl;
 import software.amazon.jdbc.util.ExecutorFactory;
 import software.amazon.jdbc.util.FullServicesContainer;
@@ -117,7 +117,7 @@ public class HostMonitorV1Impl extends AbstractMonitor implements HostMonitor, S
   }
 
   @Override
-  public void startMonitoring(final HostMonitorConnectionContext context) {
+  public void startMonitoring(final ConnectionContext context) {
     if (this.stop.get()) {
       LOGGER.warning(() -> Messages.get("HostMonitorImpl.monitorIsStopped", new Object[] {this.hostSpec.getHost()}));
     }

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/v1/HostMonitoringConnectionPluginV1.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/v1/HostMonitoringConnectionPluginV1.java
@@ -40,10 +40,10 @@ public class HostMonitoringConnectionPluginV1 extends HostMonitoringConnectionBa
   }
 
   public HostMonitoringConnectionPluginV1(
-      final @NonNull FullServicesContainer serviceContainer,
+      final @NonNull FullServicesContainer servicesContainer,
       final @NonNull Properties properties,
       final @NonNull Supplier<HostMonitorService> monitorServiceSupplier,
       final RdsUtils rdsHelper) {
-    super(serviceContainer, properties, monitorServiceSupplier, rdsHelper);
+    super(servicesContainer, properties, monitorServiceSupplier, rdsHelper);
   }
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/v2/HostMonitorConnectionContextV2.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/v2/HostMonitorConnectionContextV2.java
@@ -16,21 +16,18 @@
 
 package software.amazon.jdbc.plugin.efm.v2;
 
+import java.lang.ref.WeakReference;
 import java.sql.Connection;
 import software.amazon.jdbc.plugin.efm.base.HostMonitorConnectionContext;
+import software.amazon.jdbc.util.telemetry.TelemetryCounter;
 
 /**
- * Monitoring context for each connection. This contains each connection's criteria for whether a
- * server should be considered unhealthy. The context is shared between the main thread and the monitor thread.
+ * Monitoring context for each connection. This contains each connection's criteria for whether a server should be
+ * considered unhealthy. The context is shared between the main thread and the monitor thread.
  */
 public class HostMonitorConnectionContextV2 extends HostMonitorConnectionContext {
 
-  /**
-   * Constructor.
-   *
-   * @param connectionToAbort A reference to the connection associated with this context that will be aborted.
-   */
-  public HostMonitorConnectionContextV2(final Connection connectionToAbort) {
-    super(connectionToAbort);
+  public void init(Connection connectionToAbort) {
+    this.connectionToAbortRef.set(new WeakReference<>(connectionToAbort));
   }
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/v2/HostMonitorConnectionContextV2.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/v2/HostMonitorConnectionContextV2.java
@@ -19,7 +19,6 @@ package software.amazon.jdbc.plugin.efm.v2;
 import java.lang.ref.WeakReference;
 import java.sql.Connection;
 import software.amazon.jdbc.plugin.efm.base.HostMonitorConnectionContext;
-import software.amazon.jdbc.util.telemetry.TelemetryCounter;
 
 /**
  * Monitoring context for each connection. This contains each connection's criteria for whether a server should be
@@ -29,5 +28,6 @@ public class HostMonitorConnectionContextV2 extends HostMonitorConnectionContext
 
   public void init(Connection connectionToAbort) {
     this.connectionToAbortRef.set(new WeakReference<>(connectionToAbort));
+    this.nodeUnhealthy.set(false);
   }
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/v2/HostMonitorServiceV2Impl.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/v2/HostMonitorServiceV2Impl.java
@@ -33,8 +33,9 @@ import software.amazon.jdbc.AwsWrapperProperty;
 import software.amazon.jdbc.HostSpec;
 import software.amazon.jdbc.PluginService;
 import software.amazon.jdbc.PropertyDefinition;
+import software.amazon.jdbc.plugin.efm.base.ConnectionContext;
+import software.amazon.jdbc.plugin.efm.base.ConnectionContextService;
 import software.amazon.jdbc.plugin.efm.base.HostMonitor;
-import software.amazon.jdbc.plugin.efm.base.HostMonitorConnectionContext;
 import software.amazon.jdbc.plugin.efm.base.HostMonitorService;
 import software.amazon.jdbc.util.CoreServicesContainer;
 import software.amazon.jdbc.util.ExecutorFactory;
@@ -47,8 +48,7 @@ import software.amazon.jdbc.util.telemetry.TelemetryCounter;
 import software.amazon.jdbc.util.telemetry.TelemetryFactory;
 
 /**
- * This class handles the creation and clean up of monitoring threads to servers with one or more
- * active connections.
+ * This class handles the creation and clean up of monitoring threads to servers with one or more active connections.
  */
 public class HostMonitorServiceV2Impl implements HostMonitorService, StateSnapshotProvider {
 
@@ -63,6 +63,7 @@ public class HostMonitorServiceV2Impl implements HostMonitorService, StateSnapsh
 
   protected final FullServicesContainer serviceContainer;
   protected final PluginService pluginService;
+  protected final ConnectionContextService connectionContextService;
   protected final MonitorService coreMonitorService;
   protected final TelemetryFactory telemetryFactory;
   protected final TelemetryCounter abortedConnectionsCounter;
@@ -79,6 +80,7 @@ public class HostMonitorServiceV2Impl implements HostMonitorService, StateSnapsh
   public HostMonitorServiceV2Impl(final @NonNull FullServicesContainer serviceContainer, final Properties props) {
     this.serviceContainer = serviceContainer;
     this.coreMonitorService = serviceContainer.getMonitorService();
+    this.connectionContextService = serviceContainer.getConnectionContextService();
     this.pluginService = serviceContainer.getPluginService();
     this.telemetryFactory = serviceContainer.getTelemetryFactory();
     this.abortedConnectionsCounter = telemetryFactory.createCounter("efm2.connections.aborted");
@@ -100,22 +102,24 @@ public class HostMonitorServiceV2Impl implements HostMonitorService, StateSnapsh
   }
 
   @Override
-  public HostMonitorConnectionContext startMonitoring(
+  public ConnectionContext startMonitoring(
       Connection connectionToAbort,
       HostSpec hostSpec,
       Properties properties) throws SQLException {
 
     final HostMonitor monitor = this.getMonitor(hostSpec, properties);
-    final HostMonitorConnectionContextV2 context = new HostMonitorConnectionContextV2(connectionToAbort);
+    final ConnectionContext context = this.connectionContextService.acquire(
+        HostMonitorConnectionContextV2.class,
+        (connectionContext) -> connectionContext.init(connectionToAbort));
     monitor.startMonitoring(context);
     return context;
   }
 
   @Override
-  public void stopMonitoring(@NonNull final HostMonitorConnectionContext context) {
+  public void stopMonitoring(final @NonNull ConnectionContext context) {
     if (context.shouldAbort()) {
       final Connection connectionToAbort = context.getConnection();
-      context.setInactive();
+      this.connectionContextService.release(context);
       if (connectionToAbort != null) {
         try {
           connectionToAbort.abort(ABORT_EXECUTOR);
@@ -128,18 +132,18 @@ public class HostMonitorServiceV2Impl implements HostMonitorService, StateSnapsh
           LOGGER.finest(
               () -> Messages.get(
                   "HostMonitorConnectionContext.exceptionAbortingConnection",
-                  new Object[]{sqlEx.getMessage()}));
+                  new Object[] {sqlEx.getMessage()}));
         }
       }
     } else {
-      context.setInactive();
+      this.connectionContextService.release(context);
     }
   }
 
   /**
    * Get or create a {@link HostMonitorV2Impl} for a server.
    *
-   * @param hostSpec Information such as hostname of the server.
+   * @param hostSpec   Information such as hostname of the server.
    * @param properties The user configuration for the current connection.
    * @return A {@link HostMonitorV2Impl} object associated with a specific server.
    * @throws SQLException if there's errors getting or creating a monitor
@@ -186,6 +190,7 @@ public class HostMonitorServiceV2Impl implements HostMonitorService, StateSnapsh
   }
 
   protected static class HostMonitorKey {
+
     private final String url;
     private final String keyValue;
 

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/v2/HostMonitorV2Impl.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/v2/HostMonitorV2Impl.java
@@ -37,8 +37,8 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import software.amazon.jdbc.AtomicConnection;
 import software.amazon.jdbc.HostSpec;
 import software.amazon.jdbc.PropertyDefinition;
+import software.amazon.jdbc.plugin.efm.base.ConnectionContext;
 import software.amazon.jdbc.plugin.efm.base.HostMonitor;
-import software.amazon.jdbc.plugin.efm.base.HostMonitorConnectionContext;
 import software.amazon.jdbc.util.ExecutorFactory;
 import software.amazon.jdbc.util.FullServicesContainer;
 import software.amazon.jdbc.util.Messages;
@@ -165,7 +165,7 @@ public class HostMonitorV2Impl extends AbstractMonitor implements HostMonitor, S
   }
 
   @Override
-  public void startMonitoring(final HostMonitorConnectionContext context) {
+  public void startMonitoring(final ConnectionContext context) {
     if (this.stop.get()) {
       LOGGER.warning(() -> Messages.get("HostMonitorImpl.monitorIsStopped", new Object[] {this.hostSpec.getHost()}));
     }
@@ -287,7 +287,7 @@ public class HostMonitorV2Impl extends AbstractMonitor implements HostMonitor, S
             // Kill connection.
             monitorContext.setNodeUnhealthy(true);
             final Connection connectionToAbort = monitorContext.getConnection();
-            monitorContext.setInactive();
+            this.servicesContainer.getConnectionContextService().release(monitorContext);
             if (connectionToAbort != null) {
               this.abortConnection(connectionToAbort);
               if (this.abortedConnectionsCounter != null) {

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/v2/HostMonitoringConnectionPluginV2.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/v2/HostMonitoringConnectionPluginV2.java
@@ -19,7 +19,9 @@ package software.amazon.jdbc.plugin.efm.v2;
 import java.util.Properties;
 import java.util.logging.Logger;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import software.amazon.jdbc.plugin.efm.base.ConnectionContextServiceImpl;
 import software.amazon.jdbc.plugin.efm.base.HostMonitoringConnectionBasePlugin;
+import software.amazon.jdbc.plugin.efm.v1.HostMonitorConnectionContextV1;
 import software.amazon.jdbc.util.FullServicesContainer;
 import software.amazon.jdbc.util.RdsUtils;
 

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/v2/HostMonitoringConnectionPluginV2.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/v2/HostMonitoringConnectionPluginV2.java
@@ -19,9 +19,7 @@ package software.amazon.jdbc.plugin.efm.v2;
 import java.util.Properties;
 import java.util.logging.Logger;
 import org.checkerframework.checker.nullness.qual.NonNull;
-import software.amazon.jdbc.plugin.efm.base.ConnectionContextServiceImpl;
 import software.amazon.jdbc.plugin.efm.base.HostMonitoringConnectionBasePlugin;
-import software.amazon.jdbc.plugin.efm.v1.HostMonitorConnectionContextV1;
 import software.amazon.jdbc.util.FullServicesContainer;
 import software.amazon.jdbc.util.RdsUtils;
 

--- a/wrapper/src/main/java/software/amazon/jdbc/util/FullServicesContainer.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/FullServicesContainer.java
@@ -21,6 +21,7 @@ import software.amazon.jdbc.ConnectionProvider;
 import software.amazon.jdbc.PluginManagerService;
 import software.amazon.jdbc.PluginService;
 import software.amazon.jdbc.hostlistprovider.HostListProviderService;
+import software.amazon.jdbc.plugin.efm.base.ConnectionContextService;
 import software.amazon.jdbc.util.events.EventPublisher;
 import software.amazon.jdbc.util.monitoring.MonitorService;
 import software.amazon.jdbc.util.storage.StorageService;
@@ -39,6 +40,8 @@ public interface FullServicesContainer {
   MonitorService getMonitorService();
 
   EventPublisher getEventPublisher();
+
+  ConnectionContextService getConnectionContextService();
 
   ConnectionProvider getDefaultConnectionProvider();
 
@@ -59,6 +62,8 @@ public interface FullServicesContainer {
   void setStorageService(StorageService storageService);
 
   void setEventPublisher(EventPublisher eventPublisher);
+
+  void setConnectionContextService(ConnectionContextService connectionContextService);
 
   void setTelemetryFactory(TelemetryFactory telemetryFactory);
 

--- a/wrapper/src/main/java/software/amazon/jdbc/util/FullServicesContainerImpl.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/FullServicesContainerImpl.java
@@ -21,6 +21,7 @@ import software.amazon.jdbc.ConnectionProvider;
 import software.amazon.jdbc.PluginManagerService;
 import software.amazon.jdbc.PluginService;
 import software.amazon.jdbc.hostlistprovider.HostListProviderService;
+import software.amazon.jdbc.plugin.efm.base.ConnectionContextService;
 import software.amazon.jdbc.util.events.EventPublisher;
 import software.amazon.jdbc.util.monitoring.MonitorService;
 import software.amazon.jdbc.util.storage.StorageService;
@@ -30,6 +31,7 @@ public class FullServicesContainerImpl implements FullServicesContainer {
   private StorageService storageService;
   private MonitorService monitorService;
   private EventPublisher eventPublisher;
+  private ConnectionContextService connectionContextService;
   private ConnectionProvider defaultConnProvider;
   private TelemetryFactory telemetryFactory;
   private ConnectionPluginManager connectionPluginManager;
@@ -86,6 +88,11 @@ public class FullServicesContainerImpl implements FullServicesContainer {
   }
 
   @Override
+  public ConnectionContextService getConnectionContextService() {
+    return this.connectionContextService;
+  }
+
+  @Override
   public ConnectionProvider getDefaultConnectionProvider() {
     return this.defaultConnProvider;
   }
@@ -133,6 +140,14 @@ public class FullServicesContainerImpl implements FullServicesContainer {
   @Override
   public void setEventPublisher(EventPublisher eventPublisher) {
     this.eventPublisher = eventPublisher;
+  }
+
+  @Override
+  public void setConnectionContextService(ConnectionContextService connectionContextService) {
+    if (this.connectionContextService == null) {
+      // Only sets the connection context service if it hasn't been initialized.
+      this.connectionContextService = connectionContextService;
+    }
   }
 
   @Override

--- a/wrapper/src/main/resources/aws_advanced_jdbc_wrapper_messages.properties
+++ b/wrapper/src/main/resources/aws_advanced_jdbc_wrapper_messages.properties
@@ -329,11 +329,6 @@ HostMonitorConnectionContext.hostDead=Host {0} is *dead*.
 HostMonitorConnectionContext.hostNotResponding=Host {0} is not *responding* {1}.
 HostMonitorConnectionContext.hostAlive=Host {0} is *alive*.
 
-HostMonitorThreadContainer.emptyNodeKeys=Provided node keys are empty.
-
-HostMonitorImpl.contextNullWarning=Parameter 'context' should not be null.
-HostMonitorImpl.interruptedExceptionDuringMonitoring=Monitoring thread for node {0} was interrupted.
-HostMonitorImpl.exceptionDuringMonitoringContinue=Continuing monitoring after unhandled exception was thrown in monitoring thread for node {0}.
 HostMonitorImpl.exceptionDuringMonitoringStop=Stopping monitoring after unhandled exception was thrown in monitoring thread for node {0}.
 HostMonitorImpl.monitorIsStopped=Monitoring was already stopped for node {0}.
 HostMonitorImpl.startMonitoringThreadNewContext=Start monitoring thread for checking new contexts for {0}.
@@ -341,11 +336,7 @@ HostMonitorImpl.stopMonitoringThreadNewContext=Stop monitoring thread for checki
 HostMonitorImpl.startMonitoringThread=Start monitoring thread for {0}.
 HostMonitorImpl.stopMonitoringThread=Stop monitoring thread for {0}.
 
-HostMonitorServiceImpl.emptyAliasSet=Empty alias set passed for ''{0}''. Set should not be empty.
-
 HostResponseTimeServiceImpl.errorStartingMonitor=An error occurred while starting a response time monitor for ''{0}'': {1}
-
-MonitoringGlobalAuroraHostListProvider.globalHostPatternsRequired=Parameter 'globalClusterInstanceHostPatterns' is required for Aurora Global Database.
 
 MonitorServiceImpl.checkingMonitors=Checking monitors for errors...
 MonitorServiceImpl.monitorClassMismatch=The monitor stored at ''{0}'' did not have the expected type. The expected type was ''{1}'', but the monitor ''{2}'' had a type of ''{3}''.
@@ -392,7 +383,6 @@ ReadWriteSplittingPlugin.closingInternalConnections=Closing all internal connect
 ReadWriteSplittingPlugin.setReaderConnection=Reader connection set to ''{0}''
 ReadWriteSplittingPlugin.setWriterConnection=Writer connection set to ''{0}''
 ReadWriteSplittingPlugin.setReadOnlyFalseInTransaction=setReadOnly(false) was called on a read-only connection inside a transaction. Please complete the transaction before calling setReadOnly(false).
-ReadWriteSplittingPlugin.fallbackToWriter=Failed to switch to a reader. {0}. The current writer will be used as a fallback: ''{1}''
 ReadWriteSplittingPlugin.switchedFromWriterToReader=Switched from a writer to a reader host. New reader host: ''{0}''
 ReadWriteSplittingPlugin.switchedFromReaderToWriter=Switched from a reader to a writer host. New writer host: ''{0}''
 ReadWriteSplittingPlugin.settingCurrentConnection=Setting the current connection to ''{0}''
@@ -418,14 +408,12 @@ SAMLCredentialsProviderFactory.getSamlAssertionFailed=Failed to get SAML Asserti
 SamlAuthPlugin.javaStsSdkNotInClasspath=Required dependency 'AWS Java SDK for AWS Secret Token Service' is not on the classpath.
 SamlAuthPlugin.unhandledException=Unhandled exception: ''{0}''
 
-ServicesContainerPluginFactory.servicesContainerRequired=The {0} requires a FullServicesContainer. Please use getInstance(FullServicesContainer, Properties) instead.
 
+FullServiceContainerImpl.ReinitializingConnectionContextService=ConnectionContextService has already been initialized.
 StorageServiceImpl.unexpectedValueMismatch=Attempted to store value ''{0}'' under item class ''{1}'' but there was an unexpected mismatch between the passed in value type and the expected value type. The cache for item class ''{1}'' is ''{2}''.
 StorageServiceImpl.itemClassNotRegistered=The given item class ''{0}'' is not registered. Please register the item class before storing items of that class.
 StorageServiceImpl.itemClassMismatch=The item stored at ''{0}'' did not have the expected type. The expected type was ''{1}'', but the stored item ''{2}'' had a type of ''{3}''. Returning null.
 StorageServiceImpl.removeExpiredItems=Removing expired items from the storage service...
-
-WeightedRandomHostSelector.hostWeightPairsPropertyRequired=A host was requested from the WeightedRandomHostSelector but the required ''weightedRandomHostWeightPairs'' property was not provided.
 
 WrapperUtils.noWrapperClassExists=No wrapper class exists for ''{0}''.
 WrapperUtils.failedToInitializeClass=Can''t initialize class ''{0}''.
@@ -560,3 +548,4 @@ WrapperUtils.failedToInjectContext=Unable to inject context to exception ''{0}''
 PgTargetDriverDialect.exceptionAbortingConnection=Exception during aborting connection: {0}
 
 ConnectionContextServiceImpl.invalidMaxIdleCount=Invalid maxIdleCount value: {0}. Value must be greater than or equal to 1.
+ConnectionContextService.noSupplierRegistered=No supplier registered for context class: {0}.

--- a/wrapper/src/main/resources/aws_advanced_jdbc_wrapper_messages.properties
+++ b/wrapper/src/main/resources/aws_advanced_jdbc_wrapper_messages.properties
@@ -558,3 +558,5 @@ GdbReadWriteSplittingPlugin.parameterValue={0}={1}
 WrapperUtils.failedToInjectContext=Unable to inject context to exception ''{0}''.
 
 PgTargetDriverDialect.exceptionAbortingConnection=Exception during aborting connection: {0}
+
+ConnectionContextServiceImpl.invalidMaxIdleCount=Invalid maxIdleCount value: {0}. Value must be greater than or equal to 1.

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/cache/CacheConnectionTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/cache/CacheConnectionTest.java
@@ -437,12 +437,15 @@ public class CacheConnectionTest {
     verify(mockWriteConnPool).invalidateObject(isClusterMode ? mockClusterClient : mockClient);
 
     // Test READ exception handling
+    CompletableFuture<GlideString> failedRead = new CompletableFuture<>();
     if (isClusterMode) {
+      failedRead.completeExceptionally(new RuntimeException("cluster read error"));
       when(mockReadConnPool.borrowObject()).thenReturn(mockClusterClient);
-      when(mockClusterClient.get(any(GlideString.class))).thenThrow(new RuntimeException("cluster read error"));
+      when(mockClusterClient.get(any(GlideString.class))).thenReturn(failedRead);
     } else {
+      failedRead.completeExceptionally(new RuntimeException("standalone read error"));
       when(mockReadConnPool.borrowObject()).thenReturn(mockClient);
-      when(mockClient.get(any(GlideString.class))).thenThrow(new RuntimeException("standalone read error"));
+      when(mockClient.get(any(GlideString.class))).thenReturn(failedRead);
     }
 
     assertNull(spyConnection.readFromCache(key));
@@ -576,9 +579,11 @@ public class CacheConnectionTest {
     // Error reporting on read failure
     when(mockReadConnPool.borrowObject()).thenReturn(mockClient);
     RuntimeException testException = new RuntimeException("Connection failed");
-    when(mockClient.get(any(GlideString.class))).thenThrow(testException);
+    CompletableFuture<GlideString> failedFuture = new CompletableFuture<>();
+    failedFuture.completeExceptionally(testException);
+    when(mockClient.get(any(GlideString.class))).thenReturn(failedFuture);
     assertNull(spyConnection.readFromCache(key));
-    verify(spyConnection).reportErrorToCacheMonitor(eq(false), eq(testException), eq("READ"));
+    verify(spyConnection).reportErrorToCacheMonitor(eq(false), any(Exception.class), eq("READ"));
 
     // failWhenCacheDown: throws SQLException
     Properties props = new Properties();

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/efm/HostHostMonitorConnectionContextV1Test.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/efm/HostHostMonitorConnectionContextV1Test.java
@@ -53,13 +53,13 @@ class HostHostMonitorConnectionContextV1Test {
   @BeforeEach
   void init() {
     closeable = MockitoAnnotations.openMocks(this);
-    context =
-        new HostMonitorConnectionContextV1(
-            null,
-            FAILURE_DETECTION_TIME_MILLIS,
-            FAILURE_DETECTION_INTERVAL_MILLIS,
-            FAILURE_DETECTION_COUNT,
-            abortedConnectionsCounter);
+    context = new HostMonitorConnectionContextV1();
+    context.init(
+        null,
+        FAILURE_DETECTION_TIME_MILLIS,
+        FAILURE_DETECTION_INTERVAL_MILLIS,
+        FAILURE_DETECTION_COUNT,
+        abortedConnectionsCounter);
   }
 
   @AfterEach
@@ -159,13 +159,13 @@ class HostHostMonitorConnectionContextV1Test {
 
   @Test
   void test_abortConnection_ignoresSqlException() throws SQLException {
-    context =
-        new HostMonitorConnectionContextV1(
-            connectionToAbort,
-            FAILURE_DETECTION_TIME_MILLIS,
-            FAILURE_DETECTION_INTERVAL_MILLIS,
-            FAILURE_DETECTION_COUNT,
-            abortedConnectionsCounter);
+    context = new HostMonitorConnectionContextV1();
+    context.init(
+        connectionToAbort,
+        FAILURE_DETECTION_TIME_MILLIS,
+        FAILURE_DETECTION_INTERVAL_MILLIS,
+        FAILURE_DETECTION_COUNT,
+        abortedConnectionsCounter);
 
     doThrow(new SQLException("unexpected SQLException during abort")).when(connectionToAbort)
         .close();

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/efm/base/ConnectionContextServiceImplTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/efm/base/ConnectionContextServiceImplTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.jdbc.plugin.efm.base;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import software.amazon.jdbc.plugin.efm.v1.HostMonitorConnectionContextV1;
+import software.amazon.jdbc.plugin.efm.v2.HostMonitorConnectionContextV2;
+
+class ConnectionContextServiceImplTest {
+
+  static Stream<Arguments> contextSuppliers() {
+    return Stream.of(
+        Arguments.of(HostMonitorConnectionContextV1.class),
+        Arguments.of(HostMonitorConnectionContextV2.class)
+    );
+  }
+
+  @AfterEach
+  void cleanUp() {
+    System.clearProperty("aws.jdbc.efm.contextPool.initialCapacity");
+    System.clearProperty("aws.jdbc.efm.contextPool.maxIdleCount");
+    ConnectionContextServiceImpl.clear();
+  }
+
+  @ParameterizedTest
+  @MethodSource("contextSuppliers")
+  void test_defaultConfiguration(Class<? extends ConnectionContext> contextClass) {
+    ConnectionContextService service = new ConnectionContextServiceImpl();
+    ConnectionContext context = service.acquire(contextClass);
+    assertNotNull(context);
+  }
+
+  @ParameterizedTest
+  @MethodSource("contextSuppliers")
+  void test_acquireAndRelease(Class<? extends ConnectionContext> contextClass) {
+    ConnectionContextService service = new ConnectionContextServiceImpl();
+    ConnectionContext context = service.acquire(contextClass);
+
+    boolean released = service.release(context);
+    assertTrue(released);
+  }
+
+  @ParameterizedTest
+  @MethodSource("contextSuppliers")
+  void test_contextReuse(Class<? extends ConnectionContext> contextClass) {
+    ConnectionContextService service = new ConnectionContextServiceImpl();
+    ConnectionContext context1 = service.acquire(contextClass);
+    service.release(context1);
+
+    ConnectionContext context2 = service.acquire(contextClass);
+    assertSame(context1, context2);
+  }
+
+  @ParameterizedTest
+  @MethodSource("contextSuppliers")
+  void test_releaseCallsSetInactive(Class<? extends ConnectionContext> contextClass) {
+    ConnectionContext mockContext = mock(ConnectionContext.class);
+    ConnectionContextService service = new ConnectionContextServiceImpl();
+
+    service.release(mockContext);
+    verify(mockContext, times(1)).setInactive();
+  }
+
+  @ParameterizedTest
+  @MethodSource("contextSuppliers")
+  void test_customInitialCapacity(Class<? extends ConnectionContext> contextClass) {
+    System.setProperty("aws.jdbc.efm.contextPool.initialCapacity", "5");
+    ConnectionContextService service = new ConnectionContextServiceImpl();
+    assertNotNull(service);
+  }
+
+  @ParameterizedTest
+  @MethodSource("contextSuppliers")
+  void test_customMaxIdleCount(Class<? extends ConnectionContext> contextClass) {
+    System.setProperty("aws.jdbc.efm.contextPool.maxIdleCount", "3");
+    ConnectionContextService service = new ConnectionContextServiceImpl();
+    assertNotNull(service);
+  }
+
+  @ParameterizedTest
+  @MethodSource("contextSuppliers")
+  void test_multipleAcquireAndRelease(Class<? extends ConnectionContext> contextClass) {
+    System.setProperty("aws.jdbc.efm.contextPool.initialCapacity", "1");
+    ConnectionContextService service = new ConnectionContextServiceImpl();
+    ConnectionContext ctx1 = service.acquire(contextClass);
+    ConnectionContext ctx2 = service.acquire(contextClass);
+    ConnectionContext ctx3 = service.acquire(contextClass);
+
+    service.release(ctx1);
+    service.release(ctx2);
+    service.release(ctx3);
+
+    ConnectionContext ctx4 = service.acquire(contextClass);
+    assertSame(ctx1, ctx4);
+  }
+}

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/efm/base/ContextPoolImplTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/efm/base/ContextPoolImplTest.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.jdbc.plugin.efm.base;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import software.amazon.jdbc.plugin.efm.v1.HostMonitorConnectionContextV1;
+import software.amazon.jdbc.plugin.efm.v2.HostMonitorConnectionContextV2;
+
+class ContextPoolImplTest {
+
+  static Stream<Arguments> contextSuppliers() {
+    return Stream.of(
+        Arguments.of((Supplier<ConnectionContext>) HostMonitorConnectionContextV1::new),
+        Arguments.of((Supplier<ConnectionContext>) HostMonitorConnectionContextV2::new)
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("contextSuppliers")
+  void test_lazyInitializationDisabled(Supplier<ConnectionContext> supplier) {
+    ContextPool pool = new ContextPoolImpl(3, supplier);
+    assertEquals(0, pool.size());
+    pool.acquire();
+    assertEquals(2, pool.size());
+  }
+
+  @ParameterizedTest
+  @MethodSource("contextSuppliers")
+  void test_lazyInitializationEnabled(Supplier<ConnectionContext> supplier) {
+    ContextPool pool = new ContextPoolImpl(5, true, supplier);
+    assertEquals(0, pool.size());
+
+    pool.acquire();
+    assertEquals(2, pool.size());
+
+    pool.acquire();
+    assertEquals(3, pool.size());
+
+    pool.acquire();
+    assertEquals(4, pool.size());
+
+    pool.acquire();
+    assertEquals(5, pool.size());
+
+    // maxIdleCount has been reached.
+    pool.acquire();
+    assertEquals(4, pool.size());
+    // acquire should no longer refill idle context pool.
+    pool.acquire();
+    assertEquals(3, pool.size());
+  }
+
+  @ParameterizedTest
+  @MethodSource("contextSuppliers")
+  void test_releaseNull_returnsFalse(Supplier<ConnectionContext> supplier) {
+    ContextPool pool = new ContextPoolImpl(2, supplier);
+    pool.acquire();
+    int sizeBeforeRelease = pool.size();
+
+    boolean released = pool.release(null);
+    assertFalse(released);
+    assertEquals(sizeBeforeRelease, pool.size());
+  }
+
+  @ParameterizedTest
+  @MethodSource("contextSuppliers")
+  void test_contextReuse_diffInstanceReturnedForLazyInitialization(Supplier<ConnectionContext> supplier) {
+    ContextPool pool = new ContextPoolImpl(1, true, supplier);
+
+    ConnectionContext context1 = pool.acquire();
+
+    // Another idle context should have been created due to the lazy initialization method.
+    assertEquals(1, pool.size());
+
+    // maxIdleCount has already been reached. Release should be no-op.
+    assertFalse(pool.release(context1));
+
+    ConnectionContext context2 = pool.acquire();
+    assertNotSame(context1, context2);
+  }
+
+  @ParameterizedTest
+  @MethodSource("contextSuppliers")
+  @SuppressWarnings("checkstyle:VariableDeclarationUsageDistance")
+  void test_contextReuse_sameInstanceReturnedForLazyInitialization(Supplier<ConnectionContext> supplier) {
+    ContextPool pool = new ContextPoolImpl(3, true, supplier);
+
+    ConnectionContext context1 = pool.acquire();
+
+    // 2 more idle contexts should have been created due to the lazy initialization method.
+    assertEquals(2, pool.size());
+
+    // Should create 2 more idle contexts to reach maxIdleCount
+    pool.acquire();
+    assertEquals(3, pool.size());
+
+    // Exhaust the pool.
+    pool.acquire();
+    pool.acquire();
+    pool.acquire();
+
+    // Release original context back to pool.
+    assertTrue(pool.release(context1));
+    assertEquals(1, pool.size());
+
+    ConnectionContext context2 = pool.acquire();
+    assertSame(context1, context2);
+  }
+
+  @ParameterizedTest
+  @MethodSource("contextSuppliers")
+  @SuppressWarnings("checkstyle:VariableDeclarationUsageDistance")
+  void test_contextReuse_multipleContextsReused(Supplier<ConnectionContext> supplier) {
+    ContextPool pool = new ContextPoolImpl(3, supplier);
+
+    // Acquire all contexts.
+    ConnectionContext context1 = pool.acquire();
+    ConnectionContext context2 = pool.acquire();
+    ConnectionContext context3 = pool.acquire();
+    assertEquals(0, pool.size());
+
+    pool.release(context1);
+    pool.release(context2);
+    pool.release(context3);
+    assertEquals(3, pool.size());
+
+    Set<ConnectionContext> originalContexts = new HashSet<>();
+    originalContexts.add(context1);
+    originalContexts.add(context2);
+    originalContexts.add(context3);
+    ConnectionContext reacquired1 = pool.acquire();
+    ConnectionContext reacquired2 = pool.acquire();
+    ConnectionContext reacquired3 = pool.acquire();
+
+    assertTrue(originalContexts.contains(reacquired1));
+    assertTrue(originalContexts.contains(reacquired2));
+    assertTrue(originalContexts.contains(reacquired3));
+  }
+
+  @ParameterizedTest
+  @MethodSource("contextSuppliers")
+  void test_releaseCallsSetInactive(Supplier<ConnectionContext> supplier) {
+    ConnectionContext mockContext = mock(ConnectionContext.class);
+    ContextPool pool = new ContextPoolImpl(1, supplier);
+
+    final boolean released = pool.release(mockContext);
+    assertTrue(released);
+    verify(mockContext, times(1)).setInactive();
+  }
+
+  @ParameterizedTest
+  @MethodSource("contextSuppliers")
+  void test_clearPool(Supplier<ConnectionContext> supplier) {
+    ContextPool pool = new ContextPoolImpl(5, supplier);
+    pool.acquire();
+    assertEquals(4, pool.size());
+
+    pool.clearPool();
+    assertEquals(0, pool.size());
+  }
+
+  @ParameterizedTest
+  @MethodSource("contextSuppliers")
+  @SuppressWarnings("checkstyle:VariableDeclarationUsageDistance")
+  void test_releaseWhenAtCapacity_doesNotAddToPool(Supplier<ConnectionContext> supplier) {
+    ContextPool pool = new ContextPoolImpl(2, supplier);
+    ConnectionContext ctx1 = pool.acquire();
+    ConnectionContext ctx2 = pool.acquire();
+    ConnectionContext ctx3 = pool.acquire();
+    assertEquals(0, pool.size());
+
+    assertTrue(pool.release(ctx1));
+    assertTrue(pool.release(ctx2));
+    assertEquals(2, pool.size());
+
+    // Pool is at capacity, this release does not update pool.
+    assertFalse(pool.release(ctx3));
+    assertEquals(2, pool.size());
+  }
+
+  @ParameterizedTest
+  @MethodSource("contextSuppliers")
+  void test_threadSafety_concurrentAcquireRelease(Supplier<ConnectionContext> supplier) throws Exception {
+    final int maxIdleCount = 5;
+    final int threadCount = 10;
+    final int operationsPerThread = 100;
+
+    ContextPool pool = new ContextPoolImpl(maxIdleCount, supplier);
+
+    CompletableFuture<?>[] futures = new CompletableFuture[threadCount];
+    for (int i = 0; i < threadCount; i++) {
+      futures[i] = CompletableFuture.runAsync(() -> {
+        for (int j = 0; j < operationsPerThread; j++) {
+          ConnectionContext ctx = pool.acquire();
+          assertNotNull(ctx);
+          Thread.yield();
+          pool.release(ctx);
+        }
+      });
+    }
+
+    CompletableFuture.allOf(futures).get(30, TimeUnit.SECONDS);
+
+    assertTrue(pool.size() <= maxIdleCount);
+  }
+}

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/efm/base/ContextPoolImplTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/efm/base/ContextPoolImplTest.java
@@ -32,6 +32,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -39,6 +40,16 @@ import software.amazon.jdbc.plugin.efm.v1.HostMonitorConnectionContextV1;
 import software.amazon.jdbc.plugin.efm.v2.HostMonitorConnectionContextV2;
 
 class ContextPoolImplTest {
+
+  private ContextPool pool;
+
+  @BeforeEach
+  void setUp() {
+    if (pool != null) {
+      pool.clearPool();
+    }
+    pool = null;
+  }
 
   static Stream<Arguments> contextSuppliers() {
     return Stream.of(
@@ -167,17 +178,6 @@ class ContextPoolImplTest {
     assertTrue(originalContexts.contains(reacquired1));
     assertTrue(originalContexts.contains(reacquired2));
     assertTrue(originalContexts.contains(reacquired3));
-  }
-
-  @ParameterizedTest
-  @MethodSource("contextSuppliers")
-  void test_releaseCallsSetInactive(Supplier<ConnectionContext> supplier) {
-    ConnectionContext mockContext = mock(ConnectionContext.class);
-    ContextPool pool = new ContextPoolImpl(1, supplier);
-
-    final boolean released = pool.release(mockContext);
-    assertTrue(released);
-    verify(mockContext, times(1)).setInactive();
   }
 
   @ParameterizedTest

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/efm/base/PoolConnectionContextServiceImplTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/efm/base/PoolConnectionContextServiceImplTest.java
@@ -25,13 +25,14 @@ import static org.mockito.Mockito.verify;
 
 import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import software.amazon.jdbc.plugin.efm.v1.HostMonitorConnectionContextV1;
 import software.amazon.jdbc.plugin.efm.v2.HostMonitorConnectionContextV2;
 
-class ConnectionContextServiceImplTest {
+class PoolConnectionContextServiceImplTest {
 
   static Stream<Arguments> contextSuppliers() {
     return Stream.of(
@@ -40,17 +41,21 @@ class ConnectionContextServiceImplTest {
     );
   }
 
+  @BeforeEach
+  void beforeEach() {
+    System.setProperty("efm.contextPool.maxIdleCount", "1");
+  }
+
   @AfterEach
   void cleanUp() {
-    System.clearProperty("aws.jdbc.efm.contextPool.initialCapacity");
-    System.clearProperty("aws.jdbc.efm.contextPool.maxIdleCount");
-    ConnectionContextServiceImpl.clear();
+    System.clearProperty("efm.contextPool.maxIdleCount");
+    PoolConnectionContextServiceImpl.clear();
   }
 
   @ParameterizedTest
   @MethodSource("contextSuppliers")
   void test_defaultConfiguration(Class<? extends ConnectionContext> contextClass) {
-    ConnectionContextService service = new ConnectionContextServiceImpl();
+    ConnectionContextService service = new PoolConnectionContextServiceImpl();
     ConnectionContext context = service.acquire(contextClass);
     assertNotNull(context);
   }
@@ -58,8 +63,11 @@ class ConnectionContextServiceImplTest {
   @ParameterizedTest
   @MethodSource("contextSuppliers")
   void test_acquireAndRelease(Class<? extends ConnectionContext> contextClass) {
-    ConnectionContextService service = new ConnectionContextServiceImpl();
+    ConnectionContextService service = new PoolConnectionContextServiceImpl();
     ConnectionContext context = service.acquire(contextClass);
+
+    // Grab the idle context out of the pool so has capacity for new idle contexts.
+    service.acquire(contextClass);
 
     boolean released = service.release(context);
     assertTrue(released);
@@ -68,8 +76,13 @@ class ConnectionContextServiceImplTest {
   @ParameterizedTest
   @MethodSource("contextSuppliers")
   void test_contextReuse(Class<? extends ConnectionContext> contextClass) {
-    ConnectionContextService service = new ConnectionContextServiceImpl();
+    ConnectionContextService service = new PoolConnectionContextServiceImpl();
+    // This call will create a new context and initialize an idle context in the pool.
     ConnectionContext context1 = service.acquire(contextClass);
+
+    // Grab the idle context out of the pool.
+    service.acquire(contextClass);
+
     service.release(context1);
 
     ConnectionContext context2 = service.acquire(contextClass);
@@ -79,8 +92,13 @@ class ConnectionContextServiceImplTest {
   @ParameterizedTest
   @MethodSource("contextSuppliers")
   void test_releaseCallsSetInactive(Class<? extends ConnectionContext> contextClass) {
-    ConnectionContext mockContext = mock(ConnectionContext.class);
-    ConnectionContextService service = new ConnectionContextServiceImpl();
+    System.setProperty("efm.contextPool.maxIdleCount", "2");
+    ConnectionContext mockContext = mock(contextClass);
+
+    ConnectionContextService service = new PoolConnectionContextServiceImpl();
+
+    // Initialize pool
+    service.acquire(contextClass);
 
     service.release(mockContext);
     verify(mockContext, times(1)).setInactive();
@@ -89,24 +107,24 @@ class ConnectionContextServiceImplTest {
   @ParameterizedTest
   @MethodSource("contextSuppliers")
   void test_customInitialCapacity(Class<? extends ConnectionContext> contextClass) {
-    System.setProperty("aws.jdbc.efm.contextPool.initialCapacity", "5");
-    ConnectionContextService service = new ConnectionContextServiceImpl();
+    System.setProperty("efm.contextPool.maxIdleCount", "5");
+    ConnectionContextService service = new PoolConnectionContextServiceImpl();
     assertNotNull(service);
   }
 
   @ParameterizedTest
   @MethodSource("contextSuppliers")
   void test_customMaxIdleCount(Class<? extends ConnectionContext> contextClass) {
-    System.setProperty("aws.jdbc.efm.contextPool.maxIdleCount", "3");
-    ConnectionContextService service = new ConnectionContextServiceImpl();
+    System.setProperty("efm.contextPool.maxIdleCount", "3");
+    ConnectionContextService service = new PoolConnectionContextServiceImpl();
     assertNotNull(service);
   }
 
   @ParameterizedTest
   @MethodSource("contextSuppliers")
   void test_multipleAcquireAndRelease(Class<? extends ConnectionContext> contextClass) {
-    System.setProperty("aws.jdbc.efm.contextPool.initialCapacity", "1");
-    ConnectionContextService service = new ConnectionContextServiceImpl();
+    System.setProperty("efm.contextPool.maxIdleCount", "1");
+    ConnectionContextService service = new PoolConnectionContextServiceImpl();
     ConnectionContext ctx1 = service.acquire(contextClass);
     ConnectionContext ctx2 = service.acquire(contextClass);
     ConnectionContext ctx3 = service.acquire(contextClass);

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/efm/v1/HostMonitorConnectionContextV1Test.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/efm/v1/HostMonitorConnectionContextV1Test.java
@@ -62,15 +62,9 @@ class HostMonitorConnectionContextV1Test {
   }
 
   @Test
-  void test_singleArgConstructor() {
-    HostMonitorConnectionContextV1 ctx = new HostMonitorConnectionContextV1(connection);
-    assertNotNull(ctx.getConnection());
-  }
-
-  @Test
-  void test_initContext() {
+  void test_init() {
     HostMonitorConnectionContextV1 ctx = new HostMonitorConnectionContextV1();
-    ctx.initContext(connection, 50, 100, 3, counter);
+    ctx.init(connection, 50, 100, 3, counter);
 
     assertEquals(100, ctx.getFailureDetectionIntervalMillis());
     assertEquals(3, ctx.getFailureDetectionCount());
@@ -79,7 +73,8 @@ class HostMonitorConnectionContextV1Test {
 
   @Test
   void test_setStartMonitorTimeNano() {
-    HostMonitorConnectionContextV1 ctx = new HostMonitorConnectionContextV1(null, 100, 50, 3, counter);
+    HostMonitorConnectionContextV1 ctx = new HostMonitorConnectionContextV1();
+    ctx.init(null, 100, 50, 3, counter);
     long startTime = System.nanoTime();
     ctx.setStartMonitorTimeNano(startTime);
 
@@ -88,7 +83,8 @@ class HostMonitorConnectionContextV1Test {
 
   @Test
   void test_setInvalidNodeStartTimeNano() {
-    HostMonitorConnectionContextV1 ctx = new HostMonitorConnectionContextV1(null, 100, 50, 3, counter);
+    HostMonitorConnectionContextV1 ctx = new HostMonitorConnectionContextV1();
+    ctx.init(null, 100, 50, 3, counter);
     long time = System.nanoTime();
     ctx.setInvalidNodeStartTimeNano(time);
 
@@ -98,14 +94,16 @@ class HostMonitorConnectionContextV1Test {
 
   @Test
   void test_abortConnection_nullConnectionRef() {
-    HostMonitorConnectionContextV1 ctx = new HostMonitorConnectionContextV1(null, 100, 50, 3, counter);
+    HostMonitorConnectionContextV1 ctx = new HostMonitorConnectionContextV1();
+    ctx.init(null, 100, 50, 3, counter);
     ctx.abortConnection();
     verify(counter, never()).inc();
   }
 
   @Test
   void test_abortConnection_inactiveContext() throws SQLException {
-    HostMonitorConnectionContextV1 ctx = new HostMonitorConnectionContextV1(connection, 100, 50, 3, counter);
+    HostMonitorConnectionContextV1 ctx = new HostMonitorConnectionContextV1();
+    ctx.init(connection, 100, 50, 3, null);
     ctx.setInactive();
     ctx.abortConnection();
 
@@ -114,7 +112,8 @@ class HostMonitorConnectionContextV1Test {
 
   @Test
   void test_abortConnection_success() throws SQLException {
-    HostMonitorConnectionContextV1 ctx = new HostMonitorConnectionContextV1(connection, 100, 50, 3, counter);
+    HostMonitorConnectionContextV1 ctx = new HostMonitorConnectionContextV1();
+    ctx.init(connection, 100, 50, 3, counter);
     ctx.abortConnection();
 
     verify(connection).abort(any());
@@ -124,7 +123,8 @@ class HostMonitorConnectionContextV1Test {
 
   @Test
   void test_abortConnection_nullCounter() throws SQLException {
-    HostMonitorConnectionContextV1 ctx = new HostMonitorConnectionContextV1(connection, 100, 50, 3, null);
+    HostMonitorConnectionContextV1 ctx = new HostMonitorConnectionContextV1();
+    ctx.init(connection, 100, 50, 3, null);
     ctx.abortConnection();
 
     verify(connection).abort(any());
@@ -133,7 +133,8 @@ class HostMonitorConnectionContextV1Test {
 
   @Test
   void test_updateConnectionStatus_beforeGracePeriod() {
-    HostMonitorConnectionContextV1 ctx = spy(new HostMonitorConnectionContextV1(null, 100, 50, 3, counter));
+    HostMonitorConnectionContextV1 ctx = spy(new HostMonitorConnectionContextV1());
+    ctx.init(connection, 100, 50, 3, counter);
     long startTime = System.nanoTime();
     ctx.setStartMonitorTimeNano(startTime);
 
@@ -146,7 +147,8 @@ class HostMonitorConnectionContextV1Test {
 
   @Test
   void test_setConnectionValid_recoveryAfterFailure() {
-    HostMonitorConnectionContextV1 ctx = new HostMonitorConnectionContextV1(null, 100, 50, 3, counter);
+    HostMonitorConnectionContextV1 ctx = new HostMonitorConnectionContextV1();
+    ctx.init(null, 100, 50, 3, counter);
     long time = System.nanoTime();
 
     ctx.setConnectionValid("host", false, time, time);
@@ -167,7 +169,8 @@ class HostMonitorConnectionContextV1Test {
 
   @Test
   void test_resetInvalidNodeStartTime() {
-    HostMonitorConnectionContextV1 ctx = new HostMonitorConnectionContextV1(null, 100, 50, 3, counter);
+    HostMonitorConnectionContextV1 ctx = new HostMonitorConnectionContextV1();
+    ctx.init(null, 100, 50, 3, counter);
     ctx.setInvalidNodeStartTimeNano(System.nanoTime());
     assertTrue(ctx.isInvalidNodeStartTimeDefined());
 
@@ -177,7 +180,8 @@ class HostMonitorConnectionContextV1Test {
 
   @Test
   void test_setFailureCount() {
-    HostMonitorConnectionContextV1 ctx = new HostMonitorConnectionContextV1(null, 100, 50, 3, counter);
+    HostMonitorConnectionContextV1 ctx = new HostMonitorConnectionContextV1();
+    ctx.init(null, 100, 50, 3, counter);
     ctx.setFailureCount(5);
     assertEquals(5, ctx.getFailureCount());
   }
@@ -193,13 +197,15 @@ class HostMonitorConnectionContextV1Test {
 
   @Test
   void test_getFailureDetectionIntervalMillis() {
-    HostMonitorConnectionContextV1 ctx = new HostMonitorConnectionContextV1(null, 100, 50, 3, counter);
+    HostMonitorConnectionContextV1 ctx = new HostMonitorConnectionContextV1();
+    ctx.init(null, 100, 50, 3, counter);
     assertEquals(50, ctx.getFailureDetectionIntervalMillis());
   }
 
   @Test
   void test_getFailureDetectionCount() {
-    HostMonitorConnectionContextV1 ctx = new HostMonitorConnectionContextV1(null, 100, 50, 3, counter);
+    HostMonitorConnectionContextV1 ctx = new HostMonitorConnectionContextV1();
+    ctx.init(null, 100, 50, 3, counter);
     assertEquals(3, ctx.getFailureDetectionCount());
   }
 }

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/efm/v1/HostMonitorServiceV1ImplTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/efm/v1/HostMonitorServiceV1ImplTest.java
@@ -48,6 +48,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import software.amazon.jdbc.HostSpec;
 import software.amazon.jdbc.PluginService;
+import software.amazon.jdbc.plugin.efm.base.ConnectionContextService;
 import software.amazon.jdbc.plugin.efm.base.HostMonitor;
 import software.amazon.jdbc.plugin.efm.base.HostMonitorConnectionContext;
 import software.amazon.jdbc.util.FullServicesContainer;
@@ -71,6 +72,7 @@ class HostMonitorServiceV1ImplTest {
   @Mock private TelemetryCounter telemetryCounter;
   @Mock private FullServicesContainer servicesContainer;
   @Mock private MonitorService monitorService;
+  @Mock private ConnectionContextService connectionContextService;
 
   private Properties properties;
   private AutoCloseable closeable;
@@ -90,6 +92,12 @@ class HostMonitorServiceV1ImplTest {
     when(servicesContainer.getPluginService()).thenReturn(pluginService);
     when(servicesContainer.getTelemetryFactory()).thenReturn(telemetryFactory);
     when(servicesContainer.getMonitorService()).thenReturn(monitorService);
+    when(servicesContainer.getConnectionContextService()).thenReturn(connectionContextService);
+    when(connectionContextService.acquire(any(), any())).thenAnswer(invocation -> {
+      HostMonitorConnectionContextV1 ctx = mock(HostMonitorConnectionContextV1.class);
+      when(ctx.getConnection()).thenReturn(connection);
+      return ctx;
+    });
     when(monitorService.runIfAbsent(any(), eq("hostA"), any(), any(), any())).thenReturn(monitorA);
     when(monitorService.runIfAbsent(any(), eq("hostB"), any(), any(), any())).thenReturn(monitorB);
     when(monitorService.runIfAbsent(any(), eq("host"), any(), any(), any())).thenReturn(monitorA);
@@ -169,8 +177,8 @@ class HostMonitorServiceV1ImplTest {
     when(context.getConnection()).thenReturn(conn);
     
     hostMonitorService.stopMonitoring(context);
-    
-    verify(context).setInactive();
+
+    verify(connectionContextService).release(context);
     verify(conn).abort(any());
     verify(conn).close();
     verify(telemetryCounter).inc();
@@ -183,7 +191,7 @@ class HostMonitorServiceV1ImplTest {
     
     hostMonitorService.stopMonitoring(context);
     
-    verify(context).setInactive();
+    verify(connectionContextService).release(context);
     verify(context, never()).getConnection();
   }
 
@@ -194,8 +202,7 @@ class HostMonitorServiceV1ImplTest {
     when(context.getConnection()).thenReturn(null);
     
     hostMonitorService.stopMonitoring(context);
-    
-    verify(context).setInactive();
+    verify(connectionContextService).release(context);
   }
 
   @Test
@@ -208,7 +215,7 @@ class HostMonitorServiceV1ImplTest {
     
     hostMonitorService.stopMonitoring(context);
     
-    verify(context).setInactive();
+    verify(connectionContextService).release(context);
   }
 
   @Test


### PR DESCRIPTION
### Summary

Use a context pool to reduce memory allocation overhead in EFM plugins

### Description

This change introduce monitoring context pooling to avoid allocating a new monitor context every connection.

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.