### PR TITLE
fix: adjust internal session state for initial connection

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/GenericTargetDriverDialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/GenericTargetDriverDialect.java
@@ -35,6 +35,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import software.amazon.jdbc.HostSpec;
 import software.amazon.jdbc.JdbcMethod;
+import software.amazon.jdbc.PluginService;
 import software.amazon.jdbc.PropertyDefinition;
 import software.amazon.jdbc.util.Messages;
 import software.amazon.jdbc.util.PropertyUtils;
@@ -293,6 +294,13 @@ public class GenericTargetDriverDialect implements TargetDriverDialect {
       return rs.getBytes((Integer) columnRef);
     }
     return rs.getBytes((String) columnRef);
+  }
+
+  @Override
+  public void updateInternalState(
+      final @NonNull PluginService pluginService,
+      final @NonNull Properties props) throws SQLException {
+    // No-op for the generic dialect.
   }
 
   // Get the SQL query string from a PreparedStatement which comes after a dialect specific header

--- a/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/PgTargetDriverDialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/PgTargetDriverDialect.java
@@ -33,10 +33,13 @@ import javax.sql.DataSource;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import software.amazon.jdbc.HostSpec;
 import software.amazon.jdbc.JdbcMethod;
+import software.amazon.jdbc.PluginService;
 import software.amazon.jdbc.PropertyDefinition;
 import software.amazon.jdbc.plugin.encryption.wrapper.PgEncryptedDataHelper;
+import software.amazon.jdbc.util.Messages;
 import software.amazon.jdbc.util.PropertyUtils;
 import software.amazon.jdbc.util.ResourceLock;
