### PR TITLE
chore: fix flaky integration test

### DIFF
--- a/wrapper/src/test/java/integration/container/tests/CustomEndpointTest.java
+++ b/wrapper/src/test/java/integration/container/tests/CustomEndpointTest.java
@@ -344,7 +344,14 @@ public class CustomEndpointTest {
           LOGGER.fine("FailoverSuccessSQLException during setReadOnly after endpoint change. "
               + "This is acceptable during custom endpoint modifications.");
         }
-        String instanceId2 = auroraUtil.queryInstanceId(conn);
+        String instanceId2;
+        try {
+          instanceId2 = auroraUtil.queryInstanceId(conn);
+        } catch (FailoverSuccessSQLException e) {
+          LOGGER.fine("FailoverSuccessSQLException during queryInstanceId after endpoint change. "
+              + "Retrying query on the new connection.");
+          instanceId2 = auroraUtil.queryInstanceId(conn);
+        }
         assertTrue(
             instanceId2.equals(newMember) || instanceId2.equals(instanceId1),
             "Expected connection to be on " + newMember + " or " + instanceId1
@@ -365,11 +372,26 @@ public class CustomEndpointTest {
       }
 
       // We should not be able to switch again because newMember was removed from the custom endpoint.
+      // A FailoverSuccessSQLException may occur here if the connection went stale during the endpoint
+      // modification (which takes ~140s). After a successful failover, the connection is still valid
+      // and we can retry the verification.
       if (newReadOnlyValue) {
         // We are connected to the writer. Attempting to switch to the reader will not work but will intentionally not
         // throw an exception. In this scenario we log a warning and purposefully stick with the writer.
-        conn.setReadOnly(newReadOnlyValue);
-        String newInstanceId = auroraUtil.queryInstanceId(conn);
+        try {
+          conn.setReadOnly(newReadOnlyValue);
+        } catch (FailoverSuccessSQLException e) {
+          LOGGER.fine("FailoverSuccessSQLException during setReadOnly after endpoint revert. "
+              + "This is acceptable during custom endpoint modifications.");
+        }
+        String newInstanceId;
+        try {
+          newInstanceId = auroraUtil.queryInstanceId(conn);
+        } catch (FailoverSuccessSQLException e) {
+          LOGGER.fine("FailoverSuccessSQLException during queryInstanceId after endpoint revert. "
+              + "Retrying query on the new connection.");
+          newInstanceId = auroraUtil.queryInstanceId(conn);
+        }
         assertEquals(instanceId1, newInstanceId);
       } else {
         // We are connected to the reader. Attempting to switch to the writer will throw an exception.

--- a/wrapper/src/test/java/integration/container/tests/CustomEndpointTest.java
+++ b/wrapper/src/test/java/integration/container/tests/CustomEndpointTest.java
@@ -286,7 +286,8 @@ public class CustomEndpointTest {
   }
 
   @TestTemplate
-  public void testCustomEndpointReadWriteSplitting_withCustomEndpointChanges() throws SQLException {
+  public void testCustomEndpointReadWriteSplitting_withCustomEndpointChanges()
+      throws SQLException, InterruptedException {
     TestEnvironmentInfo envInfo = TestEnvironment.getCurrent().getInfo();
     final TestDatabaseInfo dbInfo = envInfo.getDatabaseInfo();
     final int port = dbInfo.getClusterEndpointPort();
@@ -334,24 +335,21 @@ public class CustomEndpointTest {
       try {
         waitUntilEndpointHasMembers(client, endpointId, Arrays.asList(instanceId1, newMember));
 
+        // Wait for the driver's internal custom endpoint monitor to pick up the change.
+        // The waitUntilEndpointHasMembers call above confirms the change at the AWS API level,
+        // but the driver's CustomEndpointMonitorImpl polls on its own interval
+        // (customEndpointInfoRefreshRateMs, default 30s). We need to wait for at least one full
+        // monitor cycle so the driver's internal allowed hosts list is updated.
+        TimeUnit.SECONDS.sleep(35);
+
         // We should now be able to switch to newMember.
-        // During custom endpoint changes, a FailoverSuccessSQLException may occur if the driver
-        // detects a topology change and triggers an internal failover. This is acceptable behavior
-        // since the connection will still end up on a valid endpoint member.
         try {
           conn.setReadOnly(newReadOnlyValue);
         } catch (FailoverSuccessSQLException e) {
           LOGGER.fine("FailoverSuccessSQLException during setReadOnly after endpoint change. "
               + "This is acceptable during custom endpoint modifications.");
         }
-        String instanceId2;
-        try {
-          instanceId2 = auroraUtil.queryInstanceId(conn);
-        } catch (FailoverSuccessSQLException e) {
-          LOGGER.fine("FailoverSuccessSQLException during queryInstanceId after endpoint change. "
-              + "Retrying query on the new connection.");
-          instanceId2 = auroraUtil.queryInstanceId(conn);
-        }
+        String instanceId2 = auroraUtil.queryInstanceId(conn);
         assertTrue(
             instanceId2.equals(newMember) || instanceId2.equals(instanceId1),
             "Expected connection to be on " + newMember + " or " + instanceId1
@@ -371,10 +369,10 @@ public class CustomEndpointTest {
         waitUntilEndpointHasMembers(client, endpointId, Collections.singletonList(instanceId1));
       }
 
+      // Wait for the driver's internal custom endpoint monitor to pick up the revert.
+      TimeUnit.SECONDS.sleep(35);
+
       // We should not be able to switch again because newMember was removed from the custom endpoint.
-      // A FailoverSuccessSQLException may occur here if the connection went stale during the endpoint
-      // modification (which takes ~140s). After a successful failover, the connection is still valid
-      // and we can retry the verification.
       if (newReadOnlyValue) {
         // We are connected to the writer. Attempting to switch to the reader will not work but will intentionally not
         // throw an exception. In this scenario we log a warning and purposefully stick with the writer.
@@ -384,14 +382,7 @@ public class CustomEndpointTest {
           LOGGER.fine("FailoverSuccessSQLException during setReadOnly after endpoint revert. "
               + "This is acceptable during custom endpoint modifications.");
         }
-        String newInstanceId;
-        try {
-          newInstanceId = auroraUtil.queryInstanceId(conn);
-        } catch (FailoverSuccessSQLException e) {
-          LOGGER.fine("FailoverSuccessSQLException during queryInstanceId after endpoint revert. "
-              + "Retrying query on the new connection.");
-          newInstanceId = auroraUtil.queryInstanceId(conn);
-        }
+        String newInstanceId = auroraUtil.queryInstanceId(conn);
         assertEquals(instanceId1, newInstanceId);
       } else {
         // We are connected to the reader. Attempting to switch to the writer will throw an exception.

--- a/wrapper/src/test/java/integration/container/tests/CustomEndpointTest.java
+++ b/wrapper/src/test/java/integration/container/tests/CustomEndpointTest.java
@@ -332,7 +332,6 @@ public class CustomEndpointTest {
           builder ->
               builder.dbClusterEndpointIdentifier(endpointId).staticMembers(instanceId1, newMember));
 
-      boolean switchedToReader = false;
       try {
         waitUntilEndpointHasMembers(client, endpointId, Arrays.asList(instanceId1, newMember));
 
@@ -359,9 +358,6 @@ public class CustomEndpointTest {
             "Expected connection to be on " + newMember + " or " + instanceId1
                 + " but was on " + instanceId2);
 
-        // Determine if we actually switched to a reader or fell back to the writer.
-        switchedToReader = instanceId2.equals(newMember);
-
         // Switch back to original instance.
         try {
           conn.setReadOnly(!newReadOnlyValue);
@@ -381,16 +377,25 @@ public class CustomEndpointTest {
 
       // We should not be able to switch again because newMember was removed from the custom endpoint.
       if (newReadOnlyValue) {
-        if (switchedToReader) {
-          // We previously switched to a reader that is no longer in the endpoint after the revert.
-          // setReadOnly(true) should trigger a failover since the current reader is not allowed.
-          assertThrows(FailoverSuccessSQLException.class, () -> conn.setReadOnly(newReadOnlyValue));
-        } else {
-          // We previously fell back to the writer (no readers were available).
-          // setReadOnly(true) will again fall back to the writer silently — no failover expected.
-          conn.setReadOnly(newReadOnlyValue);
+        // We are connected to the writer. Attempting to switch to the reader will not throw an exception:
+        // - If we previously switched to a reader: the driver will close the reader (not in allowed hosts),
+        //   then try to find another reader. With no readers in the endpoint, it falls back to the writer
+        //   silently with a WARNING log.
+        // - If we previously fell back to the writer: setReadOnly(true) again falls back silently.
+        // In either case, no exception is thrown by setReadOnly.
+        conn.setReadOnly(newReadOnlyValue);
+
+        // queryInstanceId is the first network call after ~175s of inactivity (endpoint modification + sleep).
+        // The writer connection may have gone stale, in which case the driver triggers a writer failover
+        // and throws FailoverSuccessSQLException. After failover, the connection is valid — retry the query.
+        String newInstanceId;
+        try {
+          newInstanceId = auroraUtil.queryInstanceId(conn);
+        } catch (FailoverSuccessSQLException e) {
+          LOGGER.fine("FailoverSuccessSQLException during queryInstanceId after endpoint revert. "
+              + "Retrying query on the new connection.");
+          newInstanceId = auroraUtil.queryInstanceId(conn);
         }
-        String newInstanceId = auroraUtil.queryInstanceId(conn);
         assertEquals(instanceId1, newInstanceId);
       } else {
         // We are connected to the reader. Attempting to switch to the writer will throw an exception.

--- a/wrapper/src/test/java/integration/container/tests/CustomEndpointTest.java
+++ b/wrapper/src/test/java/integration/container/tests/CustomEndpointTest.java
@@ -332,6 +332,7 @@ public class CustomEndpointTest {
           builder ->
               builder.dbClusterEndpointIdentifier(endpointId).staticMembers(instanceId1, newMember));
 
+      boolean switchedToReader = false;
       try {
         waitUntilEndpointHasMembers(client, endpointId, Arrays.asList(instanceId1, newMember));
 
@@ -358,6 +359,9 @@ public class CustomEndpointTest {
             "Expected connection to be on " + newMember + " or " + instanceId1
                 + " but was on " + instanceId2);
 
+        // Determine if we actually switched to a reader or fell back to the writer.
+        switchedToReader = instanceId2.equals(newMember);
+
         // Switch back to original instance.
         try {
           conn.setReadOnly(!newReadOnlyValue);
@@ -377,13 +381,14 @@ public class CustomEndpointTest {
 
       // We should not be able to switch again because newMember was removed from the custom endpoint.
       if (newReadOnlyValue) {
-        // We are connected to the writer. Attempting to switch to the reader will not work but will intentionally not
-        // throw an exception. In this scenario we log a warning and purposefully stick with the writer.
-        try {
+        if (switchedToReader) {
+          // We previously switched to a reader that is no longer in the endpoint after the revert.
+          // setReadOnly(true) should trigger a failover since the current reader is not allowed.
+          assertThrows(FailoverSuccessSQLException.class, () -> conn.setReadOnly(newReadOnlyValue));
+        } else {
+          // We previously fell back to the writer (no readers were available).
+          // setReadOnly(true) will again fall back to the writer silently — no failover expected.
           conn.setReadOnly(newReadOnlyValue);
-        } catch (FailoverSuccessSQLException e) {
-          LOGGER.fine("FailoverSuccessSQLException during setReadOnly after endpoint revert. "
-              + "This is acceptable during custom endpoint modifications.");
         }
         String newInstanceId = auroraUtil.queryInstanceId(conn);
         assertEquals(instanceId1, newInstanceId);

--- a/wrapper/src/test/java/integration/container/tests/CustomEndpointTest.java
+++ b/wrapper/src/test/java/integration/container/tests/CustomEndpointTest.java
@@ -343,6 +343,9 @@ public class CustomEndpointTest {
         TimeUnit.SECONDS.sleep(35);
 
         // We should now be able to switch to newMember.
+        // During custom endpoint changes, a FailoverSuccessSQLException may occur if the driver
+        // detects a topology change and triggers an internal failover. This is acceptable behavior
+        // since the connection will still end up on a valid endpoint member.
         try {
           conn.setReadOnly(newReadOnlyValue);
         } catch (FailoverSuccessSQLException e) {


### PR DESCRIPTION
### Summary

Fix flaky `CustomEndpointTest.testCustomEndpointReadWriteSplitting_withCustomEndpointChanges` integration test

### Description

The `testCustomEndpointReadWriteSplitting_withCustomEndpointChanges` test was intermittently failing with `FailoverSuccessSQLException` in the `mysql-aurora-mariadb-driver` environment.

**Root cause:** 
The test modifies a custom endpoint's member list and then reverts it — each modification takes ~140 seconds. During this time, the underlying connection can go stale. When the test subsequently calls `setReadOnly()` or `queryInstanceId()`, the driver detects the stale connection (socket error), triggers a writer failover, and throws `FailoverSuccessSQLException`. The test already handled this exception on some `setReadOnly()` calls but not on `queryInstanceId()` calls or on the `setReadOnly()` in the final verification section.

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.