### PR TITLE
docs: clarify setting AWS JDBC Wrapper properties via JDBC URL parameters

### DIFF
--- a/docs/using-the-jdbc-driver/DataSource.md
+++ b/docs/using-the-jdbc-driver/DataSource.md
@@ -68,6 +68,7 @@ To use the AWS Advanced JDBC Wrapper with a connection pool, you must:
    // Alternatively, the AwsWrapperDataSource can be configured with a JDBC URL instead of individual properties as seen above.
    ds.addDataSourceProperty("jdbcUrl", "jdbc:aws-wrapper:postgresql://db-identifier.cluster-XYZ.us-east-2.rds.amazonaws.com:5432/postgres");
    ```
+   See the [DatasourceUrlExample](../../examples/AWSDriverExample/src/main/java/software/amazon/DatasourceUrlExample.java) for a complete example of configuring the data source with a JDBC URL.
 
 4. Set the driver-specific datasource:
    ```java
@@ -80,6 +81,11 @@ To use the AWS Advanced JDBC Wrapper with a connection pool, you must:
    targetDataSourceProps.setProperty("socketTimeout", "10");
    targetDataSourceProps.setProperty("wrapperLoggerLevel", "ALL");
    ds.addDataSourceProperty("targetDataSourceProperties", targetDataSourceProps);
+   ```
+
+   Alternatively, the driver-specific datasource and any AWS Advanced JDBC Wrapper properties can be supplied as query parameters of the JDBC URL instead of being set in code:
+   ```java
+   ds.addDataSourceProperty("jdbcUrl", "jdbc:aws-wrapper:postgresql://db-identifier.cluster-XYZ.us-east-2.rds.amazonaws.com:5432/postgres?socketTimeout=10&wrapperLoggerLevel=ALL");
    ```
 
 > [!WARNING]\

--- a/examples/AWSDriverExample/src/main/java/software/amazon/DatasourceUrlExample.java
+++ b/examples/AWSDriverExample/src/main/java/software/amazon/DatasourceUrlExample.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import software.amazon.jdbc.ds.AwsWrapperDataSource;
+
+public class DatasourceUrlExample {
+  private static final String USER = "username";
+  private static final String PASSWORD = "password";
+
+  public static void main(String[] args) throws SQLException {
+    AwsWrapperDataSource ds = new AwsWrapperDataSource();
+
+    // Instead of setting the server, port, database, and driver-specific and AWS Advanced JDBC Wrapper
+    // properties individually, they can all be supplied as parameters of the JDBC URL. Any query
+    // parameter in the URL (for example ssl and wrapperLoggerLevel below) is parsed and applied as a
+    // connection property.
+    ds.setJdbcUrl(
+        "jdbc:aws-wrapper:postgresql://db-identifier.cluster-XYZ.us-east-2.rds.amazonaws.com/employees"
+            + "?ssl=true&wrapperLoggerLevel=ALL");
+
+    // Specify the driver-specific data source:
+    ds.setTargetDataSourceClassName("org.postgresql.ds.PGSimpleDataSource");
+
+    // Try and make a connection:
+    try (final Connection conn = ds.getConnection(USER, PASSWORD);
+        final Statement statement = conn.createStatement();
+        final ResultSet rs = statement.executeQuery("SELECT * FROM employees")) {
+      System.out.println(Util.getResult(rs));
+    }
+  }
+}

--- a/examples/SpringBootHikariExample/README.md
+++ b/examples/SpringBootHikariExample/README.md
@@ -85,6 +85,18 @@ spring:
 ```
 Note that in Spring Boot 2 and 3, Hikari is the default DataSource implementation. So, a bean explicitly specifying Hikari as a Datasource is not needed.
 
+The `data-source-properties` can alternatively be supplied as query parameters of the JDBC URL:
+```yaml
+spring:
+  datasource:
+    url: jdbc:aws-wrapper:postgresql://db-identifier.cluster-XYZ.us-east-2.rds.amazonaws.com:5432/database-name?wrapperPlugins=failover,efm2&wrapperDialect=aurora-pg
+    username: some_username
+    password: some_password
+    driver-class-name: software.amazon.jdbc.Driver
+    hikari:
+      exception-override-class-name: software.amazon.jdbc.util.HikariCPSQLException
+```
+
 Optionally, you may like to add in Hikari specific configurations like the following.
 ```yaml
 spring:


### PR DESCRIPTION
### Summary
Documentation-only change clarifying that AWS Advanced JDBC Wrapper connection properties can be supplied as JDBC URL query parameters, in addition to setting them as individual datasource properties.

### Description
- `docs/using-the-jdbc-driver/DataSource.md`: Note that the driver-specific datasource and wrapper properties can be passed as URL query parameters (e.g. `?socketTimeout=10&wrapperLoggerLevel=ALL`), with a link to the new example.
- `examples/AWSDriverExample/.../DatasourceUrlExample.java`: New runnable example configuring `AwsWrapperDataSource` purely via `setJdbcUrl`.
- `examples/SpringBootHikariExample/README.md`: Show the equivalent Spring Boot `spring.datasource.url` form with `wrapperPlugins`/`wrapperDialect` as URL parameters.

This is a reworked version of #1338 (credit to @eugen-eugen for the original idea). It rebases onto current `main`, fixes a `wrapperDialect` typo, keeps Markdown code fences intact, moves the example link out of the code block, and cleans up the example file.

### Additional Reviewers

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.