### PR TITLE
chore: speed up unit test + coverage CI job (~12m to ~2m)

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/util/monitoring/AbstractMonitor.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/monitoring/AbstractMonitor.java
@@ -80,6 +80,12 @@ public abstract class AbstractMonitor implements Monitor, Runnable {
     LOGGER.fine(Messages.get("AbstractMonitor.stoppingMonitor", new Object[] {this}));
     this.stop.set(true);
 
+    // Initiate an orderly shutdown so that awaitTermination can return as soon as the monitor task
+    // finishes (or immediately if no task was ever submitted). Without this, awaitTermination always
+    // blocks for the full termination timeout. shutdown() is idempotent, so calling it here is safe
+    // even when start() already shut the executor down.
+    this.monitorExecutor.shutdown();
+
     try {
       if (!this.monitorExecutor.awaitTermination(this.terminationTimeoutSec.get(), TimeUnit.SECONDS)) {
         LOGGER.info(Messages.get(

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/srw/SimpleReadWriteSplittingPluginTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/srw/SimpleReadWriteSplittingPluginTest.java
@@ -343,6 +343,9 @@ public class SimpleReadWriteSplittingPluginTest {
 
   @Test
   public void testWrongRoleConnection_writerEndpointToReader() throws SQLException {
+    // Use a short connect-retry timeout: role verification never succeeds in this test, so the
+    // retry loop would otherwise spin for the full default 60s timeout.
+    SimpleReadWriteSplittingPlugin.SRW_CONNECT_RETRY_TIMEOUT_MS.set(defaultProps, "5");
     when(mockPluginService.getCurrentConnection()).thenReturn(mockReaderConn);
     when(mockPluginService.getCurrentHostSpec()).thenReturn(readerHostSpec);
     when(mockPluginService.isInTransaction()).thenReturn(false);
@@ -363,6 +366,9 @@ public class SimpleReadWriteSplittingPluginTest {
 
   @Test
   public void testWrongRoleConnection_readerEndpointToWriter() throws SQLException {
+    // Use a short connect-retry timeout: role verification never succeeds in this test, so the
+    // retry loop would otherwise spin for the full default 60s timeout.
+    SimpleReadWriteSplittingPlugin.SRW_CONNECT_RETRY_TIMEOUT_MS.set(defaultProps, "5");
     when(mockPluginService.getCurrentConnection()).thenReturn(mockWriterConn);
     when(mockPluginService.getCurrentHostSpec()).thenReturn(writerHostSpec);
     when(mockPluginService.isInTransaction()).thenReturn(false);


### PR DESCRIPTION
### Summary

Cut the `test jacocoTestReport jacocoTestCoverageVerification` CI job (the longest task in Main CI) from ~12 min to ~2 min, with no change to test coverage and all tests passing.

### Background

Profiling the unit-test run showed two test classes accounted for ~84% of the wall time, almost entirely idle waiting rather than real work:

| Time | Class | Cause |
|------|-------|-------|
| 420.6s | `efm.v1.HostMonitorV1ImplTest` | 14 tests x 30s each, all idle |
| 124.9s | `srw.SimpleReadWriteSplittingPluginTest` | 2 tests x 60s each, all idle |

### Changes

**1. `AbstractMonitor.stop()` (production fix)**

`stop()` called `monitorExecutor.awaitTermination(terminationTimeoutSec)` but never called `shutdown()` on the executor — `shutdown()` was only invoked in `start()`. As a result, stopping a monitor whose task had already finished (or was never started) always blocked for the full termination timeout (30s for `HostMonitorV1Impl`). `HostMonitorV1ImplTest` creates a monitor per test but never starts it, so every test paid 30s in `@AfterEach`.

Added `monitorExecutor.shutdown()` before `awaitTermination(...)`. `shutdown()` is idempotent, so it is safe even when `start()` already shut the executor down. This also reduces real-world monitor shutdown latency.

**2. `SimpleReadWriteSplittingPluginTest` (test fix)**

`testWrongRoleConnection_readerEndpointToWriter` and `testWrongRoleConnection_writerEndpointToReader` used the default `srwConnectRetryTimeoutMs` of 60000ms. Role verification never succeeds in these tests, so the retry loop spun for the full 60s. Set `SRW_CONNECT_RETRY_TIMEOUT_MS = "5"` on these two tests, matching the short-timeout pattern already used by the other retry tests in the same class.

### Results

| | Before | After |
|---|--------|-------|
| Full coverage job | 11m 59s | 2m 4s |
| Unit test phase | ~650s | ~112s |
| `HostMonitorV1ImplTest` | 420.6s | 1.5s |
| `SimpleReadWriteSplittingPluginTest` | 124.9s | 7.9s |

All 1106 unit tests pass (0 failed, 80 skipped). Coverage is unchanged.

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.