### PR TITLE
fix: lower failover-success log level from SEVERE to INFO

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/failover/FailoverConnectionPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/failover/FailoverConnectionPlugin.java
@@ -679,7 +679,7 @@ public class FailoverConnectionPlugin extends AbstractConnectionPlugin implement
     } else {
       // "The active SQL connection has changed due to a connection failure. Please re-configure
       // session state if required. "
-      LOGGER.severe(() -> Messages.get("Failover.connectionChangedError"));
+      LOGGER.info(() -> Messages.get("Failover.connectionChangedError"));
       throw new FailoverSuccessSQLException();
     }
   }

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/failover2/FailoverConnectionPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/failover2/FailoverConnectionPlugin.java
@@ -625,7 +625,7 @@ public class FailoverConnectionPlugin extends AbstractConnectionPlugin implement
     } else {
       // "The active SQL connection has changed due to a connection failure. Please re-configure
       // session state if required. "
-      LOGGER.severe(() -> Messages.get("Failover.connectionChangedError"));
+      LOGGER.info(() -> Messages.get("Failover.connectionChangedError"));
       throw new FailoverSuccessSQLException();
     }
   }


### PR DESCRIPTION
### Summary

Lower the log level emitted when a successful failover throws `FailoverSuccessSQLException` from `SEVERE` to `INFO`.

### Description

Resolves #1951.

`throwFailoverSuccessException` in both `failover` and `failover2` plugins logs at `SEVERE` and then throws `FailoverSuccessSQLException` to signal that the connection switched. Apps that already handle the exception receive spurious `SEVERE` alerts in their error monitoring systems.

Changed `LOGGER.severe(...)` to `LOGGER.info(...)` on the failover-success path in:
- `failover/FailoverConnectionPlugin.java`
- `failover2/FailoverConnectionPlugin.java`

The transaction-resolution-unknown branch in the same method already logs at `INFO`, so this aligns the two paths.

### Additional Reviewers

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.