### PR TITLE
chore: run integration tests by schedule every workday

### DIFF
--- a/.github/workflows/run-integration-tests-default.yml
+++ b/.github/workflows/run-integration-tests-default.yml
@@ -2,10 +2,10 @@ name: Run Aurora Integration Tests Default
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
-      - main-2.x
+  schedule:
+    # Every working day (Mon-Fri) at 8:00 PM PST (4:00 AM UTC next day)
+    # Staggered: runs first, followed by "latest" at 12:30 AM PST, then "mysql-aurora-java-lts" at 5:00 AM PST
+    - cron: '0 4 * * 2-6'
 
 permissions:
   id-token: write   # This is required for requesting the JWT

--- a/.github/workflows/run-integration-tests-latest.yml
+++ b/.github/workflows/run-integration-tests-latest.yml
@@ -2,10 +2,9 @@ name: Run Aurora Integration Tests Latest
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
-      - main-2.x
+  schedule:
+    # Every working day (Mon-Fri) at 12:30 AM PST (8:30 AM UTC), ~4.5 hours after "default"
+    - cron: '30 8 * * 2-6'
 
 permissions:
   id-token: write   # This is required for requesting the JWT

--- a/.github/workflows/run-integration-tests-mysql-aurora-java-lts.yml
+++ b/.github/workflows/run-integration-tests-mysql-aurora-java-lts.yml
@@ -2,6 +2,9 @@ name: Run Integration Tests Latest against Java LTS versions
 
 on:
   workflow_dispatch:
+  schedule:
+    # Every working day (Mon-Fri) at 5:00 AM PST (13:00 UTC), ~4.5 hours after "latest"
+    - cron: '0 13 * * 2-6'
 
 permissions:
   id-token: write   # This is required for requesting the JWT


### PR DESCRIPTION
### Summary

Run integration tests daily by schedule. To minimize quota effect, workflows run sequentially with a few hours shift.

- `run-integration-tests-default` 8:00 PM PST, Mon–Fri
- `run-integration-tests-latest` 12:30 AM PST Tue–Sat
- `run-integration-tests-mysql-aurora-java-lts` 5:00 AM PST Tue–Sat

### Description

<!--- Details of what you changed -->

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.