### PR TITLE
docs: Add examples for specifying driver properties

### DIFF
--- a/docs/using-the-jdbc-driver/UsingTheJdbcDriver.md
+++ b/docs/using-the-jdbc-driver/UsingTheJdbcDriver.md
@@ -91,13 +91,13 @@ jdbc:aws-wrapper:postgresql://<host_name>[:<port>]/[<database>][?paramOne=valueO
 
 For example:
 ```
-jdbc:aws-wrapper:postgresql://db.example.com/example?wrapperPlugins=failover,efm2&tcpKeepAlive=true
+jdbc:aws-wrapper:postgresql://db.example.com/example?wrapperPlugins=failover2,efm2&tcpKeepAlive=true
 ```
 
 Parameters can also be supplied through a `Properties` object. Note that when a property is set in both the connection string and the `Properties` object, the connection string value takes precedence.
 ```java
 final Properties properties = new Properties();
-properties.setProperty("wrapperPlugins", "failover,efm2");
+properties.setProperty("wrapperPlugins", "failover2,efm2");
 properties.setProperty("wrapperDialect", "aurora-pg");
 Connection conn = DriverManager.getConnection("jdbc:aws-wrapper:postgresql://db.example.com/example", properties);
 ```
@@ -113,22 +113,41 @@ spring:
   datasource:
     hikari:
       data-source-properties:
-        wrapperPlugins: failover,efm2
+        wrapperPlugins: failover2,efm2
         wrapperDialect: aurora-pg
 ```
 
 `application.properties`:
 ```properties
-spring.datasource.hikari.data-source-properties.wrapperPlugins=failover,efm2
+spring.datasource.hikari.data-source-properties.wrapperPlugins=failover2,efm2
 spring.datasource.hikari.data-source-properties.wrapperDialect=aurora-pg
 ```
 
 Environment variable (`SPRING_APPLICATION_JSON`):
 ```bash
 SPRING_APPLICATION_JSON='{
-  "spring.datasource.hikari.data-source-properties.wrapperPlugins": "failover,efm2",
+  "spring.datasource.hikari.data-source-properties.wrapperPlugins": "failover2,efm2",
   "spring.datasource.hikari.data-source-properties.wrapperDialect": "aurora-pg"
 }'
+```
+
+### Hibernate
+When using Hibernate directly (without Spring Boot), driver parameters are passed by prefixing them with `hibernate.connection.`.
+
+`hibernate.cfg.xml`:
+```xml
+<property name="hibernate.connection.driver_class">software.amazon.jdbc.Driver</property>
+<property name="hibernate.connection.url">jdbc:aws-wrapper:postgresql://db.example.com/example</property>
+<property name="hibernate.connection.wrapperPlugins">failover2,efm2</property>
+<property name="hibernate.connection.wrapperDialect">aurora-pg</property>
+```
+
+The same prefix applies when configuring Hibernate programmatically:
+```java
+configuration.setProperty("hibernate.connection.driver_class", "software.amazon.jdbc.Driver");
+configuration.setProperty("hibernate.connection.url", "jdbc:aws-wrapper:postgresql://db.example.com/example");
+configuration.setProperty("hibernate.connection.wrapperPlugins", "failover2,efm2");
+configuration.setProperty("hibernate.connection.wrapperDialect", "aurora-pg");
 ```
 
 ## AWS Advanced JDBC Wrapper Parameters

--- a/docs/using-the-jdbc-driver/UsingTheJdbcDriver.md
+++ b/docs/using-the-jdbc-driver/UsingTheJdbcDriver.md
@@ -79,6 +79,58 @@ For `application.properties`:
 logging.level.software.amazon.jdbc=trace
 ```
 
+## Specifying Parameter Values
+There are multiple ways to configure parameters for the AWS Advanced JDBC Wrapper, depending on how the driver is instantiated.
+
+### DriverManager
+When connecting with `DriverManager`, parameters may be specified in the query section of the JDBC URL:
+
+```
+jdbc:aws-wrapper:postgresql://<host_name>[:<port>]/[<database>][?paramOne=valueOne[&paramTwo=valueTwo...]]
+```
+
+For example:
+```
+jdbc:aws-wrapper:postgresql://db.example.com/example?wrapperPlugins=failover,efm2&tcpKeepAlive=true
+```
+
+Parameters can also be supplied through a `Properties` object. Note that when a property is set in both the connection string and the `Properties` object, the connection string value takes precedence.
+```java
+final Properties properties = new Properties();
+properties.setProperty("wrapperPlugins", "failover,efm2");
+properties.setProperty("wrapperDialect", "aurora-pg");
+Connection conn = DriverManager.getConnection("jdbc:aws-wrapper:postgresql://db.example.com/example", properties);
+```
+
+### Spring + HikariCP
+When using Spring Boot with HikariCP, parameters intended for the underlying driver must be passed through the `spring.datasource.hikari.data-source-properties` configuration key.
+
+**Examples**:
+
+`application.yaml`:
+```yaml
+spring:
+  datasource:
+    hikari:
+      data-source-properties:
+        wrapperPlugins: failover,efm2
+        wrapperDialect: aurora-pg
+```
+
+`application.properties`:
+```properties
+spring.datasource.hikari.data-source-properties.wrapperPlugins=failover,efm2
+spring.datasource.hikari.data-source-properties.wrapperDialect=aurora-pg
+```
+
+Environment variable (`SPRING_APPLICATION_JSON`):
+```bash
+SPRING_APPLICATION_JSON='{
+  "spring.datasource.hikari.data-source-properties.wrapperPlugins": "failover,efm2",
+  "spring.datasource.hikari.data-source-properties.wrapperDialect": "aurora-pg"
+}'
+```
+
 ## AWS Advanced JDBC Wrapper Parameters
 These parameters are applicable to any instance of the AWS Advanced JDBC Wrapper.
 


### PR DESCRIPTION
### Summary

Add a "Specifying Parameter Values" section to `UsingTheJdbcDriver.md` showing how to pass parameters to the AWS Advanced JDBC Wrapper in the most common scenarios.

### Description

The existing documentation lists all available parameters in a table but never shows *how* to actually supply them, which is a common source of confusion (especially the HikariCP `data-source-properties` mechanism for Spring users).

This PR adds examples for:
- **DriverManager** – via JDBC URL query parameters and via a `Properties` object (including the precedence note).
- **Spring + HikariCP** – via `spring.datasource.hikari.data-source-properties` in `application.yaml`, `application.properties`, and the `SPRING_APPLICATION_JSON` environment variable.

This work is **inspired by [PR #1160](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/1160)** by @bgshacklett, with the following corrections applied:
- Fixed the broken `application.properties` example (missing value for `wrapperDialect`).
- Corrected the `SPRING_APPLICATION_JSON` example to show an actual environment variable assignment.
- Removed the MS SQL Server note, since the wrapper only supports PostgreSQL, MySQL, and MariaDB.
- Clarified the DriverManager wording (DriverManager and DataSource are distinct mechanisms).
- Rebased onto current `main` (the section header was renamed from "Driver" to "Wrapper" since #1160 was opened).

### Additional Reviewers

n/a

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.