### PR TITLE
fix: added allowlist classes for CacheResultSet

### DIFF
--- a/docs/using-the-jdbc-driver/UsingTheJdbcDriver.md
+++ b/docs/using-the-jdbc-driver/UsingTheJdbcDriver.md
@@ -445,3 +445,5 @@ Driver.skipWrappingForPackage("com.pgvector");
 This feature can be used to allow the AWS Advanced JDBC Wrapper to properly handle popular database extensions like [PGvector](https://github.com/pgvector/pgvector-java) and [PostGIS](https://github.com/postgis/postgis-java).
 
 Using `Driver.skipWrappingForPackage()` method and using driver configuration parameter `skipWrappingForPackages` are functionally similar. The configuration parameter receives a comma separated list of package names while `Driver.skipWrappingForPackage()` accepts just one package at at time.
+
+> **Security Note:** When using the `RemoteQueryCachePlugin`, classes and packages registered here are also permitted during Java deserialization of cached query results. Since cache data is treated as untrusted input, ensure that any registered third-party classes have safe deserialization behavior (i.e. no dangerous `readObject()` implementations) and cannot be used as part of a gadget chain attack. This does not affect other plugins or driver operations.

--- a/docs/using-the-jdbc-driver/using-plugins/UsingTheRemoteQueryCachePlugin.md
+++ b/docs/using-the-jdbc-driver/using-plugins/UsingTheRemoteQueryCachePlugin.md
@@ -366,5 +366,8 @@ public void main(String status) {
 }
 ```
 
+## Security Considerations
+The Remote Query Cache Plugin uses Java deserialization to reconstruct cached query results from the cache server. Since cache data is treated as untrusted input, deserialization is restricted to a set of known-safe types. If your query results contain third-party types (e.g. from database extensions like PGVector), you must register them via `Driver.skipWrappingForType()` or `Driver.skipWrappingForPackage()` to allow deserialization. Ensure that any registered classes have safe deserialization behavior and cannot be used as part of a gadget chain attack. See [Enable Third Party Classes and Packages](../UsingTheJdbcDriver.md#enable-third-party-classes-and-packages) for details.
+
 ## Other Example Programs
 [DatabaseConnectionWithCacheExample](../../../examples/AWSDriverExample/src/main/java/software/amazon/DatabaseConnectionWithCacheExample.java) demonstrates how to enable and configure Remote Query Cache Plugin with the AWS Advanced JDBC Wrapper.

--- a/wrapper/src/main/java/software/amazon/jdbc/dialect/GlobalAuroraPgDialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/dialect/GlobalAuroraPgDialect.java
@@ -29,7 +29,8 @@ import software.amazon.jdbc.util.Messages;
 
 public class GlobalAuroraPgDialect extends AuroraPgDialect implements GlobalAuroraTopologyDialect {
 
-  protected static final String GLOBAL_STATUS_FUNC_EXISTS_QUERY = "select 'pg_catalog.aurora_global_db_status'::regproc";
+  protected static final String GLOBAL_STATUS_FUNC_EXISTS_QUERY =
+      "select 'pg_catalog.aurora_global_db_status'::regproc";
   protected static final String GLOBAL_INSTANCE_STATUS_FUNC_EXISTS_QUERY =
       "select 'pg_catalog.aurora_global_db_instance_status'::regproc";
 

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/cache/CachedResultSet.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/cache/CachedResultSet.java
@@ -63,6 +63,7 @@ import java.util.Set;
 import java.util.TimeZone;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import software.amazon.jdbc.util.Messages;
+import software.amazon.jdbc.util.WrapperUtils;
 
 public class CachedResultSet implements ResultSet {
 
@@ -193,6 +194,12 @@ public class CachedResultSet implements ResultSet {
             || ZoneId.class.isAssignableFrom(cls)) {
           return cls;
         }
+      }
+      // Allow user-registered third-party classes and packages (via Driver.skipWrappingForType
+      // or Driver.skipWrappingForPackage). See security note in UsingTheJdbcDriver.md.
+      if (WrapperUtils.skipWrappingForClasses.stream().anyMatch(c -> c.getName().equals(className))
+          || WrapperUtils.skipWrappingForPackages.stream().anyMatch(p -> className.startsWith(p + "."))) {
+        return super.resolveClass(desc);
       }
       throw new ClassNotFoundException(
           Messages.get("CachedResultSet.blockedDeserialization", new Object[]{className}));

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/cache/CachedResultSet.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/cache/CachedResultSet.java
@@ -50,8 +50,11 @@ import java.time.OffsetDateTime;
 import java.time.OffsetTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.time.temporal.Temporal;
+import java.time.temporal.TemporalAmount;
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -119,74 +122,23 @@ public class CachedResultSet implements ResultSet {
     static {
       Set<String> allowed = new HashSet<>();
 
-      // --- Internal cache serialization classes ---
+      // Internal cache serialization classes
       allowed.add("software.amazon.jdbc.plugin.cache.CachedResultSetMetaData");
       allowed.add("software.amazon.jdbc.plugin.cache.CachedResultSetMetaData$Field");
       allowed.add("[Lsoftware.amazon.jdbc.plugin.cache.CachedResultSetMetaData$Field;");
       allowed.add("software.amazon.jdbc.plugin.cache.CachedSQLXML");
 
-      // --- Java primitive wrappers ---
+      // Types with no useful base class for isAssignableFrom
       allowed.add("java.lang.String");
-      allowed.add("java.lang.Integer");
-      allowed.add("java.lang.Long");
-      allowed.add("java.lang.Double");
-      allowed.add("java.lang.Float");
-      allowed.add("java.lang.Short");
-      allowed.add("java.lang.Byte");
       allowed.add("java.lang.Boolean");
       allowed.add("java.lang.Character");
-      allowed.add("java.lang.Number");
-      allowed.add("java.math.BigDecimal");
-      allowed.add("java.math.BigInteger");
-
-      // --- SQL/JDBC date and time types ---
-      allowed.add("java.sql.Date");
-      allowed.add("java.sql.Time");
-      allowed.add("java.sql.Timestamp");
-
-      // --- java.time types (modern JDBC drivers) ---
-      allowed.add("java.time.LocalDate");
-      allowed.add("java.time.LocalTime");
-      allowed.add("java.time.LocalDateTime");
-      allowed.add("java.time.OffsetDateTime");
-      allowed.add("java.time.OffsetTime");
-      allowed.add("java.time.ZonedDateTime");
-      allowed.add("java.time.Instant");
-      allowed.add("java.time.ZoneId");
-      allowed.add("java.time.ZoneOffset");
-      allowed.add("java.time.ZoneRegion");
-      allowed.add("java.time.Duration");
-      allowed.add("java.time.Period");
-      allowed.add("java.time.Ser");
-
-      // --- Common JDBC column value types ---
       allowed.add("java.util.UUID");
-      allowed.add("java.util.Date");
       allowed.add("java.net.URL");
       allowed.add("java.net.URI");
+      // Package-private JVM serialization proxy for java.time types; cannot be referenced by class literal
+      allowed.add("java.time.Ser");
 
-      // --- Java collections (can appear as column values from getObject()) ---
-      allowed.add("java.util.ArrayList");
-      allowed.add("java.util.LinkedList");
-      allowed.add("java.util.HashSet");
-      allowed.add("java.util.LinkedHashSet");
-      allowed.add("java.util.TreeSet");
-      allowed.add("java.util.HashMap");
-      allowed.add("java.util.LinkedHashMap");
-      allowed.add("java.util.TreeMap");
-      allowed.add("java.util.Collections$EmptyList");
-      allowed.add("java.util.Collections$EmptyMap");
-      allowed.add("java.util.Collections$EmptySet");
-      allowed.add("java.util.Collections$SingletonList");
-      allowed.add("java.util.Collections$SingletonMap");
-      allowed.add("java.util.Collections$SingletonSet");
-      allowed.add("java.util.Collections$UnmodifiableList");
-      allowed.add("java.util.Collections$UnmodifiableMap");
-      allowed.add("java.util.Collections$UnmodifiableSet");
-      allowed.add("java.util.Collections$UnmodifiableRandomAccessList");
-      allowed.add("java.util.Arrays$ArrayList");
-
-      // --- Byte and primitive arrays ---
+      // Primitive arrays
       allowed.add("[B");
       allowed.add("[I");
       allowed.add("[J");
@@ -196,7 +148,7 @@ public class CachedResultSet implements ResultSet {
       allowed.add("[C");
       allowed.add("[Z");
 
-      // --- Object arrays (JDBC Array types can produce these) ---
+      // Object arrays
       allowed.add("[Ljava.lang.Object;");
       allowed.add("[Ljava.lang.String;");
       allowed.add("[Ljava.lang.Integer;");
@@ -219,11 +171,31 @@ public class CachedResultSet implements ResultSet {
     protected Class<?> resolveClass(ObjectStreamClass desc)
         throws IOException, ClassNotFoundException {
       String className = desc.getName();
-      if (!ALLOWED_CLASSES.contains(className)) {
-        throw new ClassNotFoundException(
-            Messages.get("CachedResultSet.blockedDeserialization", new Object[]{className}));
+      if (ALLOWED_CLASSES.contains(className)) {
+        return super.resolveClass(desc);
       }
-      return super.resolveClass(desc);
+      // Only load classes from standard Java/javax packages for dynamic hierarchy checks.
+      // Never call super.resolveClass for third-party or application classes — loading them
+      // before throwing gives the JVM a window to invoke readObject() on a partially
+      // constructed object in some implementations.
+      if (className.startsWith("java.") || className.startsWith("javax.")) {
+        Class<?> cls = super.resolveClass(desc);
+        // Supported data types for deserialization. To support additional JDBC types
+        // (e.g. CLOB, BLOB, Array), add the corresponding base class or interface here.
+        if (Number.class.isAssignableFrom(cls)
+            || Collection.class.isAssignableFrom(cls)
+            || Map.class.isAssignableFrom(cls)
+            || java.util.Date.class.isAssignableFrom(cls)
+            || RowId.class.isAssignableFrom(cls)
+            || SQLXML.class.isAssignableFrom(cls)
+            || Temporal.class.isAssignableFrom(cls)
+            || TemporalAmount.class.isAssignableFrom(cls)
+            || ZoneId.class.isAssignableFrom(cls)) {
+          return cls;
+        }
+      }
+      throw new ClassNotFoundException(
+          Messages.get("CachedResultSet.blockedDeserialization", new Object[]{className}));
     }
   }
 
@@ -349,7 +321,7 @@ public class CachedResultSet implements ResultSet {
         resultRows.add(row);
       }
       return new CachedResultSet(metadata, resultRows);
-    } catch (ClassNotFoundException e) {
+    } catch (ClassNotFoundException | ClassCastException e) {
       throw new SQLException(Messages.get("CachedResultSet.classNotFoundDeserializeResultSet"), e);
     } catch (IOException e) {
       throw new SQLException(Messages.get("CachedResultSet.ioExceptionDeserializeResultSet"), e);

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/cache/CachedResultSet.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/cache/CachedResultSet.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.ObjectStreamClass;
 import java.io.Reader;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -51,8 +52,11 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.TimeZone;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import software.amazon.jdbc.util.Messages;
@@ -89,7 +93,7 @@ public class CachedResultSet implements ResultSet {
       // De-serialize the data object from raw bytes if needed.
       if (rowData[columnIndex - 1] == null && rawData[columnIndex - 1] != null) {
         try (ByteArrayInputStream bis = new ByteArrayInputStream(rawData[columnIndex - 1]);
-             ObjectInputStream ois = new ObjectInputStream(bis)) {
+             ObjectInputStream ois = new SafeObjectInputStream(bis)) {
           rowData[columnIndex - 1] = ois.readObject();
           rawData[columnIndex - 1] = null;
         } catch (ClassNotFoundException e) {
@@ -100,6 +104,126 @@ public class CachedResultSet implements ResultSet {
         }
       }
       return rowData[columnIndex - 1];
+    }
+  }
+
+  /**
+   * A restricted ObjectInputStream that only allows deserialization of known-safe classes.
+   * This prevents Remote Code Execution via cache poisoning attacks where an attacker
+   * injects malicious serialized objects (gadget chains) into the remote cache.
+   *
+   */
+  private static class SafeObjectInputStream extends ObjectInputStream {
+    private static final Set<String> ALLOWED_CLASSES;
+
+    static {
+      Set<String> allowed = new HashSet<>();
+
+      // --- Internal cache serialization classes ---
+      allowed.add("software.amazon.jdbc.plugin.cache.CachedResultSetMetaData");
+      allowed.add("software.amazon.jdbc.plugin.cache.CachedResultSetMetaData$Field");
+      allowed.add("[Lsoftware.amazon.jdbc.plugin.cache.CachedResultSetMetaData$Field;");
+      allowed.add("software.amazon.jdbc.plugin.cache.CachedSQLXML");
+
+      // --- Java primitive wrappers ---
+      allowed.add("java.lang.String");
+      allowed.add("java.lang.Integer");
+      allowed.add("java.lang.Long");
+      allowed.add("java.lang.Double");
+      allowed.add("java.lang.Float");
+      allowed.add("java.lang.Short");
+      allowed.add("java.lang.Byte");
+      allowed.add("java.lang.Boolean");
+      allowed.add("java.lang.Character");
+      allowed.add("java.lang.Number");
+      allowed.add("java.math.BigDecimal");
+      allowed.add("java.math.BigInteger");
+
+      // --- SQL/JDBC date and time types ---
+      allowed.add("java.sql.Date");
+      allowed.add("java.sql.Time");
+      allowed.add("java.sql.Timestamp");
+
+      // --- java.time types (modern JDBC drivers) ---
+      allowed.add("java.time.LocalDate");
+      allowed.add("java.time.LocalTime");
+      allowed.add("java.time.LocalDateTime");
+      allowed.add("java.time.OffsetDateTime");
+      allowed.add("java.time.OffsetTime");
+      allowed.add("java.time.ZonedDateTime");
+      allowed.add("java.time.Instant");
+      allowed.add("java.time.ZoneId");
+      allowed.add("java.time.ZoneOffset");
+      allowed.add("java.time.ZoneRegion");
+      allowed.add("java.time.Duration");
+      allowed.add("java.time.Period");
+      allowed.add("java.time.Ser");
+
+      // --- Common JDBC column value types ---
+      allowed.add("java.util.UUID");
+      allowed.add("java.util.Date");
+      allowed.add("java.net.URL");
+      allowed.add("java.net.URI");
+
+      // --- Java collections (can appear as column values from getObject()) ---
+      allowed.add("java.util.ArrayList");
+      allowed.add("java.util.LinkedList");
+      allowed.add("java.util.HashSet");
+      allowed.add("java.util.LinkedHashSet");
+      allowed.add("java.util.TreeSet");
+      allowed.add("java.util.HashMap");
+      allowed.add("java.util.LinkedHashMap");
+      allowed.add("java.util.TreeMap");
+      allowed.add("java.util.Collections$EmptyList");
+      allowed.add("java.util.Collections$EmptyMap");
+      allowed.add("java.util.Collections$EmptySet");
+      allowed.add("java.util.Collections$SingletonList");
+      allowed.add("java.util.Collections$SingletonMap");
+      allowed.add("java.util.Collections$SingletonSet");
+      allowed.add("java.util.Collections$UnmodifiableList");
+      allowed.add("java.util.Collections$UnmodifiableMap");
+      allowed.add("java.util.Collections$UnmodifiableSet");
+      allowed.add("java.util.Collections$UnmodifiableRandomAccessList");
+      allowed.add("java.util.Arrays$ArrayList");
+
+      // --- Byte and primitive arrays ---
+      allowed.add("[B");
+      allowed.add("[I");
+      allowed.add("[J");
+      allowed.add("[D");
+      allowed.add("[F");
+      allowed.add("[S");
+      allowed.add("[C");
+      allowed.add("[Z");
+
+      // --- Object arrays (JDBC Array types can produce these) ---
+      allowed.add("[Ljava.lang.Object;");
+      allowed.add("[Ljava.lang.String;");
+      allowed.add("[Ljava.lang.Integer;");
+      allowed.add("[Ljava.lang.Long;");
+      allowed.add("[Ljava.lang.Double;");
+      allowed.add("[Ljava.lang.Float;");
+      allowed.add("[Ljava.lang.Short;");
+      allowed.add("[Ljava.lang.Byte;");
+      allowed.add("[Ljava.lang.Boolean;");
+      allowed.add("[Ljava.math.BigDecimal;");
+
+      ALLOWED_CLASSES = Collections.unmodifiableSet(allowed);
+    }
+
+    SafeObjectInputStream(InputStream in) throws IOException {
+      super(in);
+    }
+
+    @Override
+    protected Class<?> resolveClass(ObjectStreamClass desc)
+        throws IOException, ClassNotFoundException {
+      String className = desc.getName();
+      if (!ALLOWED_CLASSES.contains(className)) {
+        throw new ClassNotFoundException(
+            Messages.get("CachedResultSet.blockedDeserialization", new Object[]{className}));
+      }
+      return super.resolveClass(desc);
     }
   }
 
@@ -201,7 +325,7 @@ public class CachedResultSet implements ResultSet {
    */
   public static ResultSet deserializeFromByteArray(byte[] data) throws SQLException {
     try (ByteArrayInputStream bis = new ByteArrayInputStream(data);
-         ObjectInputStream ois = new ObjectInputStream(bis)) {
+         ObjectInputStream ois = new SafeObjectInputStream(bis)) {
       CachedResultSetMetaData metadata = (CachedResultSetMetaData) ois.readObject();
       int numRows = ois.readInt();
       int numColumns = metadata.getColumnCount();

--- a/wrapper/src/main/resources/aws_advanced_jdbc_wrapper_messages.properties
+++ b/wrapper/src/main/resources/aws_advanced_jdbc_wrapper_messages.properties
@@ -186,6 +186,7 @@ CachedResultSet.columnNotFoundInResultSet=The column {0} is not found in this Re
 CachedResultSet.cannotExtractUrl=Cannot extract url: {0}
 CachedResultSet.cannotExtractRowId=Cannot extract rowId: {0}
 CachedResultSet.cannotUnwrap=Cannot unwrap to {0}
+CachedResultSet.blockedDeserialization=Deserialization of class [{0}] is not allowed. Only known-safe types can be deserialized from cache data.
 
 # CachedResultSetMetaData exception messages
 CachedResultSetMetaData.wrongColumnNumber=Wrong column number: {0}

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/cache/CachedResultSetTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/cache/CachedResultSetTest.java
@@ -58,6 +58,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import software.amazon.jdbc.util.WrapperUtils;
 
 public class CachedResultSetTest {
   private CachedResultSet testResultSet;
@@ -1021,6 +1022,59 @@ public class CachedResultSetTest {
     row.putRaw(1, blockedBytes);
 
     assertThrows(SQLException.class, () -> row.get(1));
+  }
+
+  static class ThirdPartyType implements Serializable {
+    private static final long serialVersionUID = 1L;
+    final String value;
+
+    ThirdPartyType(String value) {
+      this.value = value;
+    }
+  }
+
+  @Test
+  void test_user_registered_class_allowed_in_deserialization() throws Exception {
+    WrapperUtils.skipWrappingForClasses.add(ThirdPartyType.class);
+    try {
+      byte[] serialized;
+      try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+           ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+        oos.writeObject(new ThirdPartyType("test"));
+        oos.flush();
+        serialized = baos.toByteArray();
+      }
+      CachedResultSet.CachedRow row = new CachedResultSet.CachedRow(1);
+      row.putRaw(1, serialized);
+      Object result = row.get(1);
+      assertNotNull(result);
+      assertEquals(ThirdPartyType.class, result.getClass());
+      assertEquals("test", ((ThirdPartyType) result).value);
+    } finally {
+      WrapperUtils.skipWrappingForClasses.remove(ThirdPartyType.class);
+    }
+  }
+
+  @Test
+  void test_user_registered_package_allowed_in_deserialization() throws Exception {
+    String packageName = ThirdPartyType.class.getPackage().getName();
+    WrapperUtils.skipWrappingForPackages.add(packageName);
+    try {
+      byte[] serialized;
+      try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+           ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+        oos.writeObject(new ThirdPartyType("test"));
+        oos.flush();
+        serialized = baos.toByteArray();
+      }
+      CachedResultSet.CachedRow row = new CachedResultSet.CachedRow(1);
+      row.putRaw(1, serialized);
+      Object result = row.get(1);
+      assertNotNull(result);
+      assertEquals(ThirdPartyType.class, result.getClass());
+    } finally {
+      WrapperUtils.skipWrappingForPackages.remove(packageName);
+    }
   }
 
   @Test

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/cache/CachedResultSetTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/cache/CachedResultSetTest.java
@@ -19,6 +19,7 @@ package software.amazon.jdbc.plugin.cache;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -26,6 +27,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.when;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
 import java.math.BigDecimal;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -47,6 +52,7 @@ import java.time.ZonedDateTime;
 import java.util.Calendar;
 import java.util.HashSet;
 import java.util.TimeZone;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -905,6 +911,116 @@ public class CachedResultSetTest {
     // Test invalid unwrap attempts should throw SQLException
     assertThrows(SQLException.class, () -> cachedRs.unwrap(String.class));
     assertThrows(SQLException.class, () -> cachedRs.unwrap(Integer.class));
+  }
+
+  static class MaliciousPayload implements Serializable {
+    private static final long serialVersionUID = 1L;
+    static final AtomicBoolean CODE_EXECUTED = new AtomicBoolean(false);
+
+    private void readObject(java.io.ObjectInputStream in) throws IOException, ClassNotFoundException {
+      in.defaultReadObject();
+      CODE_EXECUTED.set(true);
+    }
+  }
+
+  @Test
+  void test_malicious_payload_blocked_in_deserialize_from_byte_array() throws IOException {
+    MaliciousPayload.CODE_EXECUTED.set(false);
+
+    byte[] maliciousBytes;
+    try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+         ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+      oos.writeObject(new MaliciousPayload());
+      oos.flush();
+      maliciousBytes = baos.toByteArray();
+    }
+
+    assertThrows(SQLException.class, () -> CachedResultSet.deserializeFromByteArray(maliciousBytes));
+    assertFalse(MaliciousPayload.CODE_EXECUTED.get(),
+        "Malicious readObject() must not execute before the class is blocked");
+  }
+
+  @Test
+  void test_wrong_metadata_type_throws_in_deserialize() throws IOException {
+    // Serialize a non-CachedResultSetMetaData object in place of metadata
+    byte[] corruptedBytes;
+    try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+         ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+      oos.writeObject("not-a-metadata-object");
+      oos.flush();
+      corruptedBytes = baos.toByteArray();
+    }
+    assertThrows(SQLException.class, () -> CachedResultSet.deserializeFromByteArray(corruptedBytes));
+  }
+
+  @Test
+  void test_primitive_array_round_trip() throws Exception {
+    Object[] primitiveArrays = {
+        new int[]{1, 2, 3},
+        new long[]{100L, 200L},
+        new double[]{1.1, 2.2},
+        new float[]{3.3f, 4.4f},
+        new short[]{10, 20},
+        new char[]{'a', 'b'},
+        new boolean[]{true, false}
+    };
+    for (Object arr : primitiveArrays) {
+      byte[] serialized;
+      try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+           ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+        oos.writeObject(arr);
+        oos.flush();
+        serialized = baos.toByteArray();
+      }
+      CachedResultSet.CachedRow row = new CachedResultSet.CachedRow(1);
+      row.putRaw(1, serialized);
+      // Verify deserialization succeeded and type is preserved
+      assertNotNull(row.get(1));
+      assertEquals(arr.getClass(), row.get(1).getClass());
+    }
+  }
+
+  @Test
+  void test_object_array_round_trip() throws Exception {
+    Object[][] objectArrays = {
+        new String[]{"a", "b"},
+        new Integer[]{1, 2},
+        new Long[]{1L, 2L},
+        new Double[]{1.0, 2.0},
+        new Float[]{1.0f, 2.0f},
+        new Short[]{1, 2},
+        new Byte[]{1, 2},
+        new Boolean[]{true, false},
+        new BigDecimal[]{new BigDecimal("1.23"), new BigDecimal("4.56")}
+    };
+    for (Object arr : objectArrays) {
+      byte[] serialized;
+      try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+           ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+        oos.writeObject(arr);
+        oos.flush();
+        serialized = baos.toByteArray();
+      }
+      CachedResultSet.CachedRow row = new CachedResultSet.CachedRow(1);
+      row.putRaw(1, serialized);
+      assertArrayEquals((Object[]) arr, (Object[]) row.get(1));
+    }
+  }
+
+  @Test
+  void test_blocked_type_rejected_in_lazy_deserialization() throws Exception {
+    byte[] blockedBytes;
+    try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+         ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+      oos.writeObject(new MaliciousPayload());
+      oos.flush();
+      blockedBytes = baos.toByteArray();
+    }
+
+    CachedResultSet.CachedRow row = new CachedResultSet.CachedRow(1);
+    row.putRaw(1, blockedBytes);
+
+    assertThrows(SQLException.class, () -> row.get(1));
   }
 
   @Test


### PR DESCRIPTION
### Summary

Fix unsafe Java deserialization issue in RemoteQueryCachePlugin

### Description

**Fix:** Added `SafeObjectInputStream` that overrides `resolveClass()` with a class allowlist. Non-allowlisted classes are rejected before instantiation, blocking gadget chains. Compatible with all Java 8+ (no `ObjectInputFilter` dependency). Unknown types gracefully fall back to cache miss.

**Files changed:**
- `CachedResultSet.java` — added `SafeObjectInputStream`, replaced `ObjectInputStream` at both deserialization points
- `aws_advanced_jdbc_wrapper_messages.properties` — added blocked deserialization error message

### Additional Reviewers

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.