### PR TITLE
fix: prevent NPE in HostMonitorServiceV2Impl.getSnapshotState

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/v2/HostMonitorServiceV2Impl.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/v2/HostMonitorServiceV2Impl.java
@@ -185,7 +185,7 @@ public class HostMonitorServiceV2Impl implements HostMonitorService, StateSnapsh
     state.add(Pair.create("failureDetectionTimeMillis", this.failureDetectionTimeMillis));
     state.add(Pair.create("failureDetectionIntervalMillis", this.failureDetectionIntervalMillis));
     state.add(Pair.create("failureDetectionCount", this.failureDetectionCount));
-    state.add(Pair.create("monitorKey", this.monitorKey.toString()));
+    state.add(Pair.create("monitorKey", this.monitorKey == null ? "null" : this.monitorKey.toString()));
     return state;
   }
 


### PR DESCRIPTION
### Summary

Guard `monitorKey.toString()` when `monitorKey` is null to prevent NPE during `Connection.isValid()` calls with the `efm2` plugin and HikariCP.

### Description

Fixes #1896.

`HostMonitorServiceV2Impl.getSnapshotState()` is invoked from `WrapperUtils.addSnapshotState()` whenever the plugin chain collects state, including when HikariCP calls `Connection.isValid()` during `PoolBase.checkValidationSupport()`. This happens before any monitored statement runs, so `startMonitoring()` has not yet initialized `this.monitorKey`, and `monitorKey.toString()` throws NPE.

The fix replaces `this.monitorKey.toString()` on line 188 with a null-guarded expression that emits `"null"` when the key has not been initialized yet, preserving the snapshot key shape for telemetry.

### Additional Reviewers

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.