### PR TITLE
chore: upgrade jsqlparser to 4.9

### DIFF
--- a/examples/EncryptSpring/build.gradle.kts
+++ b/examples/EncryptSpring/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("software.amazon.awssdk:kms:2.46.3")
-    implementation("com.github.jsqlparser:jsqlparser:4.5")
+    implementation("com.github.jsqlparser:jsqlparser:4.9")
     implementation(project(":aws-advanced-jdbc-wrapper"))
     runtimeOnly("org.postgresql:postgresql")
 }

--- a/wrapper/build.gradle.kts
+++ b/wrapper/build.gradle.kts
@@ -54,7 +54,7 @@ dependencies {
     optionalImplementation("io.opentelemetry:opentelemetry-sdk:1.62.0")
     optionalImplementation("io.opentelemetry:opentelemetry-sdk-metrics:1.62.0")
     optionalImplementation("io.valkey:valkey-glide:2.3.0:$nativeClassifier")
-    optionalImplementation("com.github.jsqlparser:jsqlparser:4.5")
+    optionalImplementation("com.github.jsqlparser:jsqlparser:4.9")
 
     compileOnly("org.checkerframework:checker-qual:3.55.1")
     compileOnly("com.mysql:mysql-connector-j:9.6.0")

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/encryption/parser/JSQLParserAnalyzer.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/encryption/parser/JSQLParserAnalyzer.java
@@ -141,14 +141,15 @@ public final class JSQLParserAnalyzer {
   }
 
   private static void extractFromSelect(Select select, QueryAnalysis analysis) {
-    // Extract table names
+    // Extract table names. In jsqlparser 4.9, Select implements both Statement and
+    // Expression, so the Statement cast is required to disambiguate the getTables overloads.
     TablesNamesFinder tablesFinder = new TablesNamesFinder();
-    List<String> tableList = tablesFinder.getTableList(select);
-    analysis.tables.addAll(tableList);
+    analysis.tables.addAll(tablesFinder.getTables((Statement) select));
 
-    // Extract columns from SELECT clause
-    if (select.getSelectBody() instanceof PlainSelect) {
-      PlainSelect plainSelect = (PlainSelect) select.getSelectBody();
+    // Extract columns from SELECT clause. In jsqlparser 4.9, Select is itself the
+    // body, so PlainSelect can be obtained via a direct instanceof check.
+    if (select instanceof PlainSelect) {
+      PlainSelect plainSelect = (PlainSelect) select;
 
       // Extract WHERE clause columns only if there are parameters
       if (plainSelect.getWhere() != null) {


### PR DESCRIPTION
### Summary

Bump `com.github.jsqlparser:jsqlparser` from 4.5 to 4.9 and adapt `JSQLParserAnalyzer` to the new API. 

### Description

- Replace the deprecated `getTableList(Statement)` with `getTables(Statement)`  (the new non-deprecated API). A `(Statement)` cast is required to  disambiguate the overloads.
- Drop the deprecated `Select.getSelectBody()` — in 4.9 it just returns `this`,  so we use the `Select` reference directly when checking for `PlainSelect`.

The dependency version is bumped in:

- `wrapper/build.gradle.kts` (optional implementation)
- `examples/EncryptSpring/build.gradle.kts`


### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.