### PR TITLE
chore(deps): bump org.hibernate:hibernate-core to org.hibernate.orm:hibernate-core 7.4.1.Final

### DIFF
--- a/wrapper/build.gradle.kts
+++ b/wrapper/build.gradle.kts
@@ -220,7 +220,7 @@ dependencies {
     add(java17.implementationConfigurationName, "tools.jackson.core:jackson-databind:3.1.3")
     add(java24.compileOnlyConfigurationName, "org.checkerframework:checker-qual:3.55.1")
     // Hibernate test dependencies (Java 17+)
-    add(hibernateTest.implementationConfigurationName, "org.hibernate:hibernate-core:7.3.5.Final")
+    add(hibernateTest.implementationConfigurationName, "org.hibernate.orm:hibernate-core:7.4.1.Final")
     add(hibernateTest.implementationConfigurationName, "jakarta.persistence:jakarta.persistence-api:3.2.0")
 }
 

--- a/wrapper/src/test/build.gradle.kts
+++ b/wrapper/src/test/build.gradle.kts
@@ -100,7 +100,7 @@ tasks.named<JavaCompile>(hibernateTest.compileJavaTaskName) {
 
 dependencies {
     // Hibernate test dependencies (Java 17+)
-    add(hibernateTest.implementationConfigurationName, "org.hibernate:hibernate-core:7.3.0.Final")
+    add(hibernateTest.implementationConfigurationName, "org.hibernate.orm:hibernate-core:7.4.1.Final")
     add(hibernateTest.implementationConfigurationName, "jakarta.persistence:jakarta.persistence-api:3.2.0")
 }
 


### PR DESCRIPTION
### Summary
Bumps Hibernate ORM used in the wrapper's `hibernateTest` source set to 7.4.1.Final, and migrates the dependency coordinate from the legacy group id `org.hibernate` to the new GA `org.hibernate.orm` introduced with the 7.4 series.

Supersedes #1956. Dependabot's bump in #1956 fails because it only changes the version, keeping the legacy `org.hibernate:hibernate-core` coordinate. Starting with 7.4, that artifact is a Maven relocation pointing at `org.hibernate.orm:hibernate-core`, and the new BOM (`hibernate-platform`) declares the legacy coordinate as a Gradle capability. Gradle then sees the same capability (`org.hibernate:hibernate-core`) declared by both modules and rejects them both with a capability conflict, so `compileHibernateTestJava` cannot resolve its classpath. Because every `Test` task in `wrapper/build.gradle.kts` depends on `compileHibernateTestJava`, this caused the unit test job and all 12 Docker/Caching matrix jobs in #1956 to fail at build setup, before any test ran.