### PR TITLE
docs(bg): note reduced switchover downtime on recent version of Aurora PostgreSQL

### DIFF
--- a/docs/using-the-jdbc-driver/using-plugins/UsingTheBlueGreenPlugin.md
+++ b/docs/using-the-jdbc-driver/using-plugins/UsingTheBlueGreenPlugin.md
@@ -39,6 +39,9 @@ The AWS Advanced JDBC Wrapper leverages the Blue/Green Deployment approach by in
 >
 > **No action is required** if your database does not include the new metadata table -- the driver will continue to operate as before. If you have questions or encounter issues, please open an issue in this repository.
 >
+> Aurora PostgreSQL clusters running Engine Release `17.7, 16.11, 15.15, 14.20, 13.23` or above experience shorter switchover downtime compared to earlier versions.
+> - This improvement follows the source (blue) cluster's engine version.
+>
 > Supported RDS PostgreSQL Versions: `rds_tools v1.7 (17.1, 16.5, 15.9, 14.14, 13.17, 12.21)` and above.<br>
 > Supported Aurora PostgreSQL Versions: Engine Release `17.5, 16.9, 15.13, 14.18, 13.21` and above.<br>
 > Supported Aurora MySQL Versions: Engine Release `3.07` and above.


### PR DESCRIPTION
### Summary

Reduced Blue/Green switchover downtime on recent Aurora PostgreSQL versions affected Blue/Green Deployment Plugin.

### Description

Aurora PostgreSQL engine releases `17.7`, `16.11`, `15.15`, `14.20`, and `13.23` (all released on December 18, 2025) introduced an engine-side improvement that minimizes switchover downtime during Blue/Green switchover operations, and this behavior depends on the engine version of the source (blue) cluster.

The Blue/Green Deployment Plugin coordinates with the underlying switchover, so users running the `bg` plugin on these (or later) engine releases will observe shorter switchover downtime than on earlier versions. Because this directly affects what users experience with the plugin, surfacing this information in the plugin guide seems helpful so users can factor it into upgrade and switchover planning.

This PR updates `docs/using-the-jdbc-driver/using-plugins/UsingTheBlueGreenPlugin.md` to note this version-dependent behavior.

References:
- Aurora PostgreSQL release notes: https://docs.aws.amazon.com/AmazonRDS/latest/AuroraPostgreSQLReleaseNotes/AuroraPostgreSQL.Updates.html

No code changes. Documentation only.


### Additional Reviewers

N/A

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.