### PR TITLE
chore: Checker Framework adoption (parts 4 & 5)

### DIFF
--- a/wrapper/build.gradle.kts
+++ b/wrapper/build.gradle.kts
@@ -314,16 +314,18 @@ if (project.hasProperty("enableCheckerFramework")) {
         checkers = listOf(
             "org.checkerframework.checker.nullness.NullnessChecker"
         )
-        // Scope: core connection/plugin path (parts 1-2) plus the self-contained util
-        // classes (part 3). Util classes that require widening central contracts
-        // (WrapperUtils -> all wrappers, RetryUtil/ConnectionUrlParser -> HostSpec/PluginService,
-        // LazyCleanerImpl -> Reference internals) are deferred to a later part.
+        // Scope: core connection/plugin path (parts 1-2), the self-contained util classes
+        // (part 3), and the util classes that depend on central-type nullness contracts
+        // (part 4: RetryUtil, ConnectionUrlParser, HostIdCacheServiceImpl - enabled together
+        // with the HostSpec / HostRole / PluginService / HostSpecBuilder / Dialect alignment).
+        // WrapperUtils and LazyCleanerImpl remain deferred (wrapper-wide / Reference internals).
         // No end-anchor: matching an outer class also covers its nested classes.
         extraJavacArgs = listOf(
             "-AonlyDefs=^software\\.amazon\\.jdbc\\.(ConnectionPluginManager|PluginServiceImpl"
                 + "|wrapper\\.ConnectionWrapper"
                 + "|util\\.(RdsUtils|RegionUtils|GDBRegionUtils|SqlMethodAnalyzer|CacheItem"
-                + "|Messages|Pair|PropertyUtils|ConnectionUrlBuilder|StringUtils))",
+                + "|Messages|Pair|PropertyUtils|ConnectionUrlBuilder|StringUtils"
+                + "|ConnectionUrlParser|RetryUtil|HostIdCacheServiceImpl))",
             // Warning mode: report issues but do not fail the build.
             "-Awarns",
             // Keep the output focused and avoid drowning in framework boilerplate.

--- a/wrapper/build.gradle.kts
+++ b/wrapper/build.gradle.kts
@@ -315,17 +315,18 @@ if (project.hasProperty("enableCheckerFramework")) {
             "org.checkerframework.checker.nullness.NullnessChecker"
         )
         // Scope: core connection/plugin path (parts 1-2), the self-contained util classes
-        // (part 3), and the util classes that depend on central-type nullness contracts
+        // (part 3), the util classes that depend on central-type nullness contracts
         // (part 4: RetryUtil, ConnectionUrlParser, HostIdCacheServiceImpl - enabled together
-        // with the HostSpec / HostRole / PluginService / HostSpecBuilder / Dialect alignment).
-        // WrapperUtils and LazyCleanerImpl remain deferred (wrapper-wide / Reference internals).
+        // with the HostSpec / HostRole / PluginService / HostSpecBuilder / Dialect alignment),
+        // and WrapperUtils (part 5: the generic plugin-execution / proxy-wrapping helpers).
+        // LazyCleanerImpl and the per-object JDBC wrapper classes remain deferred.
         // No end-anchor: matching an outer class also covers its nested classes.
         extraJavacArgs = listOf(
             "-AonlyDefs=^software\\.amazon\\.jdbc\\.(ConnectionPluginManager|PluginServiceImpl"
                 + "|wrapper\\.ConnectionWrapper"
                 + "|util\\.(RdsUtils|RegionUtils|GDBRegionUtils|SqlMethodAnalyzer|CacheItem"
                 + "|Messages|Pair|PropertyUtils|ConnectionUrlBuilder|StringUtils"
-                + "|ConnectionUrlParser|RetryUtil|HostIdCacheServiceImpl))",
+                + "|ConnectionUrlParser|RetryUtil|HostIdCacheServiceImpl|WrapperUtils))",
             // Warning mode: report issues but do not fail the build.
             "-Awarns",
             // Keep the output focused and avoid drowning in framework boilerplate.

--- a/wrapper/src/main/java/software/amazon/jdbc/HostSpec.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/HostSpec.java
@@ -19,6 +19,7 @@ package software.amazon.jdbc;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.Objects;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import software.amazon.jdbc.hostavailability.HostAvailability;
 import software.amazon.jdbc.hostavailability.HostAvailabilityStrategy;
 import software.amazon.jdbc.util.ResourceLock;
@@ -103,7 +104,7 @@ public class HostSpec {
    * @param copyHost the host whose details to copy.
    * @param role     the role of this host (writer or reader).
    */
-  public HostSpec(final HostSpec copyHost, final HostRole role) {
+  public HostSpec(final HostSpec copyHost, final @Nullable HostRole role) {
     this(copyHost.getHost(), copyHost.getPort(), copyHost.getHostId(), role, copyHost.getAvailability(),
         copyHost.getHostAvailabilityStrategy());
   }

--- a/wrapper/src/main/java/software/amazon/jdbc/HostSpecBuilder.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/HostSpecBuilder.java
@@ -18,6 +18,7 @@ package software.amazon.jdbc;
 
 import java.sql.Timestamp;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import software.amazon.jdbc.hostavailability.HostAvailability;
 import software.amazon.jdbc.hostavailability.HostAvailabilityStrategy;
 
@@ -73,7 +74,7 @@ public class HostSpecBuilder {
     return this;
   }
 
-  public HostSpecBuilder hostId(String hostId) {
+  public HostSpecBuilder hostId(@Nullable String hostId) {
     this.hostId = hostId;
     return this;
   }

--- a/wrapper/src/main/java/software/amazon/jdbc/PartialPluginService.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/PartialPluginService.java
@@ -183,13 +183,14 @@ public class PartialPluginService implements PluginService, CanReleaseResources,
   }
 
   @Override
-  public HostSpec getHostSpecByStrategy(HostRole role, String strategy) throws SQLException {
+  public HostSpec getHostSpecByStrategy(@Nullable HostRole role, String strategy) throws SQLException {
     throw new UnsupportedOperationException(
         Messages.get("PartialPluginService.unexpectedMethodCall", new Object[] {"getHostSpecByStrategy"}));
   }
 
   @Override
-  public HostSpec getHostSpecByStrategy(List<HostSpec> hosts, HostRole role, String strategy) throws SQLException {
+  public HostSpec getHostSpecByStrategy(List<HostSpec> hosts, @Nullable HostRole role, String strategy)
+      throws SQLException {
     throw new UnsupportedOperationException(
         Messages.get("PartialPluginService.unexpectedMethodCall", new Object[] {"getHostSpecByStrategy"}));
   }

--- a/wrapper/src/main/java/software/amazon/jdbc/PluginService.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/PluginService.java
@@ -124,7 +124,7 @@ public interface PluginService extends ExceptionHandler, Wrapper, StateSnapshotP
    *                                       {@link ConnectionPlugin} instances do not support the
    *                                       requested strategy
    */
-  HostSpec getHostSpecByStrategy(HostRole role, String strategy)
+  HostSpec getHostSpecByStrategy(@Nullable HostRole role, String strategy)
       throws SQLException, UnsupportedOperationException;
 
   /**
@@ -146,7 +146,7 @@ public interface PluginService extends ExceptionHandler, Wrapper, StateSnapshotP
    *                                       {@link ConnectionPlugin} instances do not support the
    *                                       requested strategy
    */
-  HostSpec getHostSpecByStrategy(List<HostSpec> hosts, HostRole role, String strategy)
+  HostSpec getHostSpecByStrategy(List<HostSpec> hosts, @Nullable HostRole role, String strategy)
       throws SQLException, UnsupportedOperationException;
 
   /**

--- a/wrapper/src/main/java/software/amazon/jdbc/PluginServiceImpl.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/PluginServiceImpl.java
@@ -245,12 +245,13 @@ public class PluginServiceImpl implements PluginService, CanReleaseResources,
   }
 
   @Override
-  public HostSpec getHostSpecByStrategy(HostRole role, String strategy) throws SQLException {
+  public HostSpec getHostSpecByStrategy(@Nullable HostRole role, String strategy) throws SQLException {
     return this.pluginManager.getHostSpecByStrategy(role, strategy);
   }
 
   @Override
-  public HostSpec getHostSpecByStrategy(List<HostSpec> hosts, HostRole role, String strategy) throws SQLException {
+  public HostSpec getHostSpecByStrategy(List<HostSpec> hosts, @Nullable HostRole role, String strategy)
+      throws SQLException {
     return this.pluginManager.getHostSpecByStrategy(hosts, role, strategy);
   }
 
@@ -760,7 +761,7 @@ public class PluginServiceImpl implements PluginService, CanReleaseResources,
   @Override
   public @Nullable HostSpec identifyConnection(Connection connection) throws SQLException {
     try {
-      Pair<String, String> instanceIds = this.dialect.getHostId(connection);
+      Pair<@Nullable String, @Nullable String> instanceIds = this.dialect.getHostId(connection);
       if (instanceIds == null) {
         return null;
       }
@@ -774,8 +775,8 @@ public class PluginServiceImpl implements PluginService, CanReleaseResources,
         return null;
       }
 
-      String instanceId = instanceIds.getValue1();
-      String instanceName = instanceIds.getValue2();
+      final @Nullable String instanceId = instanceIds.getValue1();
+      final @Nullable String instanceName = instanceIds.getValue2();
       return topology.stream()
           .filter(host -> Objects.equals(instanceId, host.getHostId())
               || Objects.equals(instanceName, host.getHost()))

--- a/wrapper/src/main/java/software/amazon/jdbc/dialect/Dialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/dialect/Dialect.java
@@ -53,7 +53,7 @@ public interface Dialect {
 
   HostRole getHostRole(Connection connection) throws SQLException;
 
-  @Nullable Pair<String, String> getHostId(Connection connection) throws SQLException;
+  @Nullable Pair<@Nullable String, @Nullable String> getHostId(Connection connection) throws SQLException;
 
   /**
    * Filters the provided list of hosts by the set of accessible AWS regions.

--- a/wrapper/src/main/java/software/amazon/jdbc/util/HostIdCacheServiceImpl.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/HostIdCacheServiceImpl.java
@@ -34,7 +34,8 @@ public class HostIdCacheServiceImpl implements HostIdCacheService {
   public static final String PROP_ENABLED = "aws.jdbc.config.host.cache.enabled";
   public static final String PROP_REGEXP  = "aws.jdbc.config.hast.cache.regexp";
 
-  private static final ConcurrentHashMap<String, Pair<String, String>> cache = new ConcurrentHashMap<>();
+  private static final ConcurrentHashMap<String, Pair<@Nullable String, @Nullable String>> cache =
+      new ConcurrentHashMap<>();
   private static final boolean isEnabled = Boolean.parseBoolean(System.getProperty(PROP_ENABLED, "true"));
   private static final String hostRegexp = System.getProperty(PROP_REGEXP, ".*");
   private static final RdsUtils rdsHelper = new RdsUtils();
@@ -66,7 +67,7 @@ public class HostIdCacheServiceImpl implements HostIdCacheService {
       final @NonNull HostSpec connectionHostSpec,
       final @NonNull PluginService pluginService) throws SQLException {
 
-    Pair<String, String> pairIdAndName = cache.get(connectionHostSpec.getHost());
+    Pair<@Nullable String, @Nullable String> pairIdAndName = cache.get(connectionHostSpec.getHost());
     if (pairIdAndName == null) {
       try {
         pairIdAndName = pluginService.getDialect().getHostId(connection);
@@ -80,8 +81,8 @@ public class HostIdCacheServiceImpl implements HostIdCacheService {
       return null;
     }
 
-    final String instanceId = pairIdAndName.getValue1();
-    final String instanceName = pairIdAndName.getValue2();
+    final @Nullable String instanceId = pairIdAndName.getValue1();
+    final @Nullable String instanceName = pairIdAndName.getValue2();
     if (instanceId == null && instanceName == null) {
       // We've already tried to identify connection, but we got nothing.
       return null;

--- a/wrapper/src/main/java/software/amazon/jdbc/util/RetryUtil.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/RetryUtil.java
@@ -84,7 +84,7 @@ public class RetryUtil {
       final @NonNull PluginService pluginService,
       final @NonNull Properties properties,
       final @Nullable ConnectionPlugin plugin,
-      final @NonNull Supplier<Set<HostSpec>> allowedHosts,
+      final @NonNull Supplier<@Nullable Set<HostSpec>> allowedHosts,
       @Nullable String strategy,
       @Nullable HostRole verifyRole,
       final long retryEndNano)

--- a/wrapper/src/main/java/software/amazon/jdbc/util/WrapperUtils.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/WrapperUtils.java
@@ -54,6 +54,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.Timer;
 import java.util.concurrent.ConcurrentHashMap;
@@ -270,7 +271,7 @@ public class WrapperUtils {
 
       try {
         if (jdbcMethod.wrapResults) {
-          return wrapWithProxyIfNeeded(resultClass, result, connectionWrapper, pluginManager);
+          return wrapNonNullResult(resultClass, result, connectionWrapper, pluginManager);
         } else {
           return result;
         }
@@ -344,7 +345,7 @@ public class WrapperUtils {
 
       if (jdbcMethod.wrapResults) {
         try {
-          return wrapWithProxyIfNeeded(resultClass, result, connectionWrapper, pluginManager);
+          return wrapNonNullResult(resultClass, result, connectionWrapper, pluginManager);
         } catch (final InstantiationException e) {
           if (context != null) {
             context.setSuccess(false);
@@ -371,9 +372,27 @@ public class WrapperUtils {
     }
   }
 
+  /**
+   * Wraps a non-null result via {@link #wrapWithProxyIfNeeded}. Callers invoke this only when the
+   * result is known to be non-null (the value comes from {@link ConnectionPluginManager#execute},
+   * which returns a non-null value). {@code wrapWithProxyIfNeeded} preserves non-nullness for a
+   * non-null input - its only {@code null} return is the {@code toProxy == null} guard - so the
+   * declared {@code @Nullable} return type cannot actually be {@code null} here. The nullness
+   * checker cannot express "preserves non-nullness" for a type variable whose bound is
+   * {@code @Nullable Object}, hence the localized suppression.
+   */
+  @SuppressWarnings("nullness")
+  private static <T> T wrapNonNullResult(
+      final Class<T> resultClass,
+      final T toProxy,
+      final ConnectionWrapper connectionWrapper,
+      final ConnectionPluginManager pluginManager) throws InstantiationException {
+    return wrapWithProxyIfNeeded(resultClass, toProxy, connectionWrapper, pluginManager);
+  }
+
   public static @Nullable <T> T wrapWithProxyIfNeeded(
       final Class<T> resultClass,
-      @Nullable final T toProxy,
+      final @Nullable T toProxy,
       final ConnectionWrapper connectionWrapper,
       final ConnectionPluginManager pluginManager) throws InstantiationException {
     if (toProxy == null) {
@@ -424,10 +443,10 @@ public class WrapperUtils {
       }
     }
 
-    if (skipWrappingForPackages.contains(toProxyClass.getPackage().getName())) {
+    final Package toProxyPackage = toProxyClass.getPackage();
+    if (toProxyPackage != null && skipWrappingForPackages.contains(toProxyPackage.getName())) {
       return toProxy;
     }
-
     if (isJdbcInterface(toProxy.getClass())) {
       throw new RuntimeException(
           Messages.get(
@@ -444,7 +463,7 @@ public class WrapperUtils {
    * @param packageName the name of the package to analyze
    * @return true if the given package is a JDBC package
    */
-  public static boolean isJdbcPackage(@Nullable final String packageName) {
+  public static boolean isJdbcPackage(final @Nullable String packageName) {
     return packageName != null
         && (packageName.startsWith("java.sql")
         || packageName.startsWith("javax.sql")
@@ -495,7 +514,7 @@ public class WrapperUtils {
   public static <T> T createInstance(
       final Class<?> classToInstantiate,
       final Class<T> resultClass,
-      final Class<?>[] constructorArgClasses,
+      final Class<?> @Nullable [] constructorArgClasses,
       final Object... constructorArgs)
       throws InstantiationException {
 
@@ -512,11 +531,13 @@ public class WrapperUtils {
           || constructorArgClasses.length == 0
           || constructorArgs == null
           || constructorArgs.length == 0) {
-        return resultClass.cast(classToInstantiate.newInstance());
+        // Class.newInstance() returns a genuinely non-null instance (or throws); the
+        // @Nullable result of Class.cast comes from its null-in/null-out contract only.
+        return Objects.requireNonNull(resultClass.cast(classToInstantiate.newInstance()));
       }
 
       final Constructor<?> constructor = classToInstantiate.getConstructor(constructorArgClasses);
-      return resultClass.cast(constructor.newInstance(constructorArgs));
+      return Objects.requireNonNull(resultClass.cast(constructor.newInstance(constructorArgs)));
     } catch (final Exception e) {
       throw new InstantiationException(
           Messages.get(
@@ -550,7 +571,7 @@ public class WrapperUtils {
     return createInstance(loaded, resultClass, null, constructorArgs);
   }
 
-  public static Object getFieldValue(Object target, final String accessor) {
+  public static @Nullable Object getFieldValue(@Nullable Object target, final String accessor) {
     if (target == null) {
       return null;
     }
@@ -595,7 +616,7 @@ public class WrapperUtils {
     return target;
   }
 
-  public static Connection getConnectionFromSqlObject(final Object obj) {
+  public static @Nullable Connection getConnectionFromSqlObject(final @Nullable Object obj) {
     if (obj == null) {
       return null;
     }
@@ -698,7 +719,7 @@ public class WrapperUtils {
 
       String updatedMessage = throwable.getMessage();
       contextUpdated = (updatedMessage != null
-          && updatedMessage.contains(message)
+          && (message == null || updatedMessage.contains(message))
           && updatedMessage.contains(context));
     } catch (IllegalAccessException | NoSuchFieldException e) {
       // do nothing


### PR DESCRIPTION
## Summary

Parts 4 & 5 of the incremental Checker Framework (NullnessChecker) adoption, continuing the warn-only, scope-by-scope approach from #1981 and #1998. The checker stays scoped via `-AonlyDefs` in `wrapper/build.gradle.kts`; this PR widens that scope and aligns the contracts the newly-scoped classes touch. No behavior change is intended — only nullness contracts and a couple of latent-NPE fixes.

Verified in the JDK17 container: **0 real / 0 style / 0 checker crashes**, full wrapper unit suite **1152 passed, 0 failed**.

## Part 4 — central-type nullness alignment + 3 deferred util classes

Added `ConnectionUrlParser`, `RetryUtil`, `HostIdCacheServiceImpl` to scope. The 7 findings were resolved by fixing central contracts rather than local patches:

- `HostSpec(HostSpec, @Nullable HostRole)` constructor and `HostSpecBuilder.hostId(@Nullable String)`.
- `PluginService.getHostSpecByStrategy(@Nullable HostRole, …)` (both overloads) + `PluginServiceImpl` / `PartialPluginService` overrides.
- `Dialect.getHostId` → `Pair<@Nullable String, @Nullable String>`, with scoped callers updated.
- `RetryUtil.getAllowedConnection` → `Supplier<@Nullable Set<HostSpec>>`.

## Part 5 — WrapperUtils

Added `WrapperUtils` (the generic plugin-execution / proxy-wrapping helper) to scope:

- `getFieldValue` and `getConnectionFromSqlObject` → `@Nullable` returns/params (they genuinely return null).
- `createInstance(…, Class<?> @Nullable [] constructorArgClasses, …)`; the two `Class.cast(...)` returns wrapped in `Objects.requireNonNull` (the cast is `@Nullable` only via its null-in/null-out contract; the instantiated value is non-null).
- `injectToMessage`: latent NPE fix — `updatedMessage.contains(message)` → `(message == null || updatedMessage.contains(message))` for throwables with a null message.

`executeWithPlugins` is deliberately kept `@NonNull` (matching `ConnectionPluginManager.execute`, which returns `@NonNull`). Annotating it `@Nullable` would cascade into every JDBC wrapper class. The single pass-through spot (a known-non-null `result` flowing into the `@Nullable`-returning `wrapWithProxyIfNeeded`) is isolated in a small documented `@SuppressWarnings("nullness")` helper, so both `executeWithPlugins` bodies stay fully checked.

## Still deferred

`LazyCleanerImpl` and the per-object JDBC wrapper classes (`StatementWrapper`, `ResultSetWrapper`, `PreparedStatementWrapper`, …) — a natural next sub-part.
