### PR TITLE
chore: fix required tasks for docs-only PRs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -129,3 +129,21 @@ jobs:
           name: 'junit-report'
           path: ./wrapper/build/reports/tests/test/
           retention-days: 3
+
+  ci-gate:
+    name: 'CI Gate'
+    needs: [check-changes, markdown-link-check, lint, test]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Verify required jobs did not fail'
+        run: |
+          # Fail only if a needed job actually failed or was cancelled.
+          # Skipped jobs (e.g. tests on doc-only PRs) are treated as passing,
+          # so this gate is the single required status check for branch protection.
+          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" \
+             || "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "A required job failed or was cancelled."
+            exit 1
+          fi
+          echo "All required jobs passed or were legitimately skipped."

--- a/.github/workflows/run-standard-integration-tests.yml
+++ b/.github/workflows/run-standard-integration-tests.yml
@@ -165,3 +165,21 @@ jobs:
           name: html-summary-report-caching-${{ matrix.engine }}-${{ matrix.jvm }}
           path: ./wrapper/build/report
           retention-days: 5
+
+  integration-gate:
+    name: 'Standard Integration Tests Gate'
+    needs: [check-changes, docker-tests, caching-tests]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Verify required jobs did not fail'
+        run: |
+          # Fail only if a needed job actually failed or was cancelled.
+          # Skipped jobs (e.g. tests on doc-only PRs) are treated as passing,
+          # so this gate is the single required status check for branch protection.
+          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" \
+             || "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "A required job failed or was cancelled."
+            exit 1
+          fi
+          echo "All required jobs passed or were legitimately skipped."


### PR DESCRIPTION
### Summary

Stop doc-only PRs from being blocked by skipped required test checks.

### Description

Doc-only PRs currently can't merge without an admin override. The CI workflows already skip the heavy test/lint/docker jobs on doc-only changes (via the `only_docs` check), but those same jobs are configured as required status checks in branch protection. A skipped job never reports `success`, so the required check waits forever and a maintainer has to override the rules to merge (e.g. #1941).

This adds a single aggregation "gate" job to each PR workflow:

- `main.yml`: `CI Gate` (depends on `check-changes`, `markdown-link-check`, `lint`, `test`)
- `run-standard-integration-tests.yml`: `Standard Integration Tests Gate` (depends on `check-changes`, `docker-tests`, `caching-tests`)

Each gate runs with `if: always()` and fails only when a needed job reports `failure` or `cancelled`. Skipped jobs are treated as passing, so doc-only PRs go green automatically while code PRs stay fully enforced.

Follow-up (repo settings, not in this PR): make `CI Gate` and `Standard Integration Tests Gate` the required status checks and remove the individual job names (which also drops the brittle matrix-named checks from branch protection).



### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.