+import software.amazon.jdbc.util.StringUtils;
 
 public class PgTargetDriverDialect extends GenericTargetDriverDialect {
 
@@ -217,5 +220,30 @@ public class PgTargetDriverDialect extends GenericTargetDriverDialect {
   @Override
   public byte[] getEncryptedBytes(@NonNull ResultSet rs, Object columnRef) throws SQLException {
     return getPgEncryptedDataHelper().getEncryptedBytes(rs, columnRef);
+  }
+
+  @Override
+  public void updateInternalState(
+      final @NonNull PluginService pluginService,
+      final @NonNull Properties props) throws SQLException {
+
+    final String currentSchema = props.getProperty("currentSchema");
+    if (!StringUtils.isNullOrEmpty(currentSchema)) {
+      LOGGER.finest(() -> Messages.get(
+          "PgTargetDriverDialect.transferringPropertyToSessionState",
+          new Object[] {"currentSchema", currentSchema}));
+      pluginService.getSessionStateService().setupPristineSchema(currentSchema);
+      pluginService.getSessionStateService().setSchema(currentSchema);
+    }
+
+    final String readOnlyValue = props.getProperty("readOnly");
+    if (!StringUtils.isNullOrEmpty(readOnlyValue)) {
+      final boolean readOnly = Boolean.parseBoolean(readOnlyValue);
+      LOGGER.finest(() -> Messages.get(
+          "PgTargetDriverDialect.transferringPropertyToSessionState",
+          new Object[] {"readOnly", readOnly}));
+      pluginService.getSessionStateService().setupPristineReadOnly(readOnly);
+      pluginService.getSessionStateService().setReadOnly(readOnly);
+    }
   }
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/TargetDriverDialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/TargetDriverDialect.java
@@ -27,6 +27,7 @@ import javax.sql.DataSource;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import software.amazon.jdbc.HostSpec;
+import software.amazon.jdbc.PluginService;
 
 public interface TargetDriverDialect {
 
@@ -78,4 +79,26 @@ public interface TargetDriverDialect {
       throws SQLException;
 
   byte[] getEncryptedBytes(final @NonNull ResultSet rs, Object columnRef) throws SQLException;
+
+  /**
+   * Allows each target driver dialect to perform last-minute adjustments to the wrapper's
+   * internal state after the initial connection is established. This includes transferring
+   * driver-specific connection properties (e.g. PostgreSQL's {@code currentSchema}) into
+   * the wrapper's session state so they are preserved across connection switches
+   * (failover, read-write splitting, initial connection strategy, etc.).
+   *
+   * <p>Each dialect implementation should inspect the provided properties for driver-specific
+   * settings that affect session state and register them with the appropriate services
+   * (e.g. {@link software.amazon.jdbc.states.SessionStateService}).
+   *
+   * <p>This method is called once after the initial connection is established in
+   * {@code ConnectionWrapper.init()}.
+   *
+   * @param pluginService the plugin service providing access to session state and other services
+   * @param props         the connection properties that may contain driver-specific settings
+   * @throws SQLException if an error occurs while updating internal state
+   */
+  void updateInternalState(
+      final @NonNull PluginService pluginService,
+      final @NonNull Properties props) throws SQLException;
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/wrapper/ConnectionWrapper.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/wrapper/ConnectionWrapper.java
@@ -145,6 +145,9 @@ public class ConnectionWrapper implements Connection, CanReleaseResources {
       this.pluginService.setCurrentConnection(conn, connectedHostSpec);
       this.pluginService.setRoutedHostSpec(null);
       this.pluginService.refreshHostList();
+
+      this.pluginService.getTargetDriverDialect()
+          .updateInternalState(this.pluginService, props);
     }
   }
 

--- a/wrapper/src/main/resources/aws_advanced_jdbc_wrapper_messages.properties
+++ b/wrapper/src/main/resources/aws_advanced_jdbc_wrapper_messages.properties
@@ -540,6 +540,7 @@ GdbReadWriteSplittingPlugin.enabledGwf=The current primary writer region is {0} 
 WrapperUtils.failedToInjectContext=Unable to inject context to exception ''{0}''.
 
 PgTargetDriverDialect.exceptionAbortingConnection=Exception during aborting connection: {0}. You may consider upgrading the target driver or explicitly setting up the necessary security policies.
+PgTargetDriverDialect.transferringPropertyToSessionState=Transferring ''{0}'' property value to session state: {1}
 
 # Encryption Plugin Messages
 


### PR DESCRIPTION
### Summary

https://github.com/aws/aws-advanced-jdbc-wrapper/issues/1787

The wrapper now preserves target-driver-specific session state properties (e.g., PostgreSQL's `currentSchema` and `readOnly`) across connection switches triggered by plugins like `initialConnection`, `failover2`, and read-write splitting.

### Description

When using `AwsWrapperDataSource` with `PGSimpleDataSource` and setting `currentSchema` in `targetDataSourceProperties`, the schema was silently lost if a plugin caused a connection switch (e.g., the `initialConnection` plugin substituting a cluster endpoint with an instance endpoint). This happened because:

The `currentSchema` property was correctly applied to the target data source via `PropertyUtils.applyProperties()` during `prepareDataSource()`. However, the wrapper's `SessionStateService` was never informed of this value. When a connection switch occurred, `applyCurrentSessionState()` found sessionState.schema empty and did not restore the schema on the new connection. The new connection defaulted to public.

Added a new method `updateInternalState(PluginService, Properties)` to the `TargetDriverDialect` interface. This method is called once after the initial connection is established in `ConnectionWrapper.init()`, allowing each dialect to transfer driver-specific properties into the wrapper's internal session state.

Changes:
- TargetDriverDialect.java — Added abstract method `updateInternalState(PluginService, Properties)`
- GenericTargetDriverDialect.java — Added no-op base implementation (MySQL and MariaDB inherit this)
- PgTargetDriverDialect.java — Overrides to transfer `currentSchema` and `readOnly` properties into `SessionStateService`
- ConnectionWrapper.java — Calls `updateInternalState()` at the end of `init()` after the initial connection is set
- `aws_advanced_jdbc_wrapper_messages.properties` — Added log message for property transfer

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.