### PR TITLE
fix: make static executors recreatable after releaseResources()

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/OpenedConnectionTracker.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/OpenedConnectionTracker.java
@@ -34,6 +34,7 @@ import software.amazon.jdbc.PluginService;
 import software.amazon.jdbc.util.ExecutorFactory;
 import software.amazon.jdbc.util.Messages;
 import software.amazon.jdbc.util.RdsUtils;
+import software.amazon.jdbc.util.ResourceLock;
 import software.amazon.jdbc.util.StringUtils;
 import software.amazon.jdbc.util.SynchronousExecutor;
 import software.amazon.jdbc.util.telemetry.TelemetryContext;
@@ -45,10 +46,9 @@ public class OpenedConnectionTracker {
   static final Map<String, TrackedConnectionList> openedConnections = new ConcurrentHashMap<>();
   private static final String TELEMETRY_INVALIDATE_CONNECTIONS = "invalidate connections";
   private static final int PRUNE_INTERVAL_SEC = 30;
-  private static final ScheduledExecutorService pruneConnectionsExecutorService =
-      ExecutorFactory.newSingleThreadScheduledThreadExecutor("pruneConnection");
-  private static final ExecutorService invalidateConnectionsExecutorService =
-      ExecutorFactory.newCachedThreadPool("invalidateConnection");
+  private static final ResourceLock lock = new ResourceLock();
+  private static volatile ScheduledExecutorService pruneConnectionsExecutorService;
+  private static volatile ExecutorService invalidateConnectionsExecutorService;
   private static final Executor abortConnectionExecutor = new SynchronousExecutor();
 
   private static final Logger LOGGER = Logger.getLogger(OpenedConnectionTracker.class.getName());
@@ -62,9 +62,34 @@ public class OpenedConnectionTracker {
 
   private final PluginService pluginService;
 
-  static {
-    pruneConnectionsExecutorService.scheduleAtFixedRate(
-        OpenedConnectionTracker::pruneConnections, PRUNE_INTERVAL_SEC, PRUNE_INTERVAL_SEC, TimeUnit.SECONDS);
+  private static ScheduledExecutorService getOrCreatePruneExecutor() {
+    ScheduledExecutorService executor = pruneConnectionsExecutorService;
+    if (executor == null || executor.isShutdown()) {
+      try (ResourceLock ignored = lock.obtain()) {
+        executor = pruneConnectionsExecutorService;
+        if (executor == null || executor.isShutdown()) {
+          executor = ExecutorFactory.newSingleThreadScheduledThreadExecutor("pruneConnection");
+          executor.scheduleAtFixedRate(
+              OpenedConnectionTracker::pruneConnections, PRUNE_INTERVAL_SEC, PRUNE_INTERVAL_SEC, TimeUnit.SECONDS);
+          pruneConnectionsExecutorService = executor;
+        }
+      }
+    }
+    return executor;
+  }
+
+  private static ExecutorService getOrCreateInvalidateExecutor() {
+    ExecutorService executor = invalidateConnectionsExecutorService;
+    if (executor == null || executor.isShutdown()) {
+      try (ResourceLock ignored = lock.obtain()) {
+        executor = invalidateConnectionsExecutorService;
+        if (executor == null || executor.isShutdown()) {
+          executor = ExecutorFactory.newCachedThreadPool("invalidateConnection");
+          invalidateConnectionsExecutorService = executor;
+        }
+      }
+    }
+    return executor;
   }
 
   public OpenedConnectionTracker(final PluginService pluginService) {
@@ -176,6 +201,7 @@ public class OpenedConnectionTracker {
     if (connection == null) {
       return null;
     }
+    getOrCreatePruneExecutor();
     final TrackedConnectionList connectionList =
         openedConnections.computeIfAbsent(
             instanceEndpoint,
@@ -187,7 +213,7 @@ public class OpenedConnectionTracker {
     if (connectionList == null || connectionList.isEmpty()) {
       return;
     }
-    invalidateConnectionsExecutorService.submit(() -> {
+    getOrCreateInvalidateExecutor().submit(() -> {
       final List<Connection> connections = connectionList.drainAll();
       for (final Connection conn : connections) {
         try {
@@ -255,8 +281,14 @@ public class OpenedConnectionTracker {
   }
 
   public static void releaseResources() {
-    pruneConnectionsExecutorService.shutdownNow();
-    invalidateConnectionsExecutorService.shutdownNow();
-    openedConnections.clear();
+    try (ResourceLock ignored = lock.obtain()) {
+      if (pruneConnectionsExecutorService != null) {
+        pruneConnectionsExecutorService.shutdownNow();
+      }
+      if (invalidateConnectionsExecutorService != null) {
+        invalidateConnectionsExecutorService.shutdownNow();
+      }
+      openedConnections.clear();
+    }
   }
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/util/events/BatchingEventPublisher.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/events/BatchingEventPublisher.java
@@ -25,6 +25,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import software.amazon.jdbc.util.ExecutorFactory;
+import software.amazon.jdbc.util.ResourceLock;
 
 /**
  * An event publisher that periodically publishes a batch of all unique events encountered during the latest time
@@ -37,8 +38,10 @@ public class BatchingEventPublisher implements EventPublisher {
   // ConcurrentHashMap.newKeySet() is the recommended way to get a concurrent set. A set is used to prevent duplicate
   // event messages from being sent in the same message batch.
   protected final Set<Event> eventMessages = ConcurrentHashMap.newKeySet();
-  protected static final ScheduledExecutorService publishingExecutor =
+  private static final ResourceLock lock = new ResourceLock();
+  protected static volatile ScheduledExecutorService publishingExecutor =
       ExecutorFactory.newSingleThreadScheduledThreadExecutor("bep");
+  protected final long messageIntervalNanos;
 
   public BatchingEventPublisher() {
     this(DEFAULT_MESSAGE_INTERVAL_NANOS);
@@ -50,12 +53,27 @@ public class BatchingEventPublisher implements EventPublisher {
    * @param messageIntervalNanos the rate at which messages batches should be sent, in nanoseconds.
    */
   public BatchingEventPublisher(long messageIntervalNanos) {
+    this.messageIntervalNanos = messageIntervalNanos;
     initPublishingThread(messageIntervalNanos);
   }
 
   protected void initPublishingThread(long messageIntervalNanos) {
-    publishingExecutor.scheduleAtFixedRate(
+    getOrCreatePublishingExecutor().scheduleAtFixedRate(
         this::sendMessages, messageIntervalNanos, messageIntervalNanos, TimeUnit.NANOSECONDS);
+  }
+
+  private static ScheduledExecutorService getOrCreatePublishingExecutor() {
+    ScheduledExecutorService executor = publishingExecutor;
+    if (executor.isShutdown()) {
+      try (ResourceLock ignored = lock.obtain()) {
+        executor = publishingExecutor;
+        if (executor.isShutdown()) {
+          executor = ExecutorFactory.newSingleThreadScheduledThreadExecutor("bep");
+          publishingExecutor = executor;
+        }
+      }
+    }
+    return executor;
   }
 
   protected void sendMessages() {
@@ -102,7 +120,14 @@ public class BatchingEventPublisher implements EventPublisher {
     if (event.isImmediateDelivery()) {
       this.deliverEvent(event);
     } else {
+      ensureExecutorRunning();
       eventMessages.add(event);
+    }
+  }
+
+  private void ensureExecutorRunning() {
+    if (publishingExecutor.isShutdown()) {
+      initPublishingThread(this.messageIntervalNanos);
     }
   }
 

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/OpenedConnectionTrackerTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/OpenedConnectionTrackerTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.jdbc.plugin;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import software.amazon.jdbc.HostSpec;
+import software.amazon.jdbc.HostSpecBuilder;
+import software.amazon.jdbc.PluginService;
+import software.amazon.jdbc.hostavailability.SimpleHostAvailabilityStrategy;
+import software.amazon.jdbc.util.telemetry.TelemetryContext;
+import software.amazon.jdbc.util.telemetry.TelemetryFactory;
+
+class OpenedConnectionTrackerTest {
+
+  private AutoCloseable closeable;
+
+  @Mock private PluginService mockPluginService;
+  @Mock private TelemetryFactory mockTelemetryFactory;
+  @Mock private TelemetryContext mockTelemetryContext;
+  @Mock private Connection mockConnection;
+
+  @BeforeEach
+  void setUp() {
+    closeable = MockitoAnnotations.openMocks(this);
+    when(mockPluginService.getTelemetryFactory()).thenReturn(mockTelemetryFactory);
+    when(mockTelemetryFactory.openTelemetryContext(any(), any())).thenReturn(mockTelemetryContext);
+  }
+
+  @AfterEach
+  void tearDown() throws Exception {
+    OpenedConnectionTracker.clearCache();
+    closeable.close();
+  }
+
+  @Test
+  void testReleaseResources_shutsDownExecutors() {
+    final HostSpec hostSpec = new HostSpecBuilder(new SimpleHostAvailabilityStrategy())
+        .host("instance1.cluster-xyz.us-east-1.rds.amazonaws.com")
+        .build();
+
+    final OpenedConnectionTracker tracker = new OpenedConnectionTracker(mockPluginService);
+
+    // Track a connection to trigger executor creation
+    tracker.populateOpenedConnectionQueue(hostSpec, mockConnection);
+    assertFalse(OpenedConnectionTracker.openedConnections.isEmpty());
+
+    // Release resources should clear connections
+    OpenedConnectionTracker.releaseResources();
+    assertTrue(OpenedConnectionTracker.openedConnections.isEmpty());
+  }
+
+  @Test
+  void testExecutorsRecreatedAfterReleaseResources() {
+    final HostSpec hostSpec = new HostSpecBuilder(new SimpleHostAvailabilityStrategy())
+        .host("instance1.cluster-xyz.us-east-1.rds.amazonaws.com")
+        .build();
+
+    final OpenedConnectionTracker tracker = new OpenedConnectionTracker(mockPluginService);
+
+    // Track a connection to trigger executor creation
+    tracker.populateOpenedConnectionQueue(hostSpec, mockConnection);
+    assertFalse(OpenedConnectionTracker.openedConnections.isEmpty());
+
+    // Release resources - shuts down executors
+    OpenedConnectionTracker.releaseResources();
+    assertTrue(OpenedConnectionTracker.openedConnections.isEmpty());
+
+    // Track again after release - executors should be recreated
+    tracker.populateOpenedConnectionQueue(hostSpec, mockConnection);
+    assertFalse(OpenedConnectionTracker.openedConnections.isEmpty());
+  }
+
+  @Test
+  void testInvalidateConnectionsAfterReleaseResources() throws SQLException, InterruptedException {
+    final HostSpec hostSpec = new HostSpecBuilder(new SimpleHostAvailabilityStrategy())
+        .host("instance1.cluster-xyz.us-east-1.rds.amazonaws.com")
+        .build();
+
+    final AtomicBoolean aborted = new AtomicBoolean(false);
+    final Connection abortableConnection = mock(Connection.class);
+    doAnswer(invocation -> {
+      aborted.set(true);
+      return null;
+    }).when(abortableConnection).abort(any());
+
+    final OpenedConnectionTracker tracker = new OpenedConnectionTracker(mockPluginService);
+
+    // Track a connection
+    tracker.populateOpenedConnectionQueue(hostSpec, abortableConnection);
+
+    // Release resources - shuts down executors
+    OpenedConnectionTracker.releaseResources();
+
+    // Track a new connection after release
+    tracker.populateOpenedConnectionQueue(hostSpec, abortableConnection);
+
+    // Invalidate connections - this should recreate the invalidate executor
+    tracker.invalidateAllConnections(hostSpec);
+
+    // Wait for async invalidation to complete
+    TimeUnit.MILLISECONDS.sleep(500);
+
+    // Connection should have been aborted
+    assertTrue(aborted.get());
+  }
+
+  @Test
+  void testMultipleReleaseResourcesCalls() {
+    // Calling releaseResources multiple times should not throw
+    OpenedConnectionTracker.releaseResources();
+    OpenedConnectionTracker.releaseResources();
+    OpenedConnectionTracker.releaseResources();
+
+    // Should still be able to track connections after multiple releases
+    final HostSpec hostSpec = new HostSpecBuilder(new SimpleHostAvailabilityStrategy())
+        .host("instance1.cluster-xyz.us-east-1.rds.amazonaws.com")
+        .build();
+
+    final OpenedConnectionTracker tracker = new OpenedConnectionTracker(mockPluginService);
+    TrackedConnectionList.Node node = tracker.populateOpenedConnectionQueue(hostSpec, mockConnection);
+    assertNotNull(node);
+    assertFalse(OpenedConnectionTracker.openedConnections.isEmpty());
+  }
+}

--- a/wrapper/src/test/java/software/amazon/jdbc/util/events/BatchingEventPublisherTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/util/events/BatchingEventPublisherTest.java
@@ -17,6 +17,7 @@
 package software.amazon.jdbc.util.events;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
@@ -26,6 +27,8 @@ import java.sql.SQLException;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -74,5 +77,80 @@ class BatchingEventPublisherTest {
     publisher.sendMessages();
     assertTrue(publisher.eventMessages.isEmpty());
     verify(subscriber, times(1)).processEvent(eq(event));
+  }
+
+  @Test
+  public void testReleaseResources_shutsDownExecutor() {
+    BatchingEventPublisher publisher = new BatchingEventPublisher() {
+      @Override
+      protected void initPublishingThread(long messageIntervalNanos) {
+        // Do nothing
+      }
+    };
+
+    // Release resources should not throw
+    BatchingEventPublisher.releaseResources();
+
+    // The static executor should be shut down
+    assertTrue(BatchingEventPublisher.publishingExecutor.isShutdown());
+  }
+
+  @Test
+  public void testExecutorRecreatedAfterReleaseResources() {
+    // Release resources to shut down the executor
+    BatchingEventPublisher.releaseResources();
+    assertTrue(BatchingEventPublisher.publishingExecutor.isShutdown());
+
+    // Creating a new publisher should recreate the executor
+    BatchingEventPublisher publisher = new BatchingEventPublisher() {
+      @Override
+      protected void initPublishingThread(long messageIntervalNanos) {
+        // Call super to trigger executor recreation
+        super.initPublishingThread(messageIntervalNanos);
+      }
+    };
+
+    // Executor should be recreated and running
+    assertFalse(BatchingEventPublisher.publishingExecutor.isShutdown());
+  }
+
+  @Test
+  public void testPublishAfterReleaseResources() throws InterruptedException {
+    // Release resources to shut down the executor
+    BatchingEventPublisher.releaseResources();
+    assertTrue(BatchingEventPublisher.publishingExecutor.isShutdown());
+
+    // Create a publisher with a short interval for testing
+    final long shortInterval = TimeUnit.MILLISECONDS.toNanos(100);
+    final CountDownLatch latch = new CountDownLatch(1);
+
+    BatchingEventPublisher publisher = new BatchingEventPublisher(shortInterval);
+
+    Set<Class<? extends Event>> eventSubscriptions = new HashSet<>(Collections.singletonList(DataAccessEvent.class));
+    publisher.subscribe(new EventSubscriber() {
+      @Override
+      public void processEvent(Event event) {
+        latch.countDown();
+      }
+    }, eventSubscriptions);
+
+    // Publish an event - this should trigger executor recreation via ensureExecutorRunning
+    DataAccessEvent event = new DataAccessEvent(CustomEndpointInfo.class, "key");
+    publisher.publish(event);
+
+    // Wait for the scheduled task to deliver the event
+    assertTrue(latch.await(2, TimeUnit.SECONDS), "Event should have been delivered after executor recreation");
+  }
+
+  @Test
+  public void testMultipleReleaseResourcesCalls() {
+    // Calling releaseResources multiple times should not throw
+    BatchingEventPublisher.releaseResources();
+    BatchingEventPublisher.releaseResources();
+    BatchingEventPublisher.releaseResources();
+
+    // Should still be able to create a publisher after multiple releases
+    BatchingEventPublisher publisher = new BatchingEventPublisher();
+    assertFalse(BatchingEventPublisher.publishingExecutor.isShutdown());
   }
 }


### PR DESCRIPTION
### Summary

PR #1906 introduced `releaseResources()` methods that shut down static `ExecutorService` instances in `OpenedConnectionTracker` and `BatchingEventPublisher`. These executors were declared as static final and initialized once at class load time. Once shut down, they could not be restarted within the same JVM.

In integration tests, `TestDriverProvider.beforeEach()` calls `Driver.releaseResources()` before each test, which permanently killed the executors. When subsequent tests triggered failover and the driver attempted to invalidate idle connections via `OpenedConnectionTracker.invalidateAllConnections()`, the task was submitted to a shut-down executor and silently discarded. This caused `testServerFailoverWithIdleConnections` to fail consistently across all Aurora environments (MySQL, MariaDB, PostgreSQL) in both 2-instance and 3-instance configurations.

### Description

Changed static executors from eagerly-initialized static final fields to lazily-initialized static volatile fields that are recreated on demand after shutdown:

**OpenedConnectionTracker**:
- Removed the static initializer block and eager executor creation
- Executor fields start as null and are created lazily
- `getOrCreatePruneExecutor()` — creates the prune executor and schedules the prune task on first use (triggered when tracking a connection)
- `getOrCreateInvalidateExecutor()` — creates the invalidate executor on first use (triggered when invalidating connections)
`releaseResources()` — shuts down both executors and clears tracked connections; next usage recreates them
- Uses double-checked locking with `ResourceLock` for thread safety

**BatchingEventPublisher**:
- `getOrCreatePublishingExecutor()` — recreates the executor if it was shut down
- `ensureExecutorRunning()` — called from publish() to detect a shut-down executor and reinitialize the publishing thread
- `releaseResources()` — shuts down the executor; next usage recreates it


### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.