### PR TITLE
Fix NPE from check-then-act race in ImportantEventService#removeExpiredEvents

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/util/ImportantEventService.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/ImportantEventService.java
@@ -80,8 +80,12 @@ public class ImportantEventService {
       return;
     }
 
-    Instant current = Instant.now();
-    while (!events.isEmpty() && Duration.between(events.peek().timestamp, current).toMillis() > this.eventQueueMs) {
+    final Instant current = Instant.now();
+    while (true) {
+      final ImportantEvent head = events.peek();
+      if (head == null || Duration.between(head.timestamp, current).toMillis() <= this.eventQueueMs) {
+        break;
+      }
       events.poll();
     }
   }


### PR DESCRIPTION
## Summary
Fixes #1986.

`removeExpiredEvents()` used a check-then-act sequence (`!events.isEmpty()` followed by `events.peek().timestamp`) on a shared `ConcurrentLinkedQueue`. Under concurrent access, another thread can drain the last element between the `isEmpty()` check and `peek()`, so `peek()` returns `null` and dereferencing `.timestamp` throws a `NullPointerException`.

## Change
Capture `peek()` into a local variable once per iteration and null-check it before dereferencing, removing the race window.

## Behavior
Loop semantics are preserved: it keeps polling while the head exists and is older than `eventQueueMs`, and stops on an empty queue or a non-expired head. The boundary condition (age exactly equal to TTL) is unchanged.

## Testing
- Verified the change compiles with no diagnostics.
- The issue includes a standalone concurrent reproducer that this fix addresses.