### PR TITLE
docs: document MariaDB driver Aurora pipelining caveat

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The **Amazon Web Services (AWS) JDBC Driver** has been redesigned as an advanced
 
 The wrapper is complementary to an existing JDBC driver and aims to extend the functionality of the driver to enable applications to take full advantage of the features of clustered databases such as Amazon Aurora. In other words, the AWS Advanced JDBC Wrapper does not connect directly to any database, but enables support of AWS and Aurora functionalities on top of an underlying JDBC driver of the user's choice. This approach enables service-specific enhancements, without requiring users to change their workflow and existing JDBC driver tooling.
 
-The AWS Advanced JDBC Wrapper is targeted to work with **any** existing JDBC driver. Currently, the AWS Advanced JDBC Wrapper has been validated to support the [PostgreSQL JDBC Driver](https://github.com/pgjdbc/pgjdbc), [MySQL JDBC Driver](https://github.com/mysql/mysql-connector-j), and [MariaDB JDBC Driver](https://github.com/mariadb-corporation/mariadb-connector-j).
+The AWS Advanced JDBC Wrapper is targeted to work with **any** existing JDBC driver. Currently, the AWS Advanced JDBC Wrapper has been validated to support the [PostgreSQL JDBC Driver](https://github.com/pgjdbc/pgjdbc), [MySQL JDBC Driver](https://github.com/mysql/mysql-connector-j), and [MariaDB JDBC Driver](https://github.com/mariadb-corporation/mariadb-connector-j) (with some caveats, see [below](#mariadb)).
 
 The AWS Advanced JDBC Wrapper provides modular functionality through feature plugins, with each plugin being relevant to specific database services based on their architecture and capabilities. For example, [AWS Identity and Access Management (IAM)](https://aws.amazon.com/iam/) authentication is supported across multiple services, while [AWS Secrets Manager](https://aws.amazon.com/secrets-manager/) applies to services that support password-based authentication. The fast failover plugin provides reduced recovery time during failover for Aurora PostgreSQL and Aurora MySQL clusters.
 
@@ -279,6 +279,16 @@ Since the AWS Advanced JDBC Wrapper requires an underlying JDBC driver, please r
 To find all the documentation and concrete examples on how to use the AWS Advanced JDBC Wrapper, please refer to the [AWS Advanced JDBC Wrapper Documentation](./docs/Documentation.md) page.
 
 ### Known Limitations
+
+#### MariaDB
+
+The MariaDB driver uses pipelining, which is not compatible with Aurora. If you use the MariaDB driver against Aurora, you should disable the following properties, because they rely on pipelining.
+
+```java
+Properties props = new Properties();
+props.setProperty("usePipelineAuth", "false");
+props.setProperty("useBatchMultiSend", "false");
+```
 
 #### Amazon RDS Blue/Green Deployments
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -8,7 +8,7 @@ Before using the AWS Advanced JDBC Wrapper, you must install:
 - The AWS Advanced JDBC Wrapper.
 - Your choice of underlying JDBC driver. 
   - To use the wrapper with Aurora with PostgreSQL compatibility, install the [PostgreSQL JDBC Driver](https://github.com/pgjdbc/pgjdbc).
-  - To use the wrapper with Aurora with MySQL compatibility, install the [MySQL JDBC Driver](https://github.com/mysql/mysql-connector-j) or [MariaDB JDBC Driver](https://github.com/mariadb-corporation/mariadb-connector-j).
+  - To use the wrapper with Aurora with MySQL compatibility, install the [MySQL JDBC Driver](https://github.com/mysql/mysql-connector-j) or [MariaDB JDBC Driver](https://github.com/mariadb-corporation/mariadb-connector-j). See [here](../README.md#mariadb) for some limitations and caveats with the MariaDB driver.
 
 If you are using the AWS Advanced JDBC Wrapper as part of a Gradle project, include the wrapper and underlying driver as dependencies.  For example, to include the AWS Advanced JDBC Wrapper and the PostgreSQL JDBC Driver as dependencies in a Gradle project, update the ```build.gradle``` file as follows:
 

--- a/docs/using-the-jdbc-driver/UsingTheJdbcDriver.md
+++ b/docs/using-the-jdbc-driver/UsingTheJdbcDriver.md
@@ -1,5 +1,5 @@
 # Using the AWS Advanced JDBC Wrapper
-The AWS Advanced JDBC Wrapper leverages community JDBC drivers and enables support of AWS and Aurora functionalities. Currently, the [PostgreSQL JDBC Driver](https://github.com/pgjdbc/pgjdbc), [MySQL JDBC Driver](https://github.com/mysql/mysql-connector-j), and [MariaDB JDBC Driver](https://github.com/mariadb-corporation/mariadb-connector-j) are supported.
+The AWS Advanced JDBC Wrapper leverages community JDBC drivers and enables support of AWS and Aurora functionalities. Currently, the [PostgreSQL JDBC Driver](https://github.com/pgjdbc/pgjdbc), [MySQL JDBC Driver](https://github.com/mysql/mysql-connector-j), and [MariaDB JDBC Driver](https://github.com/mariadb-corporation/mariadb-connector-j) are supported. See [here](../../README.md#mariadb) for some limitations and caveats with the MariaDB driver.
 The JDBC Wrapper also supports [connection pooling](./DataSource.md#Using-the-AwsWrapperDataSource-with-Connection-Pooling-Frameworks).
 
 ## Using the AWS Advanced JDBC Wrapper with plain RDS databases


### PR DESCRIPTION
## Summary

The MariaDB driver uses pipelining, which is not compatible with Aurora. This PR documents that caveat and the properties (`usePipelineAuth`, `useBatchMultiSend`) that should be disabled when using the MariaDB driver against Aurora.

This is the docs-only portion of #1627, which targets the `2.6.x` line. The version downgrade (MariaDB 3.x → 2.x) and related code changes from that PR are intentionally **not** included here, since `main` continues to support MariaDB 3.x.

## Changes

- `README.md`: added a `#### MariaDB` subsection under Known Limitations with the pipelining caveat and properties to disable; added a caveat link in the intro.
- `docs/GettingStarted.md` and `docs/using-the-jdbc-driver/UsingTheJdbcDriver.md`: added links pointing to the new README MariaDB section.

## Testing

Docs-only change; no code or tests affected.

Relates to #1627