### PR TITLE
chore: improve connection tracker

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/PartialPluginService.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/PartialPluginService.java
@@ -42,6 +42,7 @@ import software.amazon.jdbc.hostavailability.HostAvailabilityStrategyFactory;
 import software.amazon.jdbc.hostlistprovider.HostListProvider;
 import software.amazon.jdbc.hostlistprovider.HostListProviderService;
 import software.amazon.jdbc.hostlistprovider.StaticHostListProvider;
+import software.amazon.jdbc.plugin.TrackedConnectionList;
 import software.amazon.jdbc.profile.ConfigurationProfile;
 import software.amazon.jdbc.states.SessionStateService;
 import software.amazon.jdbc.targetdriverdialect.TargetDriverDialect;
@@ -696,6 +697,18 @@ public class PartialPluginService implements PluginService, CanReleaseResources,
   @Override
   public void setIsPooledConnection(Boolean pooledConnection) {
     // This service implementation doesn't support call context.
+    // Do nothing.
+  }
+
+  @Override
+  public @Nullable TrackedConnectionList.Node getTrackedConnectionNode() {
+    // This service implementation doesn't support connection tracking.
+    return null;
+  }
+
+  @Override
+  public void setTrackedConnectionNode(@Nullable TrackedConnectionList.Node node) {
+    // This service implementation doesn't support connection tracking.
     // Do nothing.
   }
 

--- a/wrapper/src/main/java/software/amazon/jdbc/PartialPluginService.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/PartialPluginService.java
@@ -701,13 +701,13 @@ public class PartialPluginService implements PluginService, CanReleaseResources,
   }
 
   @Override
