### PR TITLE
chore: clean up test DB parameter groups

### DIFF
--- a/wrapper/src/test/java/integration/host/TestEnvironment.java
+++ b/wrapper/src/test/java/integration/host/TestEnvironment.java
@@ -1743,18 +1743,21 @@ public class TestEnvironment implements AutoCloseable {
             switch (env.info.getRequest().getDatabaseEngineDeployment()) {
               case RDS_MULTI_AZ_INSTANCE:
                 initEnv(env);
+                cleanUp(env);
                 authorizeRunnerIpAddress(env);
                 createMultiAzInstance(env);
                 configureIamAccess(env);
                 break;
               case RDS_MULTI_AZ_CLUSTER:
                 initEnv(env);
+                cleanUp(env);
                 authorizeRunnerIpAddress(env);
                 createDbCluster(env);
                 configureIamAccess(env);
                 break;
               case AURORA:
                 initEnv(env);
+                cleanUp(env);
                 authorizeRunnerIpAddress(env);
 
                 if (env.info.getRequest().getFeatures().contains(TestEnvironmentFeatures.BLUE_GREEN_DEPLOYMENT)) {

--- a/wrapper/src/test/java/integration/util/AuroraTestUtility.java
+++ b/wrapper/src/test/java/integration/util/AuroraTestUtility.java
@@ -2619,7 +2619,7 @@ public class AuroraTestUtility {
 
       DescribeDbClusterParameterGroupsResponse response = rdsClient.describeDBClusterParameterGroups();
       for (DBClusterParameterGroup paramGroup : response.dbClusterParameterGroups()) {
-        if (!paramGroup.dbClusterParameterGroupName().startsWith("test-cpg-")) {
+        if (!paramGroup.dbClusterParameterGroupName().startsWith("test-")) {
           continue;
         }
         if (inUseParameterGroups.contains(paramGroup.dbClusterParameterGroupName())) {


### PR DESCRIPTION
### Summary

The preCreateEnvironment path (which creates test environments in background threads) was missing the cleanUp(env) call that the non-pre-created path already had. This meant orphaned parameter groups from previous runs were never cleaned up when environments were pre-created.

### Description

- TestEnvironment.java — Added cleanUp(env) to the pre-create path for all three deployment types (RDS_MULTI_AZ_INSTANCE, RDS_MULTI_AZ_CLUSTER, AURORA), matching the existing pattern in createAuroraOrMultiAzEnvironment.
- AuroraTestUtility.java — Broadened the prefix filter in testClusterParameterGroupsCleanUp() from "test-cpg-" to "test-". This ensures both test-cpg-* (custom/BGD groups) and test-mysql-cpg-* (MySQL groups) are cleaned up, rather than only the former.

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.