### PR TITLE
docs: add other AWS Advanced Wrapper drivers to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,8 +315,6 @@ The AWS Advanced JDBC Wrapper is part of a broader family of AWS "wrapper" drive
 | AWS Advanced NodeJS Wrapper             | https://github.com/aws/aws-advanced-nodejs-wrapper                  |
 | AWS Advanced Go Wrapper                 | https://github.com/aws/aws-advanced-go-wrapper                      |
 | AWS Advanced .NET Wrapper               | https://github.com/aws/aws-advanced-dotnet-data-provider-wrapper    |
-| AWS ODBC Driver for MySQL               | https://github.com/aws/aws-mysql-odbc                               |
-| AWS ODBC Driver for PostgreSQL          | https://github.com/aws/aws-pgsql-odbc                               |
 | AWS Advanced ODBC Wrapper               | https://github.com/aws/aws-advanced-odbc-wrapper                    |
 
 ## Getting Help and Opening Issues

--- a/README.md
+++ b/README.md
@@ -306,6 +306,19 @@ Please note that Aurora Global Database and RDS Multi-AZ clusters with Blue/Gree
 | Using the AWS Advanced JDBC Wrapper with Telemetry and using the AWS Distro for OpenTelemetry Collector                                                                                                              |                                                                                                                     [PostgreSQL](examples/AWSDriverExample/src/main/java/software/amazon/TelemetryMetricsOTLPExample.java)                                                                                                                     |
 | Using the AWS Advanced JDBC Wrapper with Telemetry and using the AWS X-Ray Daemon                                                                                                                                    |                                                                                                                    [PostgreSQL](./examples/AWSDriverExample/src/main/java/software/amazon/TelemetryTracingXRayExample.java)                                                                                                                    |
 
+## Other AWS Advanced Wrapper Drivers
+The AWS Advanced JDBC Wrapper is part of a broader family of AWS "wrapper" drivers that bring the same advanced functionality, such as failover support and IAM authentication, to other languages and database connectivity standards. If you are working outside of Java, you may find one of the following drivers useful:
+
+| Driver                                  | Repository                                                          |
+|-----------------------------------------|---------------------------------------------------------------------|
+| AWS Advanced Python Wrapper             | https://github.com/aws/aws-advanced-python-wrapper                  |
+| AWS Advanced NodeJS Wrapper             | https://github.com/aws/aws-advanced-nodejs-wrapper                  |
+| AWS Advanced Go Wrapper                 | https://github.com/aws/aws-advanced-go-wrapper                      |
+| AWS Advanced .NET Wrapper               | https://github.com/aws/aws-advanced-dotnet-data-provider-wrapper    |
+| AWS ODBC Driver for MySQL               | https://github.com/aws/aws-mysql-odbc                               |
+| AWS ODBC Driver for PostgreSQL          | https://github.com/aws/aws-pgsql-odbc                               |
+| AWS Advanced ODBC Wrapper               | https://github.com/aws/aws-advanced-odbc-wrapper                    |
+
 ## Getting Help and Opening Issues
 If you encounter a bug with the AWS Advanced JDBC Wrapper, we would like to hear about it.
 Please search the [existing issues](https://github.com/aws/aws-advanced-jdbc-wrapper/issues) to see if others are also experiencing the issue before reporting the problem in a new issue. GitHub issues are intended for bug reports and feature requests.


### PR DESCRIPTION
## Summary
Adds a new "Other AWS Advanced Wrapper Drivers" section to the README that lists the broader family of AWS "wrapper" drivers available for other languages and connectivity standards, each with a link to its repository.

The section includes:
- AWS Advanced Python Wrapper
- AWS Advanced NodeJS Wrapper
- AWS Advanced Go Wrapper
- AWS Advanced .NET Wrapper
- AWS Advanced ODBC Wrapper

## Why
Helps users who are working outside of Java discover the equivalent AWS Advanced Wrapper driver for their language/stack.

## Testing
Documentation-only change. No code modified; no tests required.