### PR TITLE
fix: Add `waitUntilInstanceHasRightState` overload defaulting to "available"

### DIFF
--- a/wrapper/src/test/java/integration/util/AuroraTestUtility.java
+++ b/wrapper/src/test/java/integration/util/AuroraTestUtility.java
@@ -1291,6 +1291,10 @@ public class AuroraTestUtility {
     return dbClusterList.get(0);
   }
 
+  public void waitUntilInstanceHasRightState(String instanceId) throws InterruptedException {
+    waitUntilInstanceHasRightState(instanceId, "available");
+  }
+
   public void waitUntilInstanceHasRightState(String instanceId, String... allowedStatuses) throws InterruptedException {
 
     String status = getDBInstance(instanceId).dbInstanceStatus();


### PR DESCRIPTION
### Summary
Current `rebootAllClusterInstances` calling `waitUntilInstanceHasRightState` with the empty allowed‑set causes the loop to spin out the full 15‑minute internal timeout.
<!--- General summary / title -->

### Description
- Add overloading function that default to wait for available status
<!--- Details of what you changed -->

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.