-  public @Nullable TrackedConnectionList.Node getTrackedConnectionNode() {
+  public TrackedConnectionList.@Nullable Node getTrackedConnectionNode() {
     // This service implementation doesn't support connection tracking.
     return null;
   }
 
   @Override
-  public void setTrackedConnectionNode(@Nullable TrackedConnectionList.Node node) {
+  public void setTrackedConnectionNode(TrackedConnectionList.@Nullable Node node) {
     // This service implementation doesn't support connection tracking.
     // Do nothing.
   }

--- a/wrapper/src/main/java/software/amazon/jdbc/PluginService.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/PluginService.java
@@ -30,6 +30,7 @@ import software.amazon.jdbc.dialect.Dialect;
 import software.amazon.jdbc.exceptions.ExceptionHandler;
 import software.amazon.jdbc.hostavailability.HostAvailability;
 import software.amazon.jdbc.hostlistprovider.HostListProvider;
+import software.amazon.jdbc.plugin.TrackedConnectionList;
 import software.amazon.jdbc.states.SessionStateService;
 import software.amazon.jdbc.targetdriverdialect.TargetDriverDialect;
 import software.amazon.jdbc.util.StateSnapshotProvider;
@@ -257,6 +258,23 @@ public interface PluginService extends ExceptionHandler, Wrapper, StateSnapshotP
   <T> T getPlugin(final Class<T> pluginClazz);
 
   boolean isPluginInUse(final Class<? extends ConnectionPlugin> pluginClazz);
+
+  // Connection tracking node for O(1) removal from the tracked connection list
+
+  /**
+   * Returns the tracked connection list node associated with the current connection.
+   *
+   * @return the node, or null if the current connection is not tracked
+   */
+  @Nullable TrackedConnectionList.Node getTrackedConnectionNode();
+
+  /**
+   * Sets the tracked connection list node for the current connection.
+   *
+   * @param node the node returned by
+   *             {@link software.amazon.jdbc.plugin.OpenedConnectionTracker#populateOpenedConnectionQueue}
+   */
+  void setTrackedConnectionNode(@Nullable TrackedConnectionList.Node node);
 
   // JDBC call context functions
 

--- a/wrapper/src/main/java/software/amazon/jdbc/PluginService.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/PluginService.java
@@ -266,7 +266,7 @@ public interface PluginService extends ExceptionHandler, Wrapper, StateSnapshotP
    *
    * @return the node, or null if the current connection is not tracked
    */
-  @Nullable TrackedConnectionList.Node getTrackedConnectionNode();
+  TrackedConnectionList.@Nullable Node getTrackedConnectionNode();
 
   /**
    * Sets the tracked connection list node for the current connection.
@@ -274,7 +274,7 @@ public interface PluginService extends ExceptionHandler, Wrapper, StateSnapshotP
    * @param node the node returned by
    *             {@link software.amazon.jdbc.plugin.OpenedConnectionTracker#populateOpenedConnectionQueue}
    */
-  void setTrackedConnectionNode(@Nullable TrackedConnectionList.Node node);
+  void setTrackedConnectionNode(TrackedConnectionList.@Nullable Node node);
 
   // JDBC call context functions
 

--- a/wrapper/src/main/java/software/amazon/jdbc/PluginServiceImpl.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/PluginServiceImpl.java
@@ -95,10 +95,10 @@ public class PluginServiceImpl implements PluginService, CanReleaseResources,
   protected final SessionStateService sessionStateService;
 
   protected final ResourceLock connectionSwitchLock = new ResourceLock();
+  protected TrackedConnectionList.@Nullable Node trackedConnectionNode = null;
 
   // JDBC call context members
   protected Boolean pooledConnection = null;
-  protected TrackedConnectionList.@Nullable Node trackedConnectionNode = null;
 
   public PluginServiceImpl(
       @NonNull final FullServicesContainer servicesContainer,

--- a/wrapper/src/main/java/software/amazon/jdbc/PluginServiceImpl.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/PluginServiceImpl.java
@@ -98,7 +98,7 @@ public class PluginServiceImpl implements PluginService, CanReleaseResources,
 
   // JDBC call context members
   protected Boolean pooledConnection = null;
-  protected @Nullable TrackedConnectionList.Node trackedConnectionNode = null;
+  protected TrackedConnectionList.@Nullable Node trackedConnectionNode = null;
 
   public PluginServiceImpl(
       @NonNull final FullServicesContainer servicesContainer,
@@ -823,12 +823,12 @@ public class PluginServiceImpl implements PluginService, CanReleaseResources,
   }
 
   @Override
-  public @Nullable TrackedConnectionList.Node getTrackedConnectionNode() {
+  public TrackedConnectionList.@Nullable Node getTrackedConnectionNode() {
     return this.trackedConnectionNode;
   }
 
   @Override
-  public void setTrackedConnectionNode(@Nullable TrackedConnectionList.Node node) {
+  public void setTrackedConnectionNode(TrackedConnectionList.@Nullable Node node) {
     this.trackedConnectionNode = node;
   }
 

--- a/wrapper/src/main/java/software/amazon/jdbc/PluginServiceImpl.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/PluginServiceImpl.java
@@ -46,6 +46,7 @@ import software.amazon.jdbc.hostavailability.HostAvailabilityStrategyFactory;
 import software.amazon.jdbc.hostlistprovider.HostListProvider;
 import software.amazon.jdbc.hostlistprovider.HostListProviderService;
 import software.amazon.jdbc.hostlistprovider.StaticHostListProvider;
+import software.amazon.jdbc.plugin.TrackedConnectionList;
 import software.amazon.jdbc.profile.ConfigurationProfile;
 import software.amazon.jdbc.states.SessionStateService;
 import software.amazon.jdbc.states.SessionStateServiceImpl;
@@ -97,6 +98,7 @@ public class PluginServiceImpl implements PluginService, CanReleaseResources,
 
   // JDBC call context members
   protected Boolean pooledConnection = null;
+  protected @Nullable TrackedConnectionList.Node trackedConnectionNode = null;
 
   public PluginServiceImpl(
       @NonNull final FullServicesContainer servicesContainer,
@@ -308,6 +310,7 @@ public class PluginServiceImpl implements PluginService, CanReleaseResources,
           try {
             this.currentConnection = connection;
             this.currentHostSpec = hostSpec;
+            this.trackedConnectionNode = null;
 
             this.servicesContainer.getImportantEventService().registerEvent(
                 () -> "Current connection set to " + connection + ", " + hostSpec);
@@ -817,6 +820,16 @@ public class PluginServiceImpl implements PluginService, CanReleaseResources,
   @Override
   public void setIsPooledConnection(Boolean isPooledConnection) {
     this.pooledConnection = isPooledConnection;
+  }
+
+  @Override
+  public @Nullable TrackedConnectionList.Node getTrackedConnectionNode() {
+    return this.trackedConnectionNode;
+  }
+
+  @Override
+  public void setTrackedConnectionNode(@Nullable TrackedConnectionList.Node node) {
+    this.trackedConnectionNode = node;
   }
 
   @Override

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/AuroraConnectionTrackerPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/AuroraConnectionTrackerPlugin.java
@@ -99,7 +99,8 @@ public class AuroraConnectionTrackerPlugin extends AbstractConnectionPlugin {
           this.pluginService.setRoutedHostSpec(identifiedHostSpec);
         }
       }
-      tracker.populateOpenedConnectionQueue(connectionHostSpec, conn);
+      final TrackedConnectionList.Node node = tracker.populateOpenedConnectionQueue(hostSpec, conn);
+      this.pluginService.setTrackedConnectionNode(node);
     }
 
     return conn;
@@ -138,7 +139,13 @@ public class AuroraConnectionTrackerPlugin extends AbstractConnectionPlugin {
       final T result = jdbcMethodFunc.call();
       if ((methodName.equals(JdbcMethod.CONNECTION_CLOSE.methodName)
           || methodName.equals(JdbcMethod.CONNECTION_ABORT.methodName))) {
-        tracker.removeConnectionTracking(currentHostSpec, this.pluginService.getCurrentConnection());
+        final TrackedConnectionList.Node node = this.pluginService.getTrackedConnectionNode();
+        if (node != null) {
+          tracker.removeConnectionTracking(node);
+          this.pluginService.setTrackedConnectionNode(null);
+        } else {
+          tracker.removeConnectionTracking(currentHostSpec, this.pluginService.getCurrentConnection());
+        }
       }
       return result;
 

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/OpenedConnectionTracker.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/OpenedConnectionTracker.java
@@ -21,12 +21,10 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
@@ -45,7 +43,7 @@ import software.amazon.jdbc.util.telemetry.TelemetryTraceLevel;
 
 public class OpenedConnectionTracker {
 
-  static final Map<String, Queue<WeakReference<Connection>>> openedConnections = new ConcurrentHashMap<>();
+  static final Map<String, TrackedConnectionList> openedConnections = new ConcurrentHashMap<>();
   private static final String TELEMETRY_INVALIDATE_CONNECTIONS = "invalidate connections";
   private static final int PRUNE_INTERVAL_SEC = 30;
   private static final ScheduledExecutorService pruneConnectionsExecutorService =
@@ -74,26 +72,28 @@ public class OpenedConnectionTracker {
     this.pluginService = pluginService;
   }
 
-  public void populateOpenedConnectionQueue(final HostSpec hostSpec, final Connection conn) {
+  public TrackedConnectionList.Node populateOpenedConnectionQueue(final HostSpec hostSpec, final Connection conn) {
     if (hostSpec == null || conn == null) {
-      return;
+      return null;
     }
 
     // Check if the connection was established using an instance endpoint
     if (rdsUtils.isRdsInstance(hostSpec.getHost())) {
-      trackConnection(hostSpec.getHostAndPort(), conn);
+      final TrackedConnectionList.Node node = trackConnection(hostSpec.getHostAndPort(), conn);
       logOpenedConnections();
-      return;
+      return node;
     }
 
     // It might be a custom domain name. Let's track by hostId and custom domain name
+    TrackedConnectionList.Node lastNode = null;
     if (!StringUtils.isNullOrEmpty(hostSpec.getHostId())) {
-      trackConnection(hostSpec.getHostId(), conn);
+      lastNode = trackConnection(hostSpec.getHostId(), conn);
     }
     if (!StringUtils.isNullOrEmpty(hostSpec.getHostAndPort())) {
-      trackConnection(hostSpec.getHostAndPort(), conn);
+      lastNode = trackConnection(hostSpec.getHostAndPort(), conn);
     }
     logOpenedConnections();
+    return lastNode;
   }
 
   /**
@@ -119,9 +119,9 @@ public class OpenedConnectionTracker {
           continue;
         }
         try {
-          final Queue<WeakReference<Connection>> connectionQueue = openedConnections.get(key);
-          logConnectionQueue(key, connectionQueue);
-          invalidateConnections(connectionQueue);
+          final TrackedConnectionList connectionList = openedConnections.get(key);
+          logConnectionList(key, connectionList);
+          invalidateConnections(connectionList);
         } catch (Exception ex) {
           // ignore and continue
         }
@@ -133,6 +133,22 @@ public class OpenedConnectionTracker {
     }
   }
 
+  /**
+   * Removes a tracked connection in O(1) using a direct node reference.
+   *
+   * @param node the node returned by {@link #populateOpenedConnectionQueue}
+   */
+  public void removeConnectionTracking(final TrackedConnectionList.Node node) {
+    if (node == null) {
+      return;
+    }
+    node.ownerList.remove(node);
+  }
+
+  /**
+   * Removes a tracked connection by scanning the list for the given host.
+   * This is the O(n) fallback used when no node reference is available.
+   */
   public void removeConnectionTracking(final HostSpec hostSpec, final Connection connection) {
     final String hostAndPort = rdsUtils.isRdsInstance(hostSpec.getHost())
         ? hostSpec.getHostAndPort()
@@ -142,36 +158,36 @@ public class OpenedConnectionTracker {
       return;
     }
 
-    final Queue<WeakReference<Connection>> connectionQueue = openedConnections.get(hostAndPort);
-    if (connectionQueue != null) {
-      connectionQueue.removeIf(
-          connectionWeakReference -> Objects.equals(connectionWeakReference.get(), connection));
+    final TrackedConnectionList connectionList = openedConnections.get(host);
+    if (connectionList != null) {
+      final Connection target = connection;
+      connectionList.removeIf(
+          connectionWeakReference -> {
+            final Connection conn = connectionWeakReference.get();
+            return conn == null || conn == target;
+          });
     }
   }
 
-  private void trackConnection(final String instanceEndpoint, final Connection connection) {
+  private TrackedConnectionList.Node trackConnection(
+      final String instanceEndpoint, final Connection connection) {
     if (connection == null) {
-      return;
+      return null;
     }
-    final Queue<WeakReference<Connection>> connectionQueue =
+    final TrackedConnectionList connectionList =
         openedConnections.computeIfAbsent(
             instanceEndpoint,
-            (k) -> new ConcurrentLinkedQueue<>());
-    connectionQueue.add(new WeakReference<>(connection));
+            (k) -> new TrackedConnectionList());
+    return connectionList.add(connection);
   }
 
-  private void invalidateConnections(final Queue<WeakReference<Connection>> connectionQueue) {
-    if (connectionQueue == null || connectionQueue.isEmpty()) {
+  private void invalidateConnections(final TrackedConnectionList connectionList) {
+    if (connectionList == null || connectionList.isEmpty()) {
       return;
     }
     invalidateConnectionsExecutorService.submit(() -> {
-      WeakReference<Connection> connReference;
-      while ((connReference = connectionQueue.poll()) != null) {
-        final Connection conn = connReference.get();
-        if (conn == null) {
-          continue;
-        }
-
+      final List<Connection> connections = connectionList.drainAll();
+      for (final Connection conn : connections) {
         try {
           conn.abort(abortConnectionExecutor);
         } catch (final SQLException e) {
@@ -184,17 +200,12 @@ public class OpenedConnectionTracker {
   public void logOpenedConnections() {
     LOGGER.finest(() -> {
       final StringBuilder builder = new StringBuilder();
-      openedConnections.forEach((key, queue) -> {
-        if (!queue.isEmpty()) {
+      openedConnections.forEach((key, list) -> {
+        if (!list.isEmpty()) {
           builder.append("\t");
           builder.append(key).append(" :");
           builder.append("\n\t{");
-          for (final WeakReference<Connection> connection : queue) {
-            final Connection tmpConn = connection.get();
-            if (tmpConn != null) {
-              builder.append("\n\t\t").append(tmpConn);
-            }
-          }
+          list.appendTo(builder);
           builder.append("\n\t}\n");
         }
       });
@@ -202,23 +213,22 @@ public class OpenedConnectionTracker {
     });
   }
 
-  private void logConnectionQueue(final String host, final Queue<WeakReference<Connection>> queue) {
-    if (queue == null || queue.isEmpty()) {
+  private void logConnectionList(final String host, final TrackedConnectionList list) {
+    if (list == null || list.isEmpty()) {
       return;
     }
 
     final StringBuilder builder = new StringBuilder();
     builder.append(host).append("\n[");
-    for (final WeakReference<Connection> connection : queue) {
-      builder.append("\n\t").append(connection.get());
-    }
+    list.appendTo(builder);
     builder.append("\n]");
-    LOGGER.finest(Messages.get("OpenedConnectionTracker.invalidatingConnections", new Object[] {builder.toString()}));
+    LOGGER.finest(Messages.get("OpenedConnectionTracker.invalidatingConnections",
+        new Object[] {builder.toString()}));
   }
 
   protected static void pruneConnections() {
-    openedConnections.forEach((key, queue) -> {
-      queue.removeIf(connectionWeakReference -> {
+    openedConnections.forEach((key, list) -> {
+      list.removeIf(connectionWeakReference -> {
         final Connection conn = connectionWeakReference.get();
         if (conn == null) {
           return true;

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/OpenedConnectionTracker.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/OpenedConnectionTracker.java
@@ -158,7 +158,7 @@ public class OpenedConnectionTracker {
       return;
     }
 
-    final TrackedConnectionList connectionList = openedConnections.get(host);
+    final TrackedConnectionList connectionList = openedConnections.get(hostAndPort);
     if (connectionList != null) {
       final Connection target = connection;
       connectionList.removeIf(

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/TrackedConnectionList.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/TrackedConnectionList.java
@@ -207,7 +207,10 @@ public class TrackedConnectionList {
     try {
       Node current = head;
       while (current != null) {
-        builder.append("\n\t\t").append(current.connectionRef.get());
+        Connection conn = current.connectionRef.get();
+        if (conn != null) {
+          builder.append("\n\t\t").append(conn);
+        }
         current = current.next;
       }
     } finally {

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/TrackedConnectionList.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/TrackedConnectionList.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.jdbc.plugin;
+
+import java.lang.ref.WeakReference;
+import java.sql.Connection;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Predicate;
+
+/**
+ * A thread-safe doubly-linked list for tracking opened connections.
+ * Uses a lock-per-list approach for concurrency control.
+ * Supports O(1) removal when a direct node reference is available.
+ */
+public class TrackedConnectionList {
+
+  private final ReentrantLock lock = new ReentrantLock();
+  private Node head;
+  private Node tail;
+  private int size;
+
+  /**
+   * A node in the doubly-linked list holding a weak reference to a connection.
+   */
+  public static class Node {
+    final WeakReference<Connection> connectionRef;
+    final TrackedConnectionList ownerList;
+    Node prev;
+    Node next;
+    boolean removed;
+
+    Node(final WeakReference<Connection> connectionRef, final TrackedConnectionList ownerList) {
+      this.connectionRef = connectionRef;
+      this.ownerList = ownerList;
+    }
+  }
+
+  /**
+   * Adds a connection to the tail of the list.
+   *
+   * @param connection the connection to track
+   * @return the node representing this connection, for O(1) removal later
+   */
+  public Node add(final Connection connection) {
+    final Node node = new Node(new WeakReference<>(connection), this);
+    lock.lock();
+    try {
+      if (tail == null) {
+        head = node;
+        tail = node;
+      } else {
+        node.prev = tail;
+        tail.next = node;
+        tail = node;
+      }
+      size++;
+    } finally {
+      lock.unlock();
+    }
+    return node;
+  }
+
+  /**
+   * Removes a node from the list in O(1) time.
+   * Safe to call multiple times on the same node.
+   *
+   * @param node the node to remove
+   */
+  public void remove(final Node node) {
+    if (node == null) {
+      return;
+    }
+    lock.lock();
+    try {
+      if (node.removed) {
+        return;
+      }
+      node.removed = true;
+
+      if (node.prev != null) {
+        node.prev.next = node.next;
+      } else {
+        head = node.next;
+      }
+
+      if (node.next != null) {
+        node.next.prev = node.prev;
+      } else {
+        tail = node.prev;
+      }
+
+      node.prev = null;
+      node.next = null;
+      size--;
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  /**
+   * Removes all nodes from the list and returns the connections.
+   * Used during invalidation to drain and abort all tracked connections.
+   *
+   * @return list of connections that were in the list (may contain nulls from GC'd weak refs)
+   */
+  public List<Connection> drainAll() {
+    final List<Connection> connections = new ArrayList<>();
+    lock.lock();
+    try {
+      Node current = head;
+      while (current != null) {
+        current.removed = true;
+        final Connection conn = current.connectionRef.get();
+        if (conn != null) {
+          connections.add(conn);
+        }
+        final Node next = current.next;
+        current.prev = null;
+        current.next = null;
+        current = next;
+      }
+      head = null;
+      tail = null;
+      size = 0;
+    } finally {
+      lock.unlock();
+    }
+    return connections;
+  }
+
+  /**
+   * Removes nodes matching the predicate. Used for pruning GC'd or closed connections.
+   *
+   * @param predicate test applied to each node's weak reference
+   */
+  public void removeIf(final Predicate<WeakReference<Connection>> predicate) {
+    lock.lock();
+    try {
+      Node current = head;
+      while (current != null) {
+        final Node next = current.next;
+        if (predicate.test(current.connectionRef)) {
+          current.removed = true;
+          if (current.prev != null) {
+            current.prev.next = current.next;
+          } else {
+            head = current.next;
+          }
+          if (current.next != null) {
+            current.next.prev = current.prev;
+          } else {
+            tail = current.prev;
+          }
+          current.prev = null;
+          current.next = null;
+          size--;
+        }
+        current = next;
+      }
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  public boolean isEmpty() {
+    lock.lock();
+    try {
+      return size == 0;
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  public int size() {
+    lock.lock();
+    try {
+      return size;
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  /**
+   * Iterates over all nodes and collects connection string representations.
+   * Used for logging only.
+   *
+   * @param builder the StringBuilder to append to
+   */
+  public void appendTo(final StringBuilder builder) {
+    lock.lock();
+    try {
+      Node current = head;
+      while (current != null) {
+        builder.append("\n\t\t").append(current.connectionRef.get());
+        current = current.next;
+      }
+    } finally {
+      lock.unlock();
+    }
+  }
+}

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/TrackedConnectionListTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/TrackedConnectionListTest.java
@@ -1,0 +1,379 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.jdbc.plugin;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import java.sql.Connection;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class TrackedConnectionListTest {
+
+  private TrackedConnectionList list;
+
+  @BeforeEach
+  void setUp() {
+    list = new TrackedConnectionList();
+  }
+
+  @Test
+  void testNewListIsEmpty() {
+    assertTrue(list.isEmpty());
+    assertEquals(0, list.size());
+  }
+
+  @Test
+  void testAddSingleElement() {
+    final Connection conn = mock(Connection.class);
+    final TrackedConnectionList.Node node = list.add(conn);
+
+    assertNotNull(node);
+    assertFalse(list.isEmpty());
+    assertEquals(1, list.size());
+    assertSame(list, node.ownerList);
+    assertSame(conn, node.connectionRef.get());
+  }
+
+  @Test
+  void testAddMultipleElements() {
+    final Connection conn1 = mock(Connection.class);
+    final Connection conn2 = mock(Connection.class);
+    final Connection conn3 = mock(Connection.class);
+
+    list.add(conn1);
+    list.add(conn2);
+    list.add(conn3);
+
+    assertEquals(3, list.size());
+  }
+
+  @Test
+  void testRemoveHead() {
+    final Connection conn1 = mock(Connection.class);
+    final Connection conn2 = mock(Connection.class);
+    final TrackedConnectionList.Node node1 = list.add(conn1);
+    list.add(conn2);
+
+    list.remove(node1);
+
+    assertEquals(1, list.size());
+    final List<Connection> drained = list.drainAll();
+    assertEquals(1, drained.size());
+    assertSame(conn2, drained.get(0));
+  }
+
+  @Test
+  void testRemoveTail() {
+    final Connection conn1 = mock(Connection.class);
+    final Connection conn2 = mock(Connection.class);
+    list.add(conn1);
+    final TrackedConnectionList.Node node2 = list.add(conn2);
+
+    list.remove(node2);
+
+    assertEquals(1, list.size());
+    final List<Connection> drained = list.drainAll();
+    assertEquals(1, drained.size());
+    assertSame(conn1, drained.get(0));
+  }
+
+  @Test
+  void testRemoveMiddle() {
+    final Connection conn1 = mock(Connection.class);
+    final Connection conn2 = mock(Connection.class);
+    final Connection conn3 = mock(Connection.class);
+    list.add(conn1);
+    final TrackedConnectionList.Node node2 = list.add(conn2);
+    list.add(conn3);
+
+    list.remove(node2);
+
+    assertEquals(2, list.size());
+    final List<Connection> drained = list.drainAll();
+    assertEquals(2, drained.size());
+    assertSame(conn1, drained.get(0));
+    assertSame(conn3, drained.get(1));
+  }
+
+  @Test
+  void testRemoveOnlyElement() {
+    final Connection conn = mock(Connection.class);
+    final TrackedConnectionList.Node node = list.add(conn);
+
+    list.remove(node);
+
+    assertTrue(list.isEmpty());
+    assertEquals(0, list.size());
+  }
+
+  @Test
+  void testRemoveSameNodeTwiceIsIdempotent() {
+    final Connection conn1 = mock(Connection.class);
+    final Connection conn2 = mock(Connection.class);
+    list.add(conn1);
+    final TrackedConnectionList.Node node2 = list.add(conn2);
+
+    list.remove(node2);
+    list.remove(node2);
+
+    assertEquals(1, list.size());
+  }
+
+  @Test
+  void testRemoveNullIsNoOp() {
+    list.add(mock(Connection.class));
+    list.remove(null);
+    assertEquals(1, list.size());
+  }
+
+  @Test
+  void testDrainAllReturnsAllConnections() {
+    final Connection conn1 = mock(Connection.class);
+    final Connection conn2 = mock(Connection.class);
+    list.add(conn1);
+    list.add(conn2);
+
+    final List<Connection> drained = list.drainAll();
+
+    assertEquals(2, drained.size());
+    assertSame(conn1, drained.get(0));
+    assertSame(conn2, drained.get(1));
+    assertTrue(list.isEmpty());
+    assertEquals(0, list.size());
+  }
+
+  @Test
+  void testDrainAllOnEmptyList() {
+    final List<Connection> drained = list.drainAll();
+    assertTrue(drained.isEmpty());
+  }
+
+  @Test
+  void testDrainAllMarksNodesAsRemoved() {
+    final Connection conn = mock(Connection.class);
+    final TrackedConnectionList.Node node = list.add(conn);
+
+    list.drainAll();
+
+    assertTrue(node.removed);
+  }
+
+  @Test
+  void testRemoveIfMatchingPredicate() {
+    final Connection conn1 = mock(Connection.class);
+    final Connection conn2 = mock(Connection.class);
+    final Connection conn3 = mock(Connection.class);
+    list.add(conn1);
+    list.add(conn2);
+    list.add(conn3);
+
+    list.removeIf(ref -> ref.get() == conn2);
+
+    assertEquals(2, list.size());
+    final List<Connection> drained = list.drainAll();
+    assertSame(conn1, drained.get(0));
+    assertSame(conn3, drained.get(1));
+  }
+
+  @Test
+  void testRemoveIfNoMatch() {
+    final Connection conn1 = mock(Connection.class);
+    list.add(conn1);
+
+    list.removeIf(ref -> false);
+
+    assertEquals(1, list.size());
+  }
+
+  @Test
+  void testRemoveIfAllMatch() {
+    list.add(mock(Connection.class));
+    list.add(mock(Connection.class));
+    list.add(mock(Connection.class));
+
+    list.removeIf(ref -> true);
+
+    assertTrue(list.isEmpty());
+  }
+
+  @Test
+  void testRemoveIfGarbageCollectedRefs() {
+    // Add a connection without keeping a strong reference
+    list.add(mock(Connection.class));
+    final Connection kept = mock(Connection.class);
+    list.add(kept);
+
+    // Remove entries where the weak ref has been cleared (simulated by null check)
+    list.removeIf(ref -> ref.get() == null);
+
+    // The mock is still strongly referenced by the test, so nothing should be removed
+    assertEquals(2, list.size());
+  }
+
+  @Test
+  void testRemoveIfRemovesHeadAndTail() {
+    final Connection conn1 = mock(Connection.class);
+    final Connection conn2 = mock(Connection.class);
+    final Connection conn3 = mock(Connection.class);
+    list.add(conn1);
+    list.add(conn2);
+    list.add(conn3);
+
+    list.removeIf(ref -> ref.get() == conn1 || ref.get() == conn3);
+
+    assertEquals(1, list.size());
+    final List<Connection> drained = list.drainAll();
+    assertSame(conn2, drained.get(0));
+  }
+
+  @Test
+  void testAppendToEmptyList() {
+    final StringBuilder builder = new StringBuilder();
+    list.appendTo(builder);
+    assertEquals("", builder.toString());
+  }
+
+  @Test
+  void testAppendToWithElements() {
+    list.add(mock(Connection.class));
+    list.add(mock(Connection.class));
+
+    final StringBuilder builder = new StringBuilder();
+    list.appendTo(builder);
+
+    // Each entry should produce a "\n\t\t" prefix
+    final String result = builder.toString();
+    assertTrue(result.startsWith("\n\t\t"));
+    // Two entries means two occurrences of the prefix
+    assertEquals(2, result.split("\n\t\t").length - 1);
+  }
+
+  @Test
+  void testAddAfterDrainAll() {
+    list.add(mock(Connection.class));
+    list.drainAll();
+
+    final Connection conn = mock(Connection.class);
+    list.add(conn);
+
+    assertEquals(1, list.size());
+    final List<Connection> drained = list.drainAll();
+    assertSame(conn, drained.get(0));
+  }
+
+  @Test
+  void testAddAfterRemoveAll() {
+    final TrackedConnectionList.Node node = list.add(mock(Connection.class));
+    list.remove(node);
+
+    assertTrue(list.isEmpty());
+
+    final Connection conn = mock(Connection.class);
+    list.add(conn);
+    assertEquals(1, list.size());
+  }
+
+  @Test
+  void testRemoveAfterDrainIsNoOp() {
+    final Connection conn = mock(Connection.class);
+    final TrackedConnectionList.Node node = list.add(conn);
+
+    list.drainAll();
+    // Node is already marked removed by drainAll, this should be a no-op
+    list.remove(node);
+
+    assertTrue(list.isEmpty());
+  }
+
+  @Test
+  void testConcurrentAddAndRemove() throws InterruptedException {
+    final int threadCount = 10;
+    final int opsPerThread = 100;
+    final ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+    final CountDownLatch startLatch = new CountDownLatch(1);
+    final CountDownLatch doneLatch = new CountDownLatch(threadCount);
+
+    for (int t = 0; t < threadCount; t++) {
+      executor.submit(() -> {
+        try {
+          startLatch.await();
+          for (int i = 0; i < opsPerThread; i++) {
+            final TrackedConnectionList.Node node = list.add(mock(Connection.class));
+            list.remove(node);
+          }
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        } finally {
+          doneLatch.countDown();
+        }
+      });
+    }
+
+    startLatch.countDown();
+    assertTrue(doneLatch.await(10, TimeUnit.SECONDS));
+    executor.shutdown();
+
+    // All adds were followed by removes, list should be empty
+    assertTrue(list.isEmpty());
+    assertEquals(0, list.size());
+  }
+
+  @Test
+  void testConcurrentAddAndDrain() throws InterruptedException {
+    final int addThreads = 5;
+    final int connectionsPerThread = 50;
+    final CountDownLatch startLatch = new CountDownLatch(1);
+    final CountDownLatch addDoneLatch = new CountDownLatch(addThreads);
+    final ExecutorService executor = Executors.newFixedThreadPool(addThreads + 1);
+
+    for (int t = 0; t < addThreads; t++) {
+      executor.submit(() -> {
+        try {
+          startLatch.await();
+          for (int i = 0; i < connectionsPerThread; i++) {
+            list.add(mock(Connection.class));
+          }
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        } finally {
+          addDoneLatch.countDown();
+        }
+      });
+    }
+
+    startLatch.countDown();
+    assertTrue(addDoneLatch.await(10, TimeUnit.SECONDS));
+
+    // After all adds complete, drain should get everything
+    final List<Connection> drained = list.drainAll();
+    assertEquals(addThreads * connectionsPerThread, drained.size());
+    assertTrue(list.isEmpty());
+
+    executor.shutdown();
+  }
+}


### PR DESCRIPTION
### Summary

Use double-linked list to store connection weak references. Improve performance of removing connection from the tracked connection list when connection closes.

### Description

<!--- Details of what you changed -->

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.