### PR TITLE
chore: Checker Framework adoption parts 2 & 3

### DIFF
--- a/wrapper/build.gradle.kts
+++ b/wrapper/build.gradle.kts
@@ -314,9 +314,16 @@ if (project.hasProperty("enableCheckerFramework")) {
         checkers = listOf(
             "org.checkerframework.checker.nullness.NullnessChecker"
         )
-        // Scope the pilot to the core connection/plugin path. Expand package-by-package later.
+        // Scope: core connection/plugin path (parts 1-2) plus the self-contained util
+        // classes (part 3). Util classes that require widening central contracts
+        // (WrapperUtils -> all wrappers, RetryUtil/ConnectionUrlParser -> HostSpec/PluginService,
+        // LazyCleanerImpl -> Reference internals) are deferred to a later part.
+        // No end-anchor: matching an outer class also covers its nested classes.
         extraJavacArgs = listOf(
-            "-AonlyDefs=^software\\.amazon\\.jdbc\\.(ConnectionPluginManager|PluginServiceImpl|wrapper\\.ConnectionWrapper)",
+            "-AonlyDefs=^software\\.amazon\\.jdbc\\.(ConnectionPluginManager|PluginServiceImpl"
+                + "|wrapper\\.ConnectionWrapper"
+                + "|util\\.(RdsUtils|RegionUtils|GDBRegionUtils|SqlMethodAnalyzer|CacheItem"
+                + "|Messages|Pair|PropertyUtils|ConnectionUrlBuilder|StringUtils))",
             // Warning mode: report issues but do not fail the build.
             "-Awarns",
             // Keep the output focused and avoid drowning in framework boilerplate.

--- a/wrapper/src/main/java/software/amazon/jdbc/ConnectionPluginManager.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/ConnectionPluginManager.java
@@ -234,8 +234,7 @@ public class ConnectionPluginManager implements CanReleaseResources, Wrapper, St
     }
   }
 
