### PR TITLE
chore: create test output directories before mounting them to docker

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/RdsHostListProvider.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/RdsHostListProvider.java
@@ -205,7 +205,7 @@ public class RdsHostListProvider implements DynamicHostListProvider, CanReleaseR
   protected FetchTopologyResult getTopology() throws SQLException {
     init();
 
-    final List<HostSpec> storedHosts = this.getStoredTopology();
+    List<HostSpec> storedHosts = this.getStoredTopology();
     if (storedHosts == null) {
       // We need to re-fetch topology.
       if (!this.pluginService.isDialectConfirmed()) {
@@ -220,6 +220,7 @@ public class RdsHostListProvider implements DynamicHostListProvider, CanReleaseR
       }
     }
 
+    storedHosts = this.getStoredTopology();
     if (storedHosts == null) {
       return new FetchTopologyResult(false, this.initialHostList);
     } else {

--- a/wrapper/src/test/java/integration/util/ContainerHelper.java
+++ b/wrapper/src/test/java/integration/util/ContainerHelper.java
@@ -26,6 +26,7 @@ import com.github.dockerjava.api.exception.DockerException;
 import eu.rekawek.toxiproxy.ToxiproxyClient;
 import integration.TargetJvm;
 import integration.TestInstanceInfo;
+import java.io.File;
 import java.io.IOException;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
@@ -219,6 +220,12 @@ public class ContainerHelper {
 
         return self();
       }
+    }
+
+    // Ensure host directories exist before binding them to the container.
+    // Docker will fail with "no such file or directory" if these paths are missing.
+    for (String dir : new String[] {"./build/reports/tests", "./build/test-results", "./build/jacoco"}) {
+      new File(dir).mkdirs();
     }
 
     return new FixedExposedPortContainer<>(


### PR DESCRIPTION
### Summary

Need to create test output folders before mounting them to test containers.
This is required when running integration tests with Podman instead of Docker

### Description

<!--- Details of what you changed -->

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.