### PR TITLE
fix: Read/Write Splitting Plugin falls back to writer when a reader is unreachable (#1324)

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/ReadWriteSplittingPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/ReadWriteSplittingPlugin.java
@@ -31,6 +31,7 @@ import software.amazon.jdbc.JdbcCallable;
 import software.amazon.jdbc.PluginService;
 import software.amazon.jdbc.PropertyDefinition;
 import software.amazon.jdbc.cleanup.CanReleaseResources;
+import software.amazon.jdbc.hostavailability.HostAvailability;
 import software.amazon.jdbc.hostlistprovider.HostListProviderService;
 import software.amazon.jdbc.util.CacheItem;
 import software.amazon.jdbc.util.LogUtils;
@@ -214,14 +215,33 @@ public class ReadWriteSplittingPlugin extends AbstractReadWriteSplittingPlugin
     final List<HostSpec> hostCandidates = this.getReaderHostCandidates();
     int connAttempts = hostCandidates.size() * 2;
     for (int i = 0; i < connAttempts; i++) {
-      HostSpec hostSpec = this.pluginService.getHostSpecByStrategy(
+      final HostSpec hostSpec = this.pluginService.getHostSpecByStrategy(
           hostCandidates, HostRole.READER, this.readerSelectorStrategy);
+
+      // No eligible (AVAILABLE) reader is left. Stop retrying and fall back to the writer instead of
+      // continuing to spend the connect timeout on hosts that are already known to be unreachable.
+      if (hostSpec == null) {
+        break;
+      }
+
       try {
         conn = this.pluginService.connect(hostSpec, this.properties, this);
         this.isReaderConnFromInternalPool = Boolean.TRUE.equals(this.pluginService.isPooledConnection());
         readerHost = hostSpec;
         break;
       } catch (final SQLException e) {
+        // A login/authentication failure (e.g. wrong credentials, expired IAM token) is a
+        // showstopper: retrying other readers won't help, so rethrow immediately.
+        if (this.pluginService.isLoginException(e, this.pluginService.getTargetDriverDialect())) {
+          throw e;
+        }
+
+        // Otherwise mark the failed reader as unavailable so the host selector skips it for the
+        // remaining attempts in this loop and, thanks to the host availability cache, for
+        // subsequent requests until the cache entry expires. This avoids repeatedly paying the
+        // connect timeout on a reader that cannot be reached (e.g. when its subnet is
+        // network-partitioned).
+        this.pluginService.setAvailability(hostSpec, HostAvailability.NOT_AVAILABLE);
         if (LOGGER.isLoggable(Level.WARNING)) {
           LOGGER.log(Level.WARNING,
               Messages.get(

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/ReadWriteSplittingPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/ReadWriteSplittingPlugin.java
@@ -31,7 +31,6 @@ import software.amazon.jdbc.JdbcCallable;
 import software.amazon.jdbc.PluginService;
 import software.amazon.jdbc.PropertyDefinition;
 import software.amazon.jdbc.cleanup.CanReleaseResources;
-import software.amazon.jdbc.hostavailability.HostAvailability;
 import software.amazon.jdbc.hostlistprovider.HostListProviderService;
 import software.amazon.jdbc.util.CacheItem;
 import software.amazon.jdbc.util.LogUtils;
@@ -212,13 +211,20 @@ public class ReadWriteSplittingPlugin extends AbstractReadWriteSplittingPlugin
     Connection conn = null;
     HostSpec readerHost = null;
 
-    final List<HostSpec> hostCandidates = this.getReaderHostCandidates();
-    int connAttempts = hostCandidates.size() * 2;
-    for (int i = 0; i < connAttempts; i++) {
+    // Work on a local, mutable copy of the candidate hosts. When a connection attempt to a reader
+    // fails (for a non-login reason), the host is removed from this local list so it is not retried
+    // within this call. This is a local, per-call view of host availability and intentionally has
+    // no global side effects (it does not mark the host NOT_AVAILABLE in the shared availability
+    // cache), so a host that recovers is immediately eligible again on the next request.
+    final List<HostSpec> hostCandidates = new ArrayList<>(this.getReaderHostCandidates());
+    // Bound the number of attempts by the initial candidate count so a host selector that keeps
+    // returning the same host can never cause an infinite loop.
+    final int maxAttempts = hostCandidates.size();
+    for (int i = 0; i < maxAttempts && !hostCandidates.isEmpty(); i++) {
       final HostSpec hostSpec = this.pluginService.getHostSpecByStrategy(
           hostCandidates, HostRole.READER, this.readerSelectorStrategy);
 
-      // No eligible (AVAILABLE) reader is left. Stop retrying and fall back to the writer instead of
+      // No eligible reader is left. Stop retrying and fall back to the writer instead of
       // continuing to spend the connect timeout on hosts that are already known to be unreachable.
       if (hostSpec == null) {
         break;
@@ -236,12 +242,9 @@ public class ReadWriteSplittingPlugin extends AbstractReadWriteSplittingPlugin
           throw e;
         }
 
-        // Otherwise mark the failed reader as unavailable so the host selector skips it for the
-        // remaining attempts in this loop and, thanks to the host availability cache, for
-        // subsequent requests until the cache entry expires. This avoids repeatedly paying the
-        // connect timeout on a reader that cannot be reached (e.g. when its subnet is
-        // network-partitioned).
-        this.pluginService.setAvailability(hostSpec, HostAvailability.NOT_AVAILABLE);
+        // Remove the failed reader from the local candidate list so it is not retried again during
+        // this call, then continue trying the remaining readers.
+        hostCandidates.remove(hostSpec);
         if (LOGGER.isLoggable(Level.WARNING)) {
           LOGGER.log(Level.WARNING,
               Messages.get(

--- a/wrapper/src/test/java/integration/container/TestDriverProvider.java
+++ b/wrapper/src/test/java/integration/container/TestDriverProvider.java
@@ -31,6 +31,7 @@ import integration.TestEnvironmentFeatures;
 import integration.TestEnvironmentInfo;
 import integration.TestEnvironmentRequest;
 import integration.TestInstanceInfo;
+import integration.container.aurora.TestPluginServiceImpl;
 import integration.container.condition.EnableBasedOnEnvironmentFeatureExtension;
 import integration.container.condition.EnableBasedOnTestDriverExtension;
 import integration.container.condition.MakeSureFirstInstanceWriter;
@@ -217,6 +218,9 @@ public class TestDriverProvider implements TestTemplateInvocationContextProvider
     Driver.resetCustomTargetDriverDialect();
     Driver.resetCustomConnectionProvider();
     Driver.resetConnectionInitFunc();
+    // Reset the static host availability cache so a host marked NOT_AVAILABLE in one test
+    // (e.g. by failover or read/write splitting) does not leak into subsequent tests.
+    TestPluginServiceImpl.clearHostAvailabilityCache();
   }
 
   public static void checkClusterHealth(final boolean makeSureFirstInstanceWriter)

--- a/wrapper/src/test/java/integration/container/tests/ReadWriteSplittingTests.java
+++ b/wrapper/src/test/java/integration/container/tests/ReadWriteSplittingTests.java
@@ -74,10 +74,8 @@ import software.amazon.jdbc.ConnectionProviderManager;
 import software.amazon.jdbc.Driver;
 import software.amazon.jdbc.HikariPoolConfigurator;
 import software.amazon.jdbc.HikariPooledConnectionProvider;
-import software.amazon.jdbc.HostSpec;
 import software.amazon.jdbc.PluginService;
 import software.amazon.jdbc.PropertyDefinition;
-import software.amazon.jdbc.hostavailability.HostAvailability;
 import software.amazon.jdbc.hostlistprovider.RdsHostListProvider;
 import software.amazon.jdbc.plugin.failover.FailoverConnectionPlugin;
 import software.amazon.jdbc.plugin.failover.FailoverFailedSQLException;
@@ -393,14 +391,14 @@ public class ReadWriteSplittingTests {
   @EnableOnNumOfInstances(min = 2, max = 2)
   @EnableOnDatabaseEngineDeployment(DatabaseEngineDeployment.AURORA)
   @EnableOnTestFeature(TestEnvironmentFeatures.NETWORK_OUTAGES_ENABLED)
-  public void test_setReadOnlyTrue_oneReaderDown_marksReaderUnavailableAndFallsBackToWriter()
+  public void test_setReadOnlyTrue_oneReaderDown_fallsBackToWriter()
       throws SQLException {
     // Reproduces https://github.com/aws/aws-advanced-jdbc-wrapper/issues/1324
     // In a 2-node Aurora cluster (1 writer, 1 reader), when the single reader becomes unreachable
-    // (e.g. its subnet is network-partitioned), setReadOnly(true) should fall back to the writer.
-    // The unreachable reader should be marked NOT_AVAILABLE so that subsequent setReadOnly(true)
-    // calls skip it and fall back to the writer immediately instead of repeatedly paying the
-    // connect timeout.
+    // (e.g. its subnet is network-partitioned), setReadOnly(true) should fall back to the writer
+    // instead of getting stuck retrying the unreachable reader. Once the reader becomes reachable
+    // again, setReadOnly(true) should use it without requiring any availability cache reset (the
+    // plugin tracks failed readers only locally per call and has no global side effects).
     try (final Connection conn = DriverManager.getConnection(
         ConnectionStringHelper.getProxyWrapperUrl(), getProxiedProps())) {
 
@@ -421,27 +419,16 @@ public class ReadWriteSplittingTests {
       assertDoesNotThrow(() -> conn.setReadOnly(true));
       assertEquals(writerConnectionId, assertDoesNotThrow(() -> auroraUtil.queryInstanceId(conn)));
 
-      // The unreachable reader should have been marked NOT_AVAILABLE.
-      final PluginService pluginService = conn.unwrap(PluginService.class);
-      final HostSpec unavailableReader = pluginService.getAllHosts().stream()
-          .filter(h -> readerConnectionId.equals(h.getHostId())
-              || h.getHost().startsWith(readerConnectionId + "."))
-          .findFirst()
-          .orElse(null);
-      assertNotNull(unavailableReader,
-          "Reader host '" + readerConnectionId + "' was not found in the topology.");
-      assertEquals(HostAvailability.NOT_AVAILABLE, unavailableReader.getAvailability());
-
       // A subsequent setReadOnly(true) should still fall back to the writer without throwing.
       conn.setReadOnly(false);
       assertEquals(writerConnectionId, auroraUtil.queryInstanceId(conn));
       assertDoesNotThrow(() -> conn.setReadOnly(true));
       assertEquals(writerConnectionId, assertDoesNotThrow(() -> auroraUtil.queryInstanceId(conn)));
 
-      // Restore connectivity. After the reader becomes available again the plugin can use it.
+      // Restore connectivity. The reader should be usable again on the next request without any
+      // availability cache reset, since the plugin does not mark hosts NOT_AVAILABLE globally.
       ProxyHelper.enableAllConnectivity();
-      TestPluginServiceImpl.clearHostAvailabilityCache();
-      pluginService.forceRefreshHostList();
+      conn.unwrap(PluginService.class).forceRefreshHostList();
 
       conn.setReadOnly(false);
       assertEquals(writerConnectionId, auroraUtil.queryInstanceId(conn));

--- a/wrapper/src/test/java/integration/container/tests/ReadWriteSplittingTests.java
+++ b/wrapper/src/test/java/integration/container/tests/ReadWriteSplittingTests.java
@@ -74,8 +74,10 @@ import software.amazon.jdbc.ConnectionProviderManager;
 import software.amazon.jdbc.Driver;
 import software.amazon.jdbc.HikariPoolConfigurator;
 import software.amazon.jdbc.HikariPooledConnectionProvider;
+import software.amazon.jdbc.HostSpec;
 import software.amazon.jdbc.PluginService;
 import software.amazon.jdbc.PropertyDefinition;
+import software.amazon.jdbc.hostavailability.HostAvailability;
 import software.amazon.jdbc.hostlistprovider.RdsHostListProvider;
 import software.amazon.jdbc.plugin.failover.FailoverConnectionPlugin;
 import software.amazon.jdbc.plugin.failover.FailoverFailedSQLException;
@@ -384,6 +386,67 @@ public class ReadWriteSplittingTests {
       assertDoesNotThrow(() -> conn.setReadOnly(true));
       currentConnectionId = auroraUtil.queryInstanceId(conn);
       assertNotEquals(writerConnectionId, currentConnectionId);
+    }
+  }
+
+  @TestTemplate
+  @EnableOnNumOfInstances(min = 2, max = 2)
+  @EnableOnDatabaseEngineDeployment(DatabaseEngineDeployment.AURORA)
+  @EnableOnTestFeature(TestEnvironmentFeatures.NETWORK_OUTAGES_ENABLED)
+  public void test_setReadOnlyTrue_oneReaderDown_marksReaderUnavailableAndFallsBackToWriter()
+      throws SQLException {
+    // Reproduces https://github.com/aws/aws-advanced-jdbc-wrapper/issues/1324
+    // In a 2-node Aurora cluster (1 writer, 1 reader), when the single reader becomes unreachable
+    // (e.g. its subnet is network-partitioned), setReadOnly(true) should fall back to the writer.
+    // The unreachable reader should be marked NOT_AVAILABLE so that subsequent setReadOnly(true)
+    // calls skip it and fall back to the writer immediately instead of repeatedly paying the
+    // connect timeout.
+    try (final Connection conn = DriverManager.getConnection(
+        ConnectionStringHelper.getProxyWrapperUrl(), getProxiedProps())) {
+
+      final String writerConnectionId = auroraUtil.queryInstanceId(conn);
+
+      // Confirm the reader is reachable while connectivity is up.
+      conn.setReadOnly(true);
+      final String readerConnectionId = auroraUtil.queryInstanceId(conn);
+      assertNotEquals(writerConnectionId, readerConnectionId);
+
+      conn.setReadOnly(false);
+      assertEquals(writerConnectionId, auroraUtil.queryInstanceId(conn));
+
+      // Disable connectivity to the single reader instance.
+      ProxyHelper.disableConnectivity(readerConnectionId);
+
+      // setReadOnly(true) must not get stuck and must fall back to the writer.
+      assertDoesNotThrow(() -> conn.setReadOnly(true));
+      assertEquals(writerConnectionId, assertDoesNotThrow(() -> auroraUtil.queryInstanceId(conn)));
+
+      // The unreachable reader should have been marked NOT_AVAILABLE.
+      final PluginService pluginService = conn.unwrap(PluginService.class);
+      final HostSpec unavailableReader = pluginService.getAllHosts().stream()
+          .filter(h -> readerConnectionId.equals(h.getHostId())
+              || h.getHost().startsWith(readerConnectionId + "."))
+          .findFirst()
+          .orElse(null);
+      assertNotNull(unavailableReader,
+          "Reader host '" + readerConnectionId + "' was not found in the topology.");
+      assertEquals(HostAvailability.NOT_AVAILABLE, unavailableReader.getAvailability());
+
+      // A subsequent setReadOnly(true) should still fall back to the writer without throwing.
+      conn.setReadOnly(false);
+      assertEquals(writerConnectionId, auroraUtil.queryInstanceId(conn));
+      assertDoesNotThrow(() -> conn.setReadOnly(true));
+      assertEquals(writerConnectionId, assertDoesNotThrow(() -> auroraUtil.queryInstanceId(conn)));
+
+      // Restore connectivity. After the reader becomes available again the plugin can use it.
+      ProxyHelper.enableAllConnectivity();
+      TestPluginServiceImpl.clearHostAvailabilityCache();
+      pluginService.forceRefreshHostList();
+
+      conn.setReadOnly(false);
+      assertEquals(writerConnectionId, auroraUtil.queryInstanceId(conn));
+      conn.setReadOnly(true);
+      assertEquals(readerConnectionId, auroraUtil.queryInstanceId(conn));
     }
   }
 

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/readwritesplitting/ReadWriteSplittingPluginTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/readwritesplitting/ReadWriteSplittingPluginTest.java
@@ -54,6 +54,7 @@ import software.amazon.jdbc.NodeChangeOptions;
 import software.amazon.jdbc.OldConnectionSuggestedAction;
 import software.amazon.jdbc.PluginService;
 import software.amazon.jdbc.PropertyDefinition;
+import software.amazon.jdbc.hostavailability.HostAvailability;
 import software.amazon.jdbc.hostavailability.SimpleHostAvailabilityStrategy;
 import software.amazon.jdbc.hostlistprovider.HostListProviderService;
 import software.amazon.jdbc.plugin.failover.FailoverSuccessSQLException;
@@ -330,6 +331,90 @@ public class ReadWriteSplittingPluginTest {
         null);
     plugin.switchConnectionIfRequired(true);
 
+    verify(mockPluginService, times(0))
+        .setCurrentConnection(any(Connection.class), any(HostSpec.class));
+    assertNull(plugin.getReaderConnection());
+  }
+
+  @Test
+  public void testSetReadOnly_true_readerConnectionFailed_marksReaderUnavailable() throws SQLException {
+    when(this.mockPluginService.getAllHosts()).thenReturn(singleReaderTopology);
+    when(this.mockPluginService.getHosts()).thenReturn(singleReaderTopology);
+    when(this.mockPluginService.connect(eq(readerHostSpec1), any(Properties.class), any()))
+        .thenThrow(SQLException.class);
+    // Simulate the host selector filtering out the reader once it has been marked unavailable:
+    // the first selection returns the reader, subsequent selections return null.
+    when(this.mockPluginService.getHostSpecByStrategy(anyList(), eq(HostRole.READER), eq("random")))
+        .thenReturn(readerHostSpec1)
+        .thenReturn(null);
+
+    final ReadWriteSplittingPlugin plugin = new ReadWriteSplittingPlugin(
+        mockPluginService,
+        defaultProps,
+        mockHostListProviderService,
+        mockWriterConn,
+        null);
+    plugin.switchConnectionIfRequired(true);
+
+    // The unreachable reader should be marked unavailable so it is skipped by the host selector
+    // on the remaining attempts and on subsequent requests until the availability cache expires.
+    verify(mockPluginService, times(1))
+        .setAvailability(eq(readerHostSpec1), eq(HostAvailability.NOT_AVAILABLE));
+    // Only a single connection attempt is made; the loop breaks early once no eligible reader remains.
+    verify(mockPluginService, times(1)).connect(eq(readerHostSpec1), any(Properties.class), any());
+    // The current writer connection is kept as a fallback.
+    verify(mockPluginService, times(0))
+        .setCurrentConnection(any(Connection.class), any(HostSpec.class));
+    assertNull(plugin.getReaderConnection());
+  }
+
+  @Test
+  public void testSetReadOnly_true_readerLoginFailed_doesNotMarkReaderUnavailable() throws SQLException {
+    when(this.mockPluginService.getAllHosts()).thenReturn(singleReaderTopology);
+    when(this.mockPluginService.getHosts()).thenReturn(singleReaderTopology);
+    when(this.mockPluginService.connect(eq(readerHostSpec1), any(Properties.class), any()))
+        .thenThrow(SQLException.class);
+    // The failure is a login/authentication failure, which does not indicate the host is unreachable.
+    when(this.mockPluginService.isLoginException(any(Throwable.class), any())).thenReturn(true);
+
+    final ReadWriteSplittingPlugin plugin = new ReadWriteSplittingPlugin(
+        mockPluginService,
+        defaultProps,
+        mockHostListProviderService,
+        mockWriterConn,
+        null);
+    plugin.switchConnectionIfRequired(true);
+
+    // A login failure must not mark the reader unavailable.
+    verify(mockPluginService, never())
+        .setAvailability(any(HostSpec.class), eq(HostAvailability.NOT_AVAILABLE));
+    // A login failure is a showstopper: the exception is rethrown immediately instead of retrying
+    // other readers, so only a single connection attempt is made.
+    verify(mockPluginService, times(1)).connect(eq(readerHostSpec1), any(Properties.class), any());
+    // The current writer connection is kept as a fallback.
+    verify(mockPluginService, times(0))
+        .setCurrentConnection(any(Connection.class), any(HostSpec.class));
+    assertNull(plugin.getReaderConnection());
+  }
+
+  @Test
+  public void testSetReadOnly_true_noEligibleReader_fallsBackToWriter() throws SQLException {
+    when(this.mockPluginService.getAllHosts()).thenReturn(singleReaderTopology);
+    when(this.mockPluginService.getHosts()).thenReturn(singleReaderTopology);
+    // No eligible (AVAILABLE) reader is returned by the selector.
+    when(this.mockPluginService.getHostSpecByStrategy(anyList(), eq(HostRole.READER), eq("random")))
+        .thenReturn(null);
+
+    final ReadWriteSplittingPlugin plugin = new ReadWriteSplittingPlugin(
+        mockPluginService,
+        defaultProps,
+        mockHostListProviderService,
+        mockWriterConn,
+        null);
+    plugin.switchConnectionIfRequired(true);
+
+    // No connection attempt should be made when there is no eligible reader.
+    verify(mockPluginService, never()).connect(eq(readerHostSpec1), any(Properties.class), any());
     verify(mockPluginService, times(0))
         .setCurrentConnection(any(Connection.class), any(HostSpec.class));
     assertNull(plugin.getReaderConnection());

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/readwritesplitting/ReadWriteSplittingPluginTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/readwritesplitting/ReadWriteSplittingPluginTest.java
@@ -337,16 +337,18 @@ public class ReadWriteSplittingPluginTest {
   }
 
   @Test
-  public void testSetReadOnly_true_readerConnectionFailed_marksReaderUnavailable() throws SQLException {
+  public void testSetReadOnly_true_readerConnectionFailed_triesEachReaderOnceThenFallsBack() throws SQLException {
     when(this.mockPluginService.getAllHosts()).thenReturn(singleReaderTopology);
     when(this.mockPluginService.getHosts()).thenReturn(singleReaderTopology);
     when(this.mockPluginService.connect(eq(readerHostSpec1), any(Properties.class), any()))
         .thenThrow(SQLException.class);
-    // Simulate the host selector filtering out the reader once it has been marked unavailable:
-    // the first selection returns the reader, subsequent selections return null.
+    // The selector returns the reader from the local candidate list until it is removed after the
+    // failed attempt, after which there is no eligible reader left.
     when(this.mockPluginService.getHostSpecByStrategy(anyList(), eq(HostRole.READER), eq("random")))
-        .thenReturn(readerHostSpec1)
-        .thenReturn(null);
+        .thenAnswer(invocation -> {
+          final List<HostSpec> candidates = invocation.getArgument(0);
+          return candidates.contains(readerHostSpec1) ? readerHostSpec1 : null;
+        });
 
     final ReadWriteSplittingPlugin plugin = new ReadWriteSplittingPlugin(
         mockPluginService,
@@ -356,12 +358,11 @@ public class ReadWriteSplittingPluginTest {
         null);
     plugin.switchConnectionIfRequired(true);
 
-    // The unreachable reader should be marked unavailable so it is skipped by the host selector
-    // on the remaining attempts and on subsequent requests until the availability cache expires.
-    verify(mockPluginService, times(1))
-        .setAvailability(eq(readerHostSpec1), eq(HostAvailability.NOT_AVAILABLE));
-    // Only a single connection attempt is made; the loop breaks early once no eligible reader remains.
+    // The failed reader should be tried exactly once (it is removed from the local candidate list
+    // after the failure), and no global availability state should be changed.
     verify(mockPluginService, times(1)).connect(eq(readerHostSpec1), any(Properties.class), any());
+    verify(mockPluginService, never())
+        .setAvailability(any(HostSpec.class), any(HostAvailability.class));
     // The current writer connection is kept as a fallback.
     verify(mockPluginService, times(0))
         .setCurrentConnection(any(Connection.class), any(HostSpec.class));
@@ -369,7 +370,7 @@ public class ReadWriteSplittingPluginTest {
   }
 
   @Test
-  public void testSetReadOnly_true_readerLoginFailed_doesNotMarkReaderUnavailable() throws SQLException {
+  public void testSetReadOnly_true_readerLoginFailed_rethrowsAndDoesNotChangeAvailability() throws SQLException {
     when(this.mockPluginService.getAllHosts()).thenReturn(singleReaderTopology);
     when(this.mockPluginService.getHosts()).thenReturn(singleReaderTopology);
     when(this.mockPluginService.connect(eq(readerHostSpec1), any(Properties.class), any()))
@@ -385,12 +386,12 @@ public class ReadWriteSplittingPluginTest {
         null);
     plugin.switchConnectionIfRequired(true);
 
-    // A login failure must not mark the reader unavailable.
-    verify(mockPluginService, never())
-        .setAvailability(any(HostSpec.class), eq(HostAvailability.NOT_AVAILABLE));
     // A login failure is a showstopper: the exception is rethrown immediately instead of retrying
     // other readers, so only a single connection attempt is made.
     verify(mockPluginService, times(1)).connect(eq(readerHostSpec1), any(Properties.class), any());
+    // No global availability state should be changed.
+    verify(mockPluginService, never())
+        .setAvailability(any(HostSpec.class), any(HostAvailability.class));
     // The current writer connection is kept as a fallback.
     verify(mockPluginService, times(0))
         .setCurrentConnection(any(Connection.class), any(HostSpec.class));
@@ -401,7 +402,7 @@ public class ReadWriteSplittingPluginTest {
   public void testSetReadOnly_true_noEligibleReader_fallsBackToWriter() throws SQLException {
     when(this.mockPluginService.getAllHosts()).thenReturn(singleReaderTopology);
     when(this.mockPluginService.getHosts()).thenReturn(singleReaderTopology);
-    // No eligible (AVAILABLE) reader is returned by the selector.
+    // No eligible reader is returned by the selector.
     when(this.mockPluginService.getHostSpecByStrategy(anyList(), eq(HostRole.READER), eq("random")))
         .thenReturn(null);
 


### PR DESCRIPTION
### Summary

Fix Read/Write Splitting Plugin getting stuck retrying an unreachable reader instead of falling back to the writer (#1324).

### Description

When the Read/Write Splitting Plugin is used and a reader instance becomes unreachable at the network level (for example, when its subnet is network-partitioned by AWS FIS `aws:network:disrupt-connectivity`), `setReadOnly(true)` could block for a long time before falling back to the writer. The reader stayed reported as `AVAILABLE` in the topology, so the reader-selection retry loop in `openNewReaderConnection()` kept re-picking the same dead reader, paying the full connect timeout on each of `hostCandidates.size() * 2` attempts (the ~40s observed in the issue).

EFM does not help here, because it only monitors the host of the currently active connection (the writer), not idle reader hosts the driver is not connected to.

**Changes in `ReadWriteSplittingPlugin.openNewReaderConnection()`:**

- Operate on a local, mutable copy of the reader candidate list. When a connection attempt to a reader fails (for a non-login reason), remove that host from the local list so it is not retried again within this call, then continue with the remaining readers. This is a per-call view of availability with **no global side effects** — it does not write to the shared host availability cache, so a host that recovers is immediately eligible again on the next request.
- Stop early and fall back to the writer when the host selector returns no eligible reader, instead of exhausting all attempts at full connect timeout.
- Bound the loop by the initial candidate count so a host selector that keeps returning the same host can never cause an infinite loop.
- If the failure is a login/authentication exception (e.g. wrong credentials, expired IAM token), rethrow immediately rather than retrying other readers, since retrying cannot help. This follows the existing pattern used by `IamAuthConnectionPlugin` (`pluginService.isLoginException(...)`).

An earlier iteration marked failed readers `NOT_AVAILABLE` via `pluginService.setAvailability(...)`. Integration testing showed that approach had unwanted global side effects: the shared host availability cache persists for 5 minutes and is not reset on recovery under the default `SimpleHostAvailabilityStrategy`, so a recovered reader stayed excluded and unrelated read/write-splitting and failover tests regressed. The local candidate-list approach avoids these side effects entirely.

**Effect:**
- The unreachable reader is tried at most once per `setReadOnly(true)` call, then the request falls back to the writer.
- Once the reader becomes reachable again, it is used on the next request without requiring any availability cache reset.
- A genuine credentials problem surfaces immediately instead of being masked by reader retries.

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.