-  @Nullable
-  protected <T, E extends Exception> PluginChainJdbcCallableInfo<T, E> makePluginChainFunc(
+  protected <T, E extends Exception> @Nullable PluginChainJdbcCallableInfo<T, E> makePluginChainFunc(
       final @NonNull String methodName) {
 
     PluginChainJdbcCallable<T, E> pluginChainFunc = null;
@@ -545,8 +544,8 @@ public class ConnectionPluginManager implements CanReleaseResources, Wrapper, St
   }
 
   public EnumSet<OldConnectionSuggestedAction> notifyConnectionChanged(
-      @NonNull final EnumSet<NodeChangeOptions> changes,
-      @Nullable final ConnectionPlugin skipNotificationForThisPlugin) {
+      final @NonNull EnumSet<NodeChangeOptions> changes,
+      final @Nullable ConnectionPlugin skipNotificationForThisPlugin) {
 
     final EnumSet<OldConnectionSuggestedAction> result =
         EnumSet.noneOf(OldConnectionSuggestedAction.class);
@@ -563,7 +562,7 @@ public class ConnectionPluginManager implements CanReleaseResources, Wrapper, St
     return result;
   }
 
-  public void notifyNodeListChanged(@NonNull final Map<String, EnumSet<NodeChangeOptions>> changes) {
+  public void notifyNodeListChanged(final @NonNull Map<String, EnumSet<NodeChangeOptions>> changes) {
 
     notifySubscribedPlugins(
         JdbcMethod.NOTIFYNODELISTCHANGED.methodName,

--- a/wrapper/src/main/java/software/amazon/jdbc/PluginServiceImpl.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/PluginServiceImpl.java
@@ -89,7 +89,7 @@ public class PluginServiceImpl implements PluginService, CanReleaseResources,
   protected final DialectProvider dialectProvider;
   protected Dialect dialect;
   protected TargetDriverDialect targetDriverDialect;
-  protected @Nullable final ConfigurationProfile configurationProfile;
+  protected final @Nullable ConfigurationProfile configurationProfile;
   protected final ConnectionProviderManager connectionProviderManager;
 
   protected final SessionStateService sessionStateService;
@@ -101,11 +101,11 @@ public class PluginServiceImpl implements PluginService, CanReleaseResources,
   protected @Nullable Boolean pooledConnection = null;
 
   public PluginServiceImpl(
-      @NonNull final FullServicesContainer servicesContainer,
-      @NonNull final Properties props,
-      @NonNull final String originalUrl,
-      @NonNull final String targetDriverProtocol,
-      @NonNull final TargetDriverDialect targetDriverDialect)
+      final @NonNull FullServicesContainer servicesContainer,
+      final @NonNull Properties props,
+      final @NonNull String originalUrl,
+      final @NonNull String targetDriverProtocol,
+      final @NonNull TargetDriverDialect targetDriverDialect)
       throws SQLException {
 
     this(
@@ -121,12 +121,12 @@ public class PluginServiceImpl implements PluginService, CanReleaseResources,
   }
 
   public PluginServiceImpl(
-      @NonNull final FullServicesContainer servicesContainer,
-      @NonNull final Properties props,
-      @NonNull final String originalUrl,
-      @NonNull final String targetDriverProtocol,
-      @NonNull final TargetDriverDialect targetDriverDialect,
-      @Nullable final ConfigurationProfile configurationProfile) throws SQLException {
+      final @NonNull FullServicesContainer servicesContainer,
+      final @NonNull Properties props,
+      final @NonNull String originalUrl,
+      final @NonNull String targetDriverProtocol,
+      final @NonNull TargetDriverDialect targetDriverDialect,
+      final @Nullable ConfigurationProfile configurationProfile) throws SQLException {
     this(
         servicesContainer,
         new ExceptionManager(),
@@ -144,15 +144,15 @@ public class PluginServiceImpl implements PluginService, CanReleaseResources,
   // dereference PluginService fields during construction. Safe to suppress here.
   @SuppressWarnings({"argument", "assignment"})
   public PluginServiceImpl(
-      @NonNull final FullServicesContainer servicesContainer,
-      @NonNull final ExceptionManager exceptionManager,
-      @NonNull final Properties props,
-      @NonNull final String originalUrl,
-      @NonNull final String targetDriverProtocol,
-      @Nullable final DialectProvider dialectProvider,
-      @NonNull final TargetDriverDialect targetDriverDialect,
-      @Nullable final ConfigurationProfile configurationProfile,
-      @Nullable final SessionStateService sessionStateService) throws SQLException {
+      final @NonNull FullServicesContainer servicesContainer,
+      final @NonNull ExceptionManager exceptionManager,
+      final @NonNull Properties props,
+      final @NonNull String originalUrl,
+      final @NonNull String targetDriverProtocol,
+      final @Nullable DialectProvider dialectProvider,
+      final @NonNull TargetDriverDialect targetDriverDialect,
+      final @Nullable ConfigurationProfile configurationProfile,
+      final @Nullable SessionStateService sessionStateService) throws SQLException {
     this.servicesContainer = servicesContainer;
     this.pluginManager = servicesContainer.getConnectionPluginManager();
     this.props = props;
@@ -288,7 +288,7 @@ public class PluginServiceImpl implements PluginService, CanReleaseResources,
   public EnumSet<NodeChangeOptions> setCurrentConnection(
       final @NonNull Connection connection,
       final @NonNull HostSpec hostSpec,
-      @Nullable final ConnectionPlugin skipNotificationForThisPlugin)
+      final @Nullable ConnectionPlugin skipNotificationForThisPlugin)
       throws SQLException {
 
     try (ResourceLock ignored = connectionSwitchLock.obtain()) {
@@ -558,8 +558,8 @@ public class PluginServiceImpl implements PluginService, CanReleaseResources,
     return false;
   }
 
-  void setNodeList(@Nullable final List<HostSpec> oldHosts,
-      @Nullable final List<HostSpec> newHosts) {
+  void setNodeList(final @Nullable List<HostSpec> oldHosts,
+      final @Nullable List<HostSpec> newHosts) {
 
     final Map<String, HostSpec> oldHostMap = oldHosts == null
         ? new HashMap<>()

--- a/wrapper/src/main/java/software/amazon/jdbc/util/CacheItem.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/CacheItem.java
@@ -17,6 +17,7 @@
 package software.amazon.jdbc.util;
 
 import java.util.Objects;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class CacheItem<V> {
 
@@ -36,11 +37,11 @@ public class CacheItem<V> {
     return System.nanoTime() > expirationTime;
   }
 
-  public V get() {
+  public @Nullable V get() {
     return get(false);
   }
 
-  public V get(final boolean returnExpired) {
+  public @Nullable V get(final boolean returnExpired) {
     return (this.isExpired() && !returnExpired) ? null : item;
   }
 
@@ -50,7 +51,7 @@ public class CacheItem<V> {
   }
 
   @Override
-  public boolean equals(Object obj) {
+  public boolean equals(@Nullable Object obj) {
     if (this == obj) {
       return true;
     }

--- a/wrapper/src/main/java/software/amazon/jdbc/util/ConnectionUrlBuilder.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/ConnectionUrlBuilder.java
@@ -86,7 +86,8 @@ public class ConnectionUrlBuilder {
     final StringBuilder queryBuilder = new StringBuilder();
     final Enumeration<?> propertyNames = copy.propertyNames();
     while (propertyNames.hasMoreElements()) {
-      final String propertyName = propertyNames.nextElement().toString();
+      final Object propertyNameObj = propertyNames.nextElement();
+      final String propertyName = propertyNameObj == null ? null : propertyNameObj.toString();
       if (propertyName != null && !propertyName.trim().equals("")) {
         if (queryBuilder.length() != 0) {
           queryBuilder.append("&");

--- a/wrapper/src/main/java/software/amazon/jdbc/util/ConnectionUrlParser.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/ConnectionUrlParser.java
@@ -60,7 +60,8 @@ public class ConnectionUrlParser {
       return hostsList;
     }
 
-    final String hosts = matcher.group("hosts") == null ? null : matcher.group("hosts").trim();
+    final String hostsGroup = matcher.group("hosts");
+    final String hosts = hostsGroup == null ? null : hostsGroup.trim();
     if (hosts != null) {
       final String[] hostArray = hosts.split(HOSTS_SEPARATOR);
       for (int i = 0; i < hostArray.length; i++) {
@@ -183,7 +184,7 @@ public class ConnectionUrlParser {
 
   // Get the database name from a given url of the generic format:
   // "protocol//[hosts][/database][?properties]"
-  public static String parseDatabaseFromUrl(final String url) {
+  public static @Nullable String parseDatabaseFromUrl(final String url) {
     final String[] dbName = url.split("//")[1].split("\\?")[0].split("/");
 
     if (dbName.length == 1) {
@@ -195,7 +196,7 @@ public class ConnectionUrlParser {
 
   // Get the user name from a given url of the generic format:
   // "protocol//[hosts][/database][?properties]"
-  public static String parseUserFromUrl(final String url) {
+  public static @Nullable String parseUserFromUrl(final String url) {
     final Pattern userPattern = Pattern.compile("user=(?<username>[^&]*)");
     final Matcher matcher = userPattern.matcher(url);
     if (matcher.find()) {
@@ -207,7 +208,7 @@ public class ConnectionUrlParser {
 
   // Get the password from a given url of the generic format:
   // "protocol//[hosts][/database][?properties]"
-  public static String parsePasswordFromUrl(final String url) {
+  public static @Nullable String parsePasswordFromUrl(final String url) {
     final Pattern passwordPattern = Pattern.compile("password=(?<pass>[^&]*)");
     final Matcher matcher = passwordPattern.matcher(url);
     if (matcher.find()) {

--- a/wrapper/src/main/java/software/amazon/jdbc/util/GDBRegionUtils.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/GDBRegionUtils.java
@@ -68,8 +68,12 @@ public class GDBRegionUtils extends RegionUtils {
     return getRegionFromClusterArn(writerClusterArn);
   }
 
-  private String findWriterClusterArn(final HostSpec hostSpec, final Properties props,
-      final String globalClusterIdentifier) {
+  private @Nullable String findWriterClusterArn(final HostSpec hostSpec, final Properties props,
+      final @Nullable String globalClusterIdentifier) {
+
+    if (globalClusterIdentifier == null) {
+      return null;
+    }
 
     if (this.credentialsProvider == null) {
       this.credentialsProvider = AwsCredentialsManager.getProvider(hostSpec, props);
@@ -93,8 +97,12 @@ public class GDBRegionUtils extends RegionUtils {
     }
   }
 
-  private Region getRegionFromClusterArn(String clusterArn) {
+  private @Nullable Region getRegionFromClusterArn(String clusterArn) {
     Matcher matcher = GDB_CLUSTER_ARN_PATTERN.matcher(clusterArn);
-    return matcher.matches() ? Region.of(matcher.group(REGION_GROUP)) : null;
+    if (!matcher.matches()) {
+      return null;
+    }
+    final String region = matcher.group(REGION_GROUP);
+    return region == null ? null : Region.of(region);
   }
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/util/Messages.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/Messages.java
@@ -18,6 +18,7 @@ package software.amazon.jdbc.util;
 
 import java.text.MessageFormat;
 import java.util.ResourceBundle;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class Messages {
 
@@ -34,7 +35,7 @@ public class Messages {
     return get(key, emptyArgs);
   }
 
-  public static String get(final String key, final Object[] args) {
+  public static String get(final String key, final @Nullable Object[] args) {
     final String message = MESSAGES.getString(key);
     return MessageFormat.format(message, args);
   }

--- a/wrapper/src/main/java/software/amazon/jdbc/util/PropertyUtils.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/PropertyUtils.java
@@ -48,6 +48,9 @@ public class PropertyUtils {
     final Enumeration<?> propertyNames = properties.propertyNames();
     while (propertyNames.hasMoreElements()) {
       final Object key = propertyNames.nextElement();
+      if (key == null) {
+        continue;
+      }
       final String propName = key.toString();
       Object propValue = properties.getProperty(propName);
       if (propValue == null) {
@@ -61,8 +64,11 @@ public class PropertyUtils {
   public static void setPropertyOnTarget(
       final Object target,
       final String propName,
-      final Object propValue,
+      final @Nullable Object propValue,
       final List<Method> methods) {
+    if (propValue == null) {
+      return;
+    }
     Method writeMethod = null;
     String methodName = "set" + propName.substring(0, 1).toUpperCase() + propName.substring(1);
 
@@ -109,12 +115,13 @@ public class PropertyUtils {
       LOGGER.finest(() -> String.format("Set property '%s' with value: %s", propName, cleanPropValue));
 
     } catch (final InvocationTargetException ex) {
+      final Throwable cause = ex.getCause();
       LOGGER.warning(
           () ->
               Messages.get(
                   "PropertyUtils.failedToSetPropertyWithReason",
-                  new Object[] {propName, target.getClass(), ex.getCause().getMessage()}));
-      throw new RuntimeException(ex.getCause());
+                  new Object[] {propName, target.getClass(), cause == null ? "" : cause.getMessage()}));
+      throw new RuntimeException(cause);
     } catch (final Exception e) {
       LOGGER.warning(
           () ->
@@ -178,7 +185,7 @@ public class PropertyUtils {
     return sb.toString();
   }
 
-  public static Integer getIntegerPropertyValue(
+  public static @Nullable Integer getIntegerPropertyValue(
       final @NonNull Properties props,
       final @NonNull AwsWrapperProperty wrapperProperty) {
 
@@ -189,7 +196,7 @@ public class PropertyUtils {
     return result;
   }
 
-  public static Boolean getBooleanPropertyValue(
+  public static @Nullable Boolean getBooleanPropertyValue(
       final @NonNull Properties props,
       final @NonNull AwsWrapperProperty wrapperProperty) {
 

--- a/wrapper/src/main/java/software/amazon/jdbc/util/RdsUtils.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/RdsUtils.java
@@ -230,7 +230,8 @@ public class RdsUtils {
   private static final String DNS_GROUP = "dns";
   private static final String DOMAIN_GROUP = "domain";
   private static final String REGION_GROUP = "region";
-  private static final AtomicReference<Function<String, String>> prepareHostFunc = new AtomicReference<>(null);
+  private static final AtomicReference<@Nullable Function<String, String>> prepareHostFunc =
+      new AtomicReference<>(null);
 
   public boolean isRdsClusterDns(final String host) {
     final String dnsGroup = getDnsGroup(getPreparedHost(host));
@@ -321,7 +322,7 @@ public class RdsUtils {
     return group == null ? "?" : "?." + group;
   }
 
-  public String getRdsRegion(final String host) {
+  public @Nullable String getRdsRegion(final String host) {
     final String preparedHost = getPreparedHost(host);
     if (StringUtils.isNullOrEmpty(preparedHost)) {
       return null;
@@ -365,7 +366,7 @@ public class RdsUtils {
     return dnsGroup != null && dnsGroup.equalsIgnoreCase("shardgrp-");
   }
 
-  public String getRdsClusterHostUrl(final String host) {
+  public @Nullable String getRdsClusterHostUrl(final String host) {
     final String preparedHost = getPreparedHost(host);
     if (StringUtils.isNullOrEmpty(preparedHost)) {
       return null;
@@ -489,7 +490,8 @@ public class RdsUtils {
       if (!hostIdMatcher.matches()) {
         return host;
       }
-      return hostIdMatcher.group(1);
+      final String strippedHostId = hostIdMatcher.group(1);
+      return strippedHostId == null ? host : strippedHostId;
     }
     final String prefix = matcher.group("prefix");
     if (StringUtils.isNullOrEmpty(prefix)) {
@@ -498,7 +500,7 @@ public class RdsUtils {
     return host.replace(prefix + ".", ".");
   }
 
-  private Matcher cacheMatcher(final String host, Pattern... patterns) {
+  private @Nullable Matcher cacheMatcher(final String host, Pattern... patterns) {
     Matcher matcher;
     for (Pattern pattern : patterns) {
       matcher = cachedPatterns.get(host);
@@ -514,7 +516,7 @@ public class RdsUtils {
     return null;
   }
 
-  private String getRegexGroup(Matcher matcher, String groupName) {
+  private @Nullable String getRegexGroup(@Nullable Matcher matcher, String groupName) {
     if (matcher == null) {
       return null;
     }
@@ -526,16 +528,22 @@ public class RdsUtils {
     }
   }
 
-  private String getDnsGroup(final String host) {
+  private @Nullable String getDnsGroup(final String host) {
     if (StringUtils.isNullOrEmpty(host)) {
       return null;
     }
-    return cachedDnsPatterns.computeIfAbsent(host, (k) -> {
-      final Matcher matcher = cacheMatcher(k,
-          AURORA_DNS_PATTERN, AURORA_CHINA_DNS_PATTERN, AURORA_OLD_CHINA_DNS_PATTERN,
-          AURORA_GOV_DNS_PATTERN, AURORA_GLOBAL_WRITER_DNS_PATTERN);
-      return getRegexGroup(matcher, DNS_GROUP);
-    });
+    final String cached = cachedDnsPatterns.get(host);
+    if (cached != null) {
+      return cached;
+    }
+    final Matcher matcher = cacheMatcher(host,
+        AURORA_DNS_PATTERN, AURORA_CHINA_DNS_PATTERN, AURORA_OLD_CHINA_DNS_PATTERN,
+        AURORA_GOV_DNS_PATTERN, AURORA_GLOBAL_WRITER_DNS_PATTERN);
+    final String group = getRegexGroup(matcher, DNS_GROUP);
+    if (group != null) {
+      cachedDnsPatterns.put(host, group);
+    }
+    return group;
   }
 
   public static void clearCache() {

--- a/wrapper/src/main/java/software/amazon/jdbc/util/RegionUtils.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/RegionUtils.java
@@ -34,8 +34,7 @@ public class RegionUtils {
    * @return The AWS region defined by the properties or extracted from the host, or null if the region was not
    *     defined in the properties and could not be determined from the {@code host}.
    */
-  @Nullable
-  public Region getRegion(String host, Properties props, String propKey) {
+  public @Nullable Region getRegion(String host, Properties props, String propKey) {
     Region region = getRegion(props, propKey);
     return region != null ? region : getRegionFromHost(host);
   }
@@ -50,8 +49,7 @@ public class RegionUtils {
    * @return The AWS region defined by the properties or extracted from the host, or null if the region was not
    *     defined in the properties and could not be determined from the {@code host}.
    */
-  @Nullable
-  public Region getRegion(HostSpec hostSpec, Properties props, String propKey) {
+  public @Nullable Region getRegion(HostSpec hostSpec, Properties props, String propKey) {
     return getRegion(hostSpec.getHost(), props, propKey);
   }
 
@@ -62,8 +60,7 @@ public class RegionUtils {
    * @param propKey The key name of the region property.
    * @return The AWS region defined by the properties, or null if the region was not defined in the properties.
    */
-  @Nullable
-  public Region getRegion(Properties props, String propKey) {
+  public @Nullable Region getRegion(Properties props, String propKey) {
     String regionString = props.getProperty(propKey);
     if (StringUtils.isNullOrEmpty(regionString)) {
       return null;
@@ -78,7 +75,7 @@ public class RegionUtils {
    * @param regionString The connection properties for the connection being established.
    * @return The AWS region of the given region string, or null if the given string was null or empty.
    */
-  public Region getRegionFromRegionString(String regionString) {
+  public @Nullable Region getRegionFromRegionString(String regionString) {
     if (StringUtils.isNullOrEmpty(regionString)) {
       return null;
     }
@@ -100,7 +97,7 @@ public class RegionUtils {
    * @param host The host from which to extract the region.
    * @return The AWS region used in the host string.
    */
-  public Region getRegionFromHost(String host) {
+  public @Nullable Region getRegionFromHost(String host) {
     String regionString = rdsUtils.getRdsRegion(host);
     if (StringUtils.isNullOrEmpty(regionString)) {
       return null;

--- a/wrapper/src/main/java/software/amazon/jdbc/util/SqlMethodAnalyzer.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/SqlMethodAnalyzer.java
@@ -25,6 +25,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import software.amazon.jdbc.JdbcMethod;
 
 public class SqlMethodAnalyzer {
@@ -182,7 +183,7 @@ public class SqlMethodAnalyzer {
     return !oldAutoCommitVal && Boolean.TRUE.equals(newAutoCommitVal);
   }
 
-  public Boolean getAutoCommitValueFromSqlStatement(final Object[] args) {
+  public @Nullable Boolean getAutoCommitValueFromSqlStatement(final Object[] args) {
     if (args == null || args.length < 1) {
       return null;
     }

--- a/wrapper/src/main/java/software/amazon/jdbc/util/StringUtils.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/StringUtils.java
@@ -57,7 +57,7 @@ public class StringUtils {
    * @return true if the supplied string is null or empty
    */
   @EnsuresNonNullIf(expression = "#1", result = false)
-  public static boolean isNullOrEmpty(@Nullable final String s) {
+  public static boolean isNullOrEmpty(final @Nullable String s) {
     return s == null || s.equals("");
   }
 

--- a/wrapper/src/main/java/software/amazon/jdbc/wrapper/ConnectionWrapper.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/wrapper/ConnectionWrapper.java
@@ -76,11 +76,11 @@ public class ConnectionWrapper implements Connection, CanReleaseResources {
   // construction. Suppressing avoids threading @UnderInitialization through many types.
   @SuppressWarnings({"method.invocation", "argument"})
   public ConnectionWrapper(
-      @NonNull final FullServicesContainer servicesContainer,
-      @NonNull final Properties props,
-      @NonNull final String url,
-      @NonNull final String targetDriverProtocol,
-      @Nullable final ConfigurationProfile configurationProfile)
+      final @NonNull FullServicesContainer servicesContainer,
+      final @NonNull Properties props,
+      final @NonNull String url,
+      final @NonNull String targetDriverProtocol,
+      final @Nullable ConfigurationProfile configurationProfile)
       throws SQLException {
 
     this.servicesContainer = servicesContainer;
@@ -111,13 +111,13 @@ public class ConnectionWrapper implements Connection, CanReleaseResources {
   // on the primary constructor above).
   @SuppressWarnings("method.invocation")
   protected ConnectionWrapper(
-      @NonNull final Properties props,
-      @NonNull final String url,
-      @NonNull final String protocol,
-      @NonNull final ConnectionPluginManager connectionPluginManager,
-      @NonNull final PluginService pluginService,
-      @NonNull final HostListProviderService hostListProviderService,
-      @NonNull final PluginManagerService pluginManagerService)
+      final @NonNull Properties props,
+      final @NonNull String url,
+      final @NonNull String protocol,
+      final @NonNull ConnectionPluginManager connectionPluginManager,
+      final @NonNull PluginService pluginService,
+      final @NonNull HostListProviderService hostListProviderService,
+      final @NonNull PluginManagerService pluginManagerService)
       throws SQLException {
     this.originalUrl = url;
     this.targetDriverProtocol = protocol;


### PR DESCRIPTION
## Checker Framework adoption — Parts 2 & 3

Follow-up to the Part 1 NullnessChecker pilot. Continues the incremental, scoped,
warn-only rollout. Build remains unaffected unless run with `-PenableCheckerFramework`.

### Part 2 — core path cleanup + policy
- Fixed the 80 `type.anno.before.modifier` style warnings in the core files (moved
  qualifiers after modifiers; semantically identical), so the report is now signal-only.
- Ratified two conventions: initialization findings use narrowly-scoped, justified
  `@SuppressWarnings`; widening `StateSnapshotProvider.getSnapshotState` to
  `@Nullable Object` is deferred to its own PR.

### Part 3 — expand scope to self-contained `util` classes
- Extended `-AonlyDefs` to an explicit allowlist of self-contained `util` classes and
  fixed their findings: `@Nullable` returns where methods genuinely return null, a
  high-leverage `Messages.get(@Nullable Object[])` fix, and several local-capture + guard
  refactors (incl. a couple of latent-NPE-prone spots).
- Deferred classes that would require widening central contracts
  (`WrapperUtils`, `RetryUtil`, `ConnectionUrlParser`, `LazyCleanerImpl`,
  `HostIdCacheServiceImpl`) to Part 4, which will first align
  `HostSpec`/`HostRole`/`PluginService` nullness.

### Verification
- Checker (scoped): **0 real findings, 0 style, 0 crashes**.
- Java 8 build compiles; relevant unit tests pass (core + util suites, 163 tests in the
  util/PluginService run). All refactors are behavior-preserving.

Methodology and per-finding rationale: `docs/checker-framework-pilot/README.md`.

---

By submitting this pull request, I confirm that my contribution is made under the terms
of the Apache 2.0 license.
