### PR TITLE
chore: parallelize standard integration tests to reduce CI wall-clock time

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,18 +21,12 @@ permissions:
   contents: read
 
 jobs:
-  markdown-link-check:
+  check-changes:
+    name: 'Check for changes'
     runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
-      - uses: tcort/github-action-markdown-link-check@e7c7a18363c842693fadde5d41a3bd3573a7a225  # v1
-        with:
-          use-quiet-mode: 'yes'
-          folder-path: 'docs'
-          config-file: '.github/workflows/mlc_config.json'
-  build-driver:
-    name: 'Run non-container integration tests'
-    runs-on: ubuntu-latest
+    outputs:
+      only_docs: ${{ steps.check.outputs.ONLY_DOCS }}
+      docs_changed: ${{ steps.check.outputs.DOCS_CHANGED }}
     steps:
       - name: 'Clone repository'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
@@ -48,26 +42,88 @@ jobs:
               - '**/docs/**'
               - '**/*.jpg'
               - '**/*.png'
-      - name: 'Check changed files'
-        id: changed-files
-        if: ${{steps.changed-files-specific.outputs.doc_only_changed == 'false' && steps.changed-files-specific.outputs.doc_only_modified == 'false'}}
-        run: echo "ONLY_DOCS=false" >> $GITHUB_OUTPUT
+      - name: 'Determine change type'
+        id: check
+        run: |
+          if [[ "${{ steps.changed-files-specific.outputs.doc_only_changed }}" == "true" || "${{ steps.changed-files-specific.outputs.doc_only_modified }}" == "true" ]]; then
+            echo "ONLY_DOCS=true" >> $GITHUB_OUTPUT
+          else
+            echo "ONLY_DOCS=false" >> $GITHUB_OUTPUT
+          fi
+          if [[ "${{ steps.changed-files-specific.outputs.doc_any_changed }}" == "true" ]]; then
+            echo "DOCS_CHANGED=true" >> $GITHUB_OUTPUT
+          else
+            echo "DOCS_CHANGED=false" >> $GITHUB_OUTPUT
+          fi
+
+  markdown-link-check:
+    name: 'Markdown link check'
+    needs: check-changes
+    if: ${{ needs.check-changes.outputs.docs_changed == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: tcort/github-action-markdown-link-check@e7c7a18363c842693fadde5d41a3bd3573a7a225  # v1
+        with:
+          use-quiet-mode: 'yes'
+          folder-path: 'docs'
+          config-file: '.github/workflows/mlc_config.json'
+
+  lint:
+    name: 'Static analysis'
+    needs: check-changes
+    if: ${{ needs.check-changes.outputs.only_docs == 'false' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Clone repository'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          fetch-depth: 50
       - name: 'Set up JDK 8'
-        if: ${{steps.changed-files.outputs.ONLY_DOCS && steps.changed-files.outputs.ONLY_DOCS == 'false'}}
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5
         with:
           distribution: 'corretto'
           java-version: 8
-      - name: 'Run all checks'
-        if: ${{steps.changed-files.outputs.ONLY_DOCS && steps.changed-files.outputs.ONLY_DOCS == 'false'}}
-        run: |
-          echo ${{steps.changed-files.outputs.ONLY_DOCS}}
-          ./gradlew check
-      - name: 'Generate code coverage report'
-        if: ${{steps.changed-files.outputs.ONLY_DOCS && steps.changed-files.outputs.ONLY_DOCS == 'false'}}
-        run: ./gradlew jacocoTestReport
+      - name: 'Cache Gradle packages'
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684  # v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+      - name: 'Run checkstyle and spotbugs'
+        run: ./gradlew --build-cache checkstyleMain checkstyleTest spotbugsMain spotbugsTest
+
+  test:
+    name: 'Unit tests and coverage'
+    needs: check-changes
+    if: ${{ needs.check-changes.outputs.only_docs == 'false' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Clone repository'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          fetch-depth: 50
+      - name: 'Set up JDK 8'
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5
+        with:
+          distribution: 'corretto'
+          java-version: 8
+      - name: 'Cache Gradle packages'
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684  # v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+      - name: 'Run tests with coverage'
+        run: ./gradlew --build-cache test jacocoTestReport jacocoTestCoverageVerification
       - name: 'Archive test results'
-        if: ${{steps.changed-files.outputs.ONLY_DOCS && steps.changed-files.outputs.ONLY_DOCS == 'false'}}
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: 'junit-report'

--- a/.github/workflows/run-standard-integration-tests.yml
+++ b/.github/workflows/run-standard-integration-tests.yml
@@ -17,9 +17,11 @@ permissions:
   contents: read
 
 jobs:
-  standard-integration-tests:
-    name: 'Run standard container integration tests'
+  check-changes:
+    name: 'Check for non-doc changes'
     runs-on: ubuntu-latest
+    outputs:
+      only_docs: ${{ steps.changed-files.outputs.ONLY_DOCS }}
     steps:
       - name: 'Clone repository'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
@@ -37,36 +39,129 @@ jobs:
               - '**/*.png'
       - name: 'Check changed files'
         id: changed-files
-        if: ${{steps.changed-files-specific.outputs.doc_only_changed == 'false' && steps.changed-files-specific.outputs.doc_only_modified == 'false'}}
-        run: echo "ONLY_DOCS=false" >> $GITHUB_OUTPUT
+        run: |
+          if [[ "${{ steps.changed-files-specific.outputs.doc_only_changed }}" == "true" || "${{ steps.changed-files-specific.outputs.doc_only_modified }}" == "true" ]]; then
+            echo "ONLY_DOCS=true" >> $GITHUB_OUTPUT
+          else
+            echo "ONLY_DOCS=false" >> $GITHUB_OUTPUT
+          fi
+
+  docker-tests:
+    name: 'Docker [${{ matrix.engine }}, ${{ matrix.jvm }}]'
+    needs: check-changes
+    if: ${{ needs.check-changes.outputs.only_docs == 'false' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        engine: [mysql, pg, mariadb]
+        jvm: ${{ github.event_name == 'pull_request' && fromJSON('["openjdk8", "openjdk21"]') || fromJSON('["openjdk8", "openjdk11", "openjdk17", "openjdk21", "openjdk24", "graalvm"]') }}
+    steps:
+      - name: 'Clone repository'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          fetch-depth: 50
       - name: 'Set up JDK 8'
-        if: ${{steps.changed-files.outputs.ONLY_DOCS && steps.changed-files.outputs.ONLY_DOCS == 'false'}}
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5
         with:
           distribution: 'corretto'
           java-version: 8
+      - name: 'Cache Gradle packages'
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684  # v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
       - name: 'Run standard integration tests'
-        if: ${{steps.changed-files.outputs.ONLY_DOCS && steps.changed-files.outputs.ONLY_DOCS == 'false'}}
         run: |
-          ./gradlew --no-parallel --no-daemon test-all-docker
-      - name: 'Run caching integration tests'
-        if: ${{steps.changed-files.outputs.ONLY_DOCS && steps.changed-files.outputs.ONLY_DOCS == 'false'}}
-        run: |
-          ./gradlew --no-parallel --no-daemon test-all-caching
+          ./gradlew --no-parallel --no-daemon test-all-docker \
+            -Dtest-no-mysql-engine=${{ matrix.engine != 'mysql' }} \
+            -Dtest-no-pg-engine=${{ matrix.engine != 'pg' }} \
+            -Dtest-no-mariadb-engine=${{ matrix.engine != 'mariadb' }} \
+            -Dtest-no-openjdk8=${{ matrix.jvm != 'openjdk8' }} \
+            -Dtest-no-openjdk11=${{ matrix.jvm != 'openjdk11' }} \
+            -Dtest-no-openjdk17=${{ matrix.jvm != 'openjdk17' }} \
+            -Dtest-no-openjdk21=${{ matrix.jvm != 'openjdk21' }} \
+            -Dtest-no-openjdk24=${{ matrix.jvm != 'openjdk24' }} \
+            -Dtest-no-graalvm=${{ matrix.jvm != 'graalvm' }}
       - name: Mask data
+        if: ${{ !cancelled() }}
         run: |
           ./gradlew --no-parallel --no-daemon maskJunitHtmlReport
       - name: 'Archive junit results'
-        if: ${{steps.changed-files.outputs.ONLY_DOCS && steps.changed-files.outputs.ONLY_DOCS == 'false' && !cancelled()}}
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: junit-report
+          name: junit-report-docker-${{ matrix.engine }}-${{ matrix.jvm }}
           path: ./wrapper/build/test-results
           retention-days: 5
       - name: 'Archive html summary report'
-        if: ${{steps.changed-files.outputs.ONLY_DOCS && steps.changed-files.outputs.ONLY_DOCS == 'false' && !cancelled()}}
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: html-summary-report
+          name: html-summary-report-docker-${{ matrix.engine }}-${{ matrix.jvm }}
+          path: ./wrapper/build/report
+          retention-days: 5
+
+  caching-tests:
+    name: 'Caching [${{ matrix.engine }}, ${{ matrix.jvm }}]'
+    needs: check-changes
+    if: ${{ needs.check-changes.outputs.only_docs == 'false' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        engine: [mysql, pg, mariadb]
+        jvm: ${{ github.event_name == 'pull_request' && fromJSON('["openjdk8", "openjdk21"]') || fromJSON('["openjdk8", "openjdk11", "openjdk17", "openjdk21", "openjdk24", "graalvm"]') }}
+    steps:
+      - name: 'Clone repository'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          fetch-depth: 50
+      - name: 'Set up JDK 8'
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5
+        with:
+          distribution: 'corretto'
+          java-version: 8
+      - name: 'Cache Gradle packages'
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684  # v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+      - name: 'Run caching integration tests'
+        run: |
+          ./gradlew --no-parallel --no-daemon test-all-caching \
+            -Dtest-no-mysql-engine=${{ matrix.engine != 'mysql' }} \
+            -Dtest-no-pg-engine=${{ matrix.engine != 'pg' }} \
+            -Dtest-no-mariadb-engine=${{ matrix.engine != 'mariadb' }} \
+            -Dtest-no-openjdk8=${{ matrix.jvm != 'openjdk8' }} \
+            -Dtest-no-openjdk11=${{ matrix.jvm != 'openjdk11' }} \
+            -Dtest-no-openjdk17=${{ matrix.jvm != 'openjdk17' }} \
+            -Dtest-no-openjdk21=${{ matrix.jvm != 'openjdk21' }} \
+            -Dtest-no-openjdk24=${{ matrix.jvm != 'openjdk24' }} \
+            -Dtest-no-graalvm=${{ matrix.jvm != 'graalvm' }}
+      - name: Mask data
+        if: ${{ !cancelled() }}
+        run: |
+          ./gradlew --no-parallel --no-daemon maskJunitHtmlReport
+      - name: 'Archive junit results'
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: junit-report-caching-${{ matrix.engine }}-${{ matrix.jvm }}
+          path: ./wrapper/build/test-results
+          retention-days: 5
+      - name: 'Archive html summary report'
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: html-summary-report-caching-${{ matrix.engine }}-${{ matrix.jvm }}
           path: ./wrapper/build/report
           retention-days: 5


### PR DESCRIPTION
### Summary

Restructures `main.yml` and `run-standard-integration-tests.yml` to run test environments in parallel instead of sequentially, reducing wall-clock time from ~80 minutes to ~8-10 minutes.

### Description

Changes for **run-standard-integration-tests.yml**:
- Matrix parallelism — Split the monolithic job into a strategy.matrix over (engine, jvm) so each combination runs on its own runner in parallel.
- Separate docker and caching jobs — docker-tests and caching-tests are now independent parallel jobs instead of sequential steps in one job.
- Gradle dependency caching — Added `actions/cache@v4` for `~/.gradle/caches` and `~/.gradle/wrapper` to avoid re-downloading dependencies on every run.
- Reduced matrix on PRs — Pull requests test only openjdk8 and openjdk21 (2 JVMs × 3 engines = 6 jobs per test type). Pushes to main/main-2.x and manual dispatches run the full matrix (6 JVMs × 3 engines = 18 jobs per test type).

New job structure for **main.yml**
- check-changes — determines if only docs changed, and whether any docs changed
- markdown-link-check — runs only when markdown/docs files are modified
- lint — checkstyle + spotbugs (parallel with test)
- test — unit tests + jacoco coverage report + coverage verification (parallel with lint)

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.