### PR TITLE
fix: propagate configuration profile to PartialPluginService

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/PartialPluginService.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/PartialPluginService.java
@@ -90,24 +90,6 @@ public class PartialPluginService implements PluginService, CanReleaseResources,
 
   public PartialPluginService(
       @NonNull final FullServicesContainer servicesContainer,
-      @NonNull final Properties props,
-      @NonNull final String originalUrl,
-      @NonNull final String targetDriverProtocol,
-      @NonNull final TargetDriverDialect targetDriverDialect,
-      @NonNull final Dialect dbDialect) throws SQLException {
-    this(
-        servicesContainer,
-        new ExceptionManager(),
-        props,
-        originalUrl,
-        targetDriverProtocol,
-        targetDriverDialect,
-        dbDialect,
-        null);
-  }
-
-  public PartialPluginService(
-      @NonNull final FullServicesContainer servicesContainer,
       @NonNull final ExceptionManager exceptionManager,
       @NonNull final Properties props,
       @NonNull final String originalUrl,

--- a/wrapper/src/main/java/software/amazon/jdbc/util/ServiceUtility.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/ServiceUtility.java
@@ -25,6 +25,7 @@ import software.amazon.jdbc.PartialPluginService;
 import software.amazon.jdbc.PluginServiceImpl;
 import software.amazon.jdbc.dialect.Dialect;
 import software.amazon.jdbc.dialect.HostListProviderSupplier;
+import software.amazon.jdbc.exceptions.ExceptionManager;
 import software.amazon.jdbc.hostlistprovider.HostListProvider;
 import software.amazon.jdbc.profile.ConfigurationProfile;
 import software.amazon.jdbc.targetdriverdialect.TargetDriverDialect;
@@ -117,11 +118,13 @@ public class ServiceUtility {
 
     PartialPluginService pluginService = new PartialPluginService(
         serviceContainer,
+        new ExceptionManager(),
         props,
         originalUrl,
         targetDriverProtocol,
         driverDialect,
-        dbDialect
+        dbDialect,
+        configurationProfile
     );
 
     serviceContainer.setHostListProviderService(pluginService);
@@ -129,6 +132,8 @@ public class ServiceUtility {
     serviceContainer.setPluginManagerService(pluginService);
 
     pluginManager.initPlugins(serviceContainer, configurationProfile);
+
+    serviceContainer.setConfigurationProfile(configurationProfile);
     return serviceContainer;
   }
 


### PR DESCRIPTION
### Summary

https://github.com/aws/aws-advanced-jdbc-wrapper/issues/1800

`createMinimalServiceContainer` in `ServiceUtility.java` was not properly propagating the `ConfigurationProfile` to the `PartialPluginService` or the service container itself. This caused internal monitoring workers (e.g., `NodeMonitoringWorker`) to lose access to profile-configured plugins like IAM, leading to permanent authentication failures after the IAM token TTL (~15 minutes).

### Description

When using `ConfigurationProfile`, the main connection path correctly reads plugins from the profile. However, `ClusterTopologyMonitorImpl.getNodeMonitoringWorker()` creates service containers via `createMinimalServiceContainer`, which:
- Constructed `PartialPluginService` with the 6-arg constructor that delegates to the 8-arg constructor with configurationProfile = null
- Never called `setConfigurationProfile()` on the container

This meant monitoring workers had no access to profile-dependent plugin behaviour (e.g., IAM token refresh), causing them to die permanently once the cached token expired.


### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.