### PR TITLE
fix: issue with localhost in efm/efm2 plugin

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/base/HostMonitoringConnectionBasePlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/base/HostMonitoringConnectionBasePlugin.java
@@ -262,14 +262,11 @@ public abstract class HostMonitoringConnectionBasePlugin extends AbstractConnect
           this.monitoringHostSpec = this.pluginService.identifyConnection(
               this.pluginService.getCurrentConnection(), this.pluginService.getCurrentHostSpec());
           if (this.monitoringHostSpec == null) {
-            throw new RuntimeException(Messages.get(
-                "HostMonitoringConnectionPlugin.unableToIdentifyConnection",
-                new Object[] {
-                    this.pluginService.getCurrentHostSpec().getHost(),
-                    this.pluginService.getHostListProvider()}));
+            this.monitoringHostSpec = this.pluginService.getCurrentHostSpec();
+          } else {
+            // Update identified HostSpec for the current connection
+            this.pluginService.setCurrentConnection(this.pluginService.getCurrentConnection(), this.monitoringHostSpec);
           }
-          // Update identified HostSpec for the current connection
-          this.pluginService.setCurrentConnection(this.pluginService.getCurrentConnection(), this.monitoringHostSpec);
         }
       } catch (SQLException e) {
         // Log and throw.

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/base/HostMonitoringConnectionBasePlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/base/HostMonitoringConnectionBasePlugin.java
@@ -259,14 +259,11 @@ public abstract class HostMonitoringConnectionBasePlugin extends AbstractConnect
         if (rdsUrlType != RdsUrlType.RDS_INSTANCE) {
           LOGGER.finest("Monitoring HostSpec is associated with a cluster endpoint, "
               + "plugin needs to identify the cluster connection.");
-          this.monitoringHostSpec = this.pluginService.identifyConnection(
+          final HostSpec identifiedHostSpec = this.pluginService.identifyConnection(
               this.pluginService.getCurrentConnection(), this.pluginService.getCurrentHostSpec());
-          if (this.monitoringHostSpec == null) {
-            this.monitoringHostSpec = this.pluginService.getRoutedHostSpec() != null
-                ? this.pluginService.getRoutedHostSpec()
-                : this.pluginService.getCurrentHostSpec();
-          } else {
+          if (identifiedHostSpec != null) {
             // Update identified HostSpec for the current connection
+            this.monitoringHostSpec = identifiedHostSpec;
             this.pluginService.setCurrentConnection(this.pluginService.getCurrentConnection(), this.monitoringHostSpec);
           }
         }

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/base/HostMonitoringConnectionBasePlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/base/HostMonitoringConnectionBasePlugin.java
@@ -262,7 +262,9 @@ public abstract class HostMonitoringConnectionBasePlugin extends AbstractConnect
           this.monitoringHostSpec = this.pluginService.identifyConnection(
               this.pluginService.getCurrentConnection(), this.pluginService.getCurrentHostSpec());
           if (this.monitoringHostSpec == null) {
-            this.monitoringHostSpec = this.pluginService.getCurrentHostSpec();
+            this.monitoringHostSpec = this.pluginService.getRoutedHostSpec() != null
+                ? this.pluginService.getRoutedHostSpec()
+                : this.pluginService.getCurrentHostSpec();
           } else {
             // Update identified HostSpec for the current connection
             this.pluginService.setCurrentConnection(this.pluginService.getCurrentConnection(), this.monitoringHostSpec);

--- a/wrapper/src/main/resources/aws_advanced_jdbc_wrapper_messages.properties
+++ b/wrapper/src/main/resources/aws_advanced_jdbc_wrapper_messages.properties
@@ -273,7 +273,6 @@ HostAvailabilityStrategy.invalidInitialBackoffTime=Invalid value of {0}  for con
 HostMonitoringConnectionPlugin.activatedMonitoring=Executing method ''{0}'', monitoring is activated.
 HostMonitoringConnectionPlugin.monitoringDeactivated=Monitoring deactivated for method ''{0}''.
 HostMonitoringConnectionPlugin.errorIdentifyingConnection=Error occurred while identifying connection: ''{0}''.
-HostMonitoringConnectionPlugin.unableToIdentifyConnection=Unable to identify the given connection: ''{0}'', please ensure the correct host list provider is specified. The host list provider in use is: ''{1}''.
 
 HostSelector.roundRobinInvalidHostWeightPairs=The provided host weight pairs have not been configured correctly. Please ensure the provided host weight pairs is a comma separated list of pairs, each pair in the format of <host>:<weight>. Weight values must be an integer greater than or equal to the default weight value of 1.
 HostSelector.roundRobinInvalidDefaultWeight=The provided default weight value is not valid. Weight values must be an integer greater than or equal to the default weight value of 1.


### PR DESCRIPTION
### Summary

Fixes an issue where efm/efm2 plugins throw a RuntimeException ("Unable to identify the given connection") when used with non-RDS URLs such as localhost, custom hostnames, or IP addresses.
https://github.com/aws/aws-advanced-jdbc-wrapper/issues/1896

### Description

When identifyConnection() returns null, keep the original monitoringHostSpec (from getCurrentHostSpec() or getRoutedHostSpec()) instead of throwing a RuntimeException. This allows EFM to monitor the connection using the host from the connection string.

- Preserves the design intent: all non-RDS_INSTANCE connections still attempt identification. RDS cluster endpoints continue to be resolved correctly.
- Graceful degradation: when identification fails for non-RDS URLs, the plugin uses the connection string host — which is valid for monitoring purposes.
- No behavioural change for RDS users.
- Fixes both efm and efm2 since they share the same base class.

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.