### PR TITLE
fix: release resources and stop lingering background threads

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/Driver.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/Driver.java
@@ -34,6 +34,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import software.amazon.jdbc.ConnectionProviderManager.ConnectionInitFunc;
 import software.amazon.jdbc.authentication.AwsCredentialsManager;
+import software.amazon.jdbc.cleanup.CanReleaseResources;
 import software.amazon.jdbc.dialect.Dialect;
 import software.amazon.jdbc.dialect.DialectManager;
 import software.amazon.jdbc.exceptions.ExceptionHandler;
@@ -58,6 +59,7 @@ import software.amazon.jdbc.util.RdsUtils;
 import software.amazon.jdbc.util.ServiceUtility;
 import software.amazon.jdbc.util.StringUtils;
 import software.amazon.jdbc.util.WrapperUtils;
+import software.amazon.jdbc.util.events.BatchingEventPublisher;
 import software.amazon.jdbc.util.events.EventPublisher;
 import software.amazon.jdbc.util.monitoring.MonitorService;
 import software.amazon.jdbc.util.storage.StorageService;
@@ -447,7 +449,13 @@ public class Driver implements java.sql.Driver {
   }
 
   public static void releaseResources() {
-    CoreServicesContainer.getInstance().getMonitorService().stopAndRemoveAll();
+    CoreServicesContainer.getInstance().getMonitorService().releaseResources();
+    StorageService storageService = CoreServicesContainer.getInstance().getStorageService();
+    if (storageService instanceof CanReleaseResources) {
+      ((CanReleaseResources) storageService).releaseResources();
+    }
+    BatchingEventPublisher.releaseResources();
+    OpenedConnectionTracker.releaseResources();
     ConnectionProviderManager.releaseResources();
     InternalConnectionPoolService.releaseResources();
     HikariPoolsHolder.closeAllPools();

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/OpenedConnectionTracker.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/OpenedConnectionTracker.java
@@ -16,7 +16,6 @@
 
 package software.amazon.jdbc.plugin;
 
-import java.lang.ref.WeakReference;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Arrays;
@@ -252,6 +251,12 @@ public class OpenedConnectionTracker {
   }
 
   public static void clearCache() {
+    openedConnections.clear();
+  }
+
+  public static void releaseResources() {
+    pruneConnectionsExecutorService.shutdownNow();
+    invalidateConnectionsExecutorService.shutdownNow();
     openedConnections.clear();
   }
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/util/events/BatchingEventPublisher.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/events/BatchingEventPublisher.java
@@ -105,4 +105,8 @@ public class BatchingEventPublisher implements EventPublisher {
       eventMessages.add(event);
     }
   }
+
+  public static void releaseResources() {
+    publishingExecutor.shutdownNow();
+  }
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/util/storage/StorageServiceImpl.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/storage/StorageServiceImpl.java
@@ -29,17 +29,17 @@ import java.util.logging.Logger;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import software.amazon.jdbc.AllowedAndBlockedHosts;
+import software.amazon.jdbc.cleanup.CanReleaseResources;
 import software.amazon.jdbc.hostlistprovider.Topology;
 import software.amazon.jdbc.plugin.bluegreen.BlueGreenStatus;
 import software.amazon.jdbc.util.ExecutorFactory;
 import software.amazon.jdbc.util.Messages;
 import software.amazon.jdbc.util.Pair;
-import software.amazon.jdbc.util.StateSnapshotProvider;
 import software.amazon.jdbc.util.WrapperUtils;
 import software.amazon.jdbc.util.events.DataAccessEvent;
 import software.amazon.jdbc.util.events.EventPublisher;
 
-public class StorageServiceImpl implements StorageService {
+public class StorageServiceImpl implements StorageService, CanReleaseResources {
   private static final Logger LOGGER = Logger.getLogger(StorageServiceImpl.class.getName());
   protected static final long DEFAULT_CLEANUP_INTERVAL_NANOS = TimeUnit.MINUTES.toNanos(5);
   protected static final Map<Class<?>, Supplier<ExpirationCache<Object, ?>>> defaultCacheSuppliers;
@@ -181,6 +181,12 @@ public class StorageServiceImpl implements StorageService {
     for (ExpirationCache<Object, ?> cache : caches.values()) {
       cache.clear();
     }
+  }
+
+  @Override
+  public void releaseResources() {
+    cleanupExecutor.shutdownNow();
+    clearAll();
   }
 
   @Override

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/cache/CacheMonitorTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/cache/CacheMonitorTest.java
@@ -466,7 +466,7 @@ public class CacheMonitorTest {
     sleepCount.set(0);
     CacheMonitor finalSpy1 = spy;
     doAnswer(inv -> {
-      if (sleepCount.incrementAndGet() >= 2) {  // ← ADD counter check back
+      if (sleepCount.incrementAndGet() >= 2) {  // ADD counter check back
         Field stopField = AbstractMonitor.class.getDeclaredField("stop");
         stopField.setAccessible(true);
         ((AtomicBoolean) stopField.get(finalSpy1)).set(true);


### PR DESCRIPTION
### Summary

https://github.com/aws/aws-advanced-jdbc-wrapper/issues/1878

`Driver.releaseResources()` now shuts down all internal `ScheduledExecutorService` thread pools, ensuring background threads terminate promptly on cleanup.

### Description

The wrapper creates several static ScheduledExecutorService instances for background tasks (connection pruning, event batching, cache cleanup). These threads are daemon threads, so they don't block normal JVM exit. However, Driver.releaseResources() did not shut them down, leaving them alive in the thread group. This causes issues for modular frameworks that wait for all threads in a module's thread group to terminate before considering the module stopped.

Affected executors not previously shut down:
- OpenedConnectionTracker — pruneConnection and invalidateConnection threads
- BatchingEventPublisher — bep thread
- StorageServiceImpl — ssi thread

Changes:
- **OpenedConnectionTracker** — Added static releaseResources() that calls shutdownNow() on both executor services
- **BatchingEventPublisher** — Added static releaseResources() that calls shutdownNow() on the publishing executor
- **StorageServiceImpl** — Now implements CanReleaseResources; releaseResources() shuts down the cleanup executor
- **Driver.releaseResources()** — Updated to call all new shutdown methods, and now calls MonitorService.releaseResources() (which also shuts down its executor) instead of just stopAndRemoveAll()

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.