### PR TITLE
chore: Checker Framework adoption (parts 6 & 7)

### DIFF
--- a/wrapper/build.gradle.kts
+++ b/wrapper/build.gradle.kts
@@ -319,17 +319,12 @@ if (project.hasProperty("enableCheckerFramework")) {
         // (part 4: RetryUtil, ConnectionUrlParser, HostIdCacheServiceImpl - enabled together
         // with the HostSpec / HostRole / PluginService / HostSpecBuilder / Dialect alignment),
         // WrapperUtils (part 5: the generic plugin-execution / proxy-wrapping helpers), and
-        // (part 6) LazyCleanerImpl plus the per-object JDBC wrapper classes that are already
-        // null-clean (factories, StatementWrapper, and the small/medium wrappers).
-        // The four large wrapper classes - ResultSetWrapper, CallableStatementWrapper,
-        // DatabaseMetaDataWrapper, PreparedStatementWrapper - are excluded via negative
-        // lookahead: they expose hundreds of genuinely-@Nullable JDBC get/set methods and
-        // each warrants its own dedicated pass.
+        // (part 6) all of the per-object JDBC wrapper classes plus LazyCleanerImpl. The whole
+        // software.amazon.jdbc.wrapper package is now in scope.
         // No end-anchor: matching an outer class also covers its nested classes.
         extraJavacArgs = listOf(
             "-AonlyDefs=^software\\.amazon\\.jdbc\\.(ConnectionPluginManager|PluginServiceImpl"
-                + "|wrapper\\.(?!ResultSetWrapper|CallableStatementWrapper"
-                + "|DatabaseMetaDataWrapper|PreparedStatementWrapper)\\w+"
+                + "|wrapper\\.\\w+"
                 + "|util\\.(RdsUtils|RegionUtils|GDBRegionUtils|SqlMethodAnalyzer|CacheItem"
                 + "|Messages|Pair|PropertyUtils|ConnectionUrlBuilder|StringUtils"
                 + "|ConnectionUrlParser|RetryUtil|HostIdCacheServiceImpl|WrapperUtils"

--- a/wrapper/build.gradle.kts
+++ b/wrapper/build.gradle.kts
@@ -318,19 +318,29 @@ if (project.hasProperty("enableCheckerFramework")) {
         // (part 3), the util classes that depend on central-type nullness contracts
         // (part 4: RetryUtil, ConnectionUrlParser, HostIdCacheServiceImpl - enabled together
         // with the HostSpec / HostRole / PluginService / HostSpecBuilder / Dialect alignment),
-        // and WrapperUtils (part 5: the generic plugin-execution / proxy-wrapping helpers).
-        // LazyCleanerImpl and the per-object JDBC wrapper classes remain deferred.
+        // WrapperUtils (part 5: the generic plugin-execution / proxy-wrapping helpers), and
+        // (part 6) LazyCleanerImpl plus the per-object JDBC wrapper classes that are already
+        // null-clean (factories, StatementWrapper, and the small/medium wrappers).
+        // The four large wrapper classes - ResultSetWrapper, CallableStatementWrapper,
+        // DatabaseMetaDataWrapper, PreparedStatementWrapper - are excluded via negative
+        // lookahead: they expose hundreds of genuinely-@Nullable JDBC get/set methods and
+        // each warrants its own dedicated pass.
         // No end-anchor: matching an outer class also covers its nested classes.
         extraJavacArgs = listOf(
             "-AonlyDefs=^software\\.amazon\\.jdbc\\.(ConnectionPluginManager|PluginServiceImpl"
-                + "|wrapper\\.ConnectionWrapper"
+                + "|wrapper\\.(?!ResultSetWrapper|CallableStatementWrapper"
+                + "|DatabaseMetaDataWrapper|PreparedStatementWrapper)\\w+"
                 + "|util\\.(RdsUtils|RegionUtils|GDBRegionUtils|SqlMethodAnalyzer|CacheItem"
                 + "|Messages|Pair|PropertyUtils|ConnectionUrlBuilder|StringUtils"
-                + "|ConnectionUrlParser|RetryUtil|HostIdCacheServiceImpl|WrapperUtils))",
+                + "|ConnectionUrlParser|RetryUtil|HostIdCacheServiceImpl|WrapperUtils"
+                + "|LazyCleanerImpl))",
             // Warning mode: report issues but do not fail the build.
             "-Awarns",
             // Keep the output focused and avoid drowning in framework boilerplate.
-            "-AsuppressWarnings=uninitialized"
+            "-AsuppressWarnings=uninitialized",
+            // Raise javac's default 100-warning cap so the full finding count is visible
+            // while measuring scope (the checker runs warn-only).
+            "-Xmaxwarns", "100000"
         )
     }
 

--- a/wrapper/src/main/java/software/amazon/jdbc/ConnectionPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/ConnectionPlugin.java
@@ -41,7 +41,7 @@ public interface ConnectionPlugin extends StateSnapshotProvider {
       final Object methodInvokeOn,
       final String methodName,
       final JdbcCallable<T, E> jdbcMethodFunc,
-      final Object[] jdbcMethodArgs)
+      final @Nullable Object[] jdbcMethodArgs)
       throws E;
 
   /**

--- a/wrapper/src/main/java/software/amazon/jdbc/ConnectionPluginManager.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/ConnectionPluginManager.java
@@ -317,7 +317,7 @@ public class ConnectionPluginManager implements CanReleaseResources, Wrapper, St
       final Object methodInvokeOn,
       final JdbcMethod jdbcMethod,
       final JdbcCallable<T, E> jdbcMethodFunc,
-      final Object[] jdbcMethodArgs)
+      final @Nullable Object[] jdbcMethodArgs)
       throws E {
     return executeWithSubscribedPlugins(
         jdbcMethod,

--- a/wrapper/src/main/java/software/amazon/jdbc/util/LazyCleanerImpl.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/LazyCleanerImpl.java
@@ -41,6 +41,7 @@ import java.util.concurrent.ForkJoinPool;
 import java.util.function.BooleanSupplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class LazyCleanerImpl implements LazyCleaner {
   private static final Logger LOGGER = Logger.getLogger(LazyCleanerImpl.class.getName());
@@ -50,7 +51,7 @@ public class LazyCleanerImpl implements LazyCleaner {
       Duration.ofMillis(Long.getLong("aws.jdbc.config.cleanup.thread.ttl", 30000))
   );
 
-  private final ReferenceQueue<Object> queue = new ReferenceQueue<>();
+  private final ReferenceQueue<@Nullable Object> queue = new ReferenceQueue<>();
   private final String threadName;
   private final Duration threadTtl;
   private boolean threadRunning;
@@ -97,12 +98,13 @@ public class LazyCleanerImpl implements LazyCleaner {
   private boolean startThread() {
     ForkJoinPool.commonPool().execute(() -> {
       Thread.currentThread().setContextClassLoader(null);
-      RefQueueBlocker<Object> blocker = new RefQueueBlocker<>(queue, threadName, threadTtl, this::checkEmpty);
+      RefQueueBlocker<@Nullable Object> blocker =
+          new RefQueueBlocker<>(queue, threadName, threadTtl, this::checkEmpty);
       while (!checkEmpty()) {
         try {
           ForkJoinPool.managedBlock(blocker);
           @SuppressWarnings("unchecked")
-          Node<Object> ref = (Node<Object>) blocker.drainOne();
+          final @Nullable Node<Object> ref = (Node<Object>) blocker.drainOne();
           if (ref != null) {
             ref.onClean(true);
           }
@@ -171,7 +173,7 @@ public class LazyCleanerImpl implements LazyCleaner {
   private static class RefQueueBlocker<T> implements ForkJoinPool.ManagedBlocker {
     private final ReferenceQueue<T> queue;
     private final String threadName;
-    private Reference<? extends T> ref;
+    private @Nullable Reference<? extends T> ref;
     private final long blockTimeoutMillis;
     private final BooleanSupplier shouldTerminate;
 
@@ -211,8 +213,8 @@ public class LazyCleanerImpl implements LazyCleaner {
       return false;
     }
 
-    public Reference<? extends T> drainOne() {
-      Reference<? extends T> ref = this.ref;
+    public @Nullable Reference<? extends T> drainOne() {
+      @Nullable Reference<? extends T> ref = this.ref;
       this.ref = null;
       return ref;
     }

--- a/wrapper/src/main/java/software/amazon/jdbc/util/WrapperUtils.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/WrapperUtils.java
@@ -207,7 +207,7 @@ public class WrapperUtils {
       final Object methodInvokeOn,
       final JdbcMethod jdbcMethod,
       final JdbcRunnable<E> jdbcMethodFunc,
-      final Object... jdbcMethodArgs)
+      final @Nullable Object... jdbcMethodArgs)
       throws E {
 
     executeWithPlugins(
@@ -231,7 +231,7 @@ public class WrapperUtils {
       final Object methodInvokeOn,
       final JdbcMethod jdbcMethod,
       final JdbcCallable<T, RuntimeException> jdbcMethodFunc,
-      final Object... jdbcMethodArgs) {
+      final @Nullable Object... jdbcMethodArgs) {
 
     if (jdbcMethod.shouldLockConnection) {
       pluginManager.lock();
@@ -305,7 +305,7 @@ public class WrapperUtils {
       final Object methodInvokeOn,
       final JdbcMethod jdbcMethod,
       final JdbcCallable<T, E> jdbcMethodFunc,
-      final Object... jdbcMethodArgs)
+      final @Nullable Object... jdbcMethodArgs)
       throws E {
 
     if (jdbcMethod.shouldLockConnection) {

--- a/wrapper/src/main/java/software/amazon/jdbc/wrapper/CallableStatementWrapper.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/wrapper/CallableStatementWrapper.java
@@ -41,6 +41,7 @@ import java.sql.Timestamp;
 import java.util.Calendar;
 import java.util.Map;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import software.amazon.jdbc.ConnectionPluginManager;
 import software.amazon.jdbc.JdbcMethod;
 import software.amazon.jdbc.util.WrapperUtils;
@@ -413,7 +414,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public Array getArray(int parameterIndex) throws SQLException {
+  public @Nullable Array getArray(int parameterIndex) throws SQLException {
     return WrapperUtils.executeWithPlugins(
         Array.class,
         SQLException.class,
@@ -426,7 +427,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public Array getArray(String parameterName) throws SQLException {
+  public @Nullable Array getArray(String parameterName) throws SQLException {
     return WrapperUtils.executeWithPlugins(
         Array.class,
         SQLException.class,
@@ -440,7 +441,7 @@ public class CallableStatementWrapper implements CallableStatement {
 
   @Override
   @SuppressWarnings("deprecation")
-  public BigDecimal getBigDecimal(int parameterIndex, int scale) throws SQLException {
+  public @Nullable BigDecimal getBigDecimal(int parameterIndex, int scale) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_GETBIGDECIMAL)) {
       return WrapperUtils.executeWithPlugins(
           BigDecimal.class,
@@ -458,7 +459,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public BigDecimal getBigDecimal(int parameterIndex) throws SQLException {
+  public @Nullable BigDecimal getBigDecimal(int parameterIndex) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_GETBIGDECIMAL)) {
       return WrapperUtils.executeWithPlugins(
           BigDecimal.class,
@@ -475,7 +476,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public BigDecimal getBigDecimal(String parameterName) throws SQLException {
+  public @Nullable BigDecimal getBigDecimal(String parameterName) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_GETBIGDECIMAL)) {
       return WrapperUtils.executeWithPlugins(
           BigDecimal.class,
@@ -492,7 +493,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public Blob getBlob(int parameterIndex) throws SQLException {
+  public @Nullable Blob getBlob(int parameterIndex) throws SQLException {
     return WrapperUtils.executeWithPlugins(
         Blob.class,
         SQLException.class,
@@ -505,7 +506,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public Blob getBlob(String parameterName) throws SQLException {
+  public @Nullable Blob getBlob(String parameterName) throws SQLException {
     return WrapperUtils.executeWithPlugins(
         Blob.class,
         SQLException.class,
@@ -586,7 +587,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public byte[] getBytes(int parameterIndex) throws SQLException {
+  public byte @Nullable [] getBytes(int parameterIndex) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_GETBYTES)) {
       return WrapperUtils.executeWithPlugins(
           byte[].class,
@@ -603,7 +604,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public byte[] getBytes(String parameterName) throws SQLException {
+  public byte @Nullable [] getBytes(String parameterName) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_GETBYTES)) {
       return WrapperUtils.executeWithPlugins(
           byte[].class,
@@ -620,7 +621,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public Reader getCharacterStream(int parameterIndex) throws SQLException {
+  public @Nullable Reader getCharacterStream(int parameterIndex) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_GETCHARACTERSTREAM)) {
       return WrapperUtils.executeWithPlugins(
           Reader.class,
@@ -637,7 +638,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public Reader getCharacterStream(String parameterName) throws SQLException {
+  public @Nullable Reader getCharacterStream(String parameterName) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_GETCHARACTERSTREAM)) {
       return WrapperUtils.executeWithPlugins(
           Reader.class,
@@ -654,7 +655,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public Clob getClob(int parameterIndex) throws SQLException {
+  public @Nullable Clob getClob(int parameterIndex) throws SQLException {
     return WrapperUtils.executeWithPlugins(
         Clob.class,
         SQLException.class,
@@ -667,7 +668,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public Clob getClob(String parameterName) throws SQLException {
+  public @Nullable Clob getClob(String parameterName) throws SQLException {
     return WrapperUtils.executeWithPlugins(
         Clob.class,
         SQLException.class,
@@ -692,7 +693,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public Date getDate(int parameterIndex) throws SQLException {
+  public @Nullable Date getDate(int parameterIndex) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_GETDATE)) {
       return WrapperUtils.executeWithPlugins(
           Date.class,
@@ -709,7 +710,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public Date getDate(int parameterIndex, Calendar cal) throws SQLException {
+  public @Nullable Date getDate(int parameterIndex, @Nullable Calendar cal) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_GETDATE)) {
       return WrapperUtils.executeWithPlugins(
           Date.class,
@@ -727,7 +728,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public Date getDate(String parameterName) throws SQLException {
+  public @Nullable Date getDate(String parameterName) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_GETDATE)) {
       return WrapperUtils.executeWithPlugins(
           Date.class,
@@ -744,7 +745,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public Date getDate(String parameterName, Calendar cal) throws SQLException {
+  public @Nullable Date getDate(String parameterName, @Nullable Calendar cal) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_GETDATE)) {
       return WrapperUtils.executeWithPlugins(
           Date.class,
@@ -975,7 +976,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public ResultSetMetaData getMetaData() throws SQLException {
+  public @Nullable ResultSetMetaData getMetaData() throws SQLException {
     return WrapperUtils.executeWithPlugins(
         ResultSetMetaData.class,
         SQLException.class,
@@ -1020,7 +1021,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public Reader getNCharacterStream(int parameterIndex) throws SQLException {
+  public @Nullable Reader getNCharacterStream(int parameterIndex) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_GETNCHARACTERSTREAM)) {
       return WrapperUtils.executeWithPlugins(
           Reader.class,
@@ -1037,7 +1038,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public Reader getNCharacterStream(String parameterName) throws SQLException {
+  public @Nullable Reader getNCharacterStream(String parameterName) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_GETNCHARACTERSTREAM)) {
       return WrapperUtils.executeWithPlugins(
           Reader.class,
@@ -1054,7 +1055,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public NClob getNClob(int parameterIndex) throws SQLException {
+  public @Nullable NClob getNClob(int parameterIndex) throws SQLException {
     return WrapperUtils.executeWithPlugins(
         NClob.class,
         SQLException.class,
@@ -1067,7 +1068,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public NClob getNClob(String parameterName) throws SQLException {
+  public @Nullable NClob getNClob(String parameterName) throws SQLException {
     return WrapperUtils.executeWithPlugins(
         NClob.class,
         SQLException.class,
@@ -1080,7 +1081,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public String getNString(int parameterIndex) throws SQLException {
+  public @Nullable String getNString(int parameterIndex) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_GETNSTRING)) {
       return WrapperUtils.executeWithPlugins(
           String.class,
@@ -1097,7 +1098,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public String getNString(String parameterName) throws SQLException {
+  public @Nullable String getNString(String parameterName) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_GETNSTRING)) {
       return WrapperUtils.executeWithPlugins(
           String.class,
@@ -1114,7 +1115,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public Object getObject(int parameterIndex) throws SQLException {
+  public @Nullable Object getObject(int parameterIndex) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_GETOBJECT)) {
       return WrapperUtils.executeWithPlugins(
           Object.class,
@@ -1131,7 +1132,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public Object getObject(int parameterIndex, Map<String, Class<?>> map) throws SQLException {
+  public @Nullable Object getObject(int parameterIndex, Map<String, Class<?>> map) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_GETOBJECT)) {
       return WrapperUtils.executeWithPlugins(
           Object.class,
@@ -1149,7 +1150,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public Object getObject(String parameterName) throws SQLException {
+  public @Nullable Object getObject(String parameterName) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_GETOBJECT)) {
       return WrapperUtils.executeWithPlugins(
           Object.class,
@@ -1166,7 +1167,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public Object getObject(String parameterName, Map<String, Class<?>> map) throws SQLException {
+  public @Nullable Object getObject(String parameterName, Map<String, Class<?>> map) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_GETOBJECT)) {
       return WrapperUtils.executeWithPlugins(
           Object.class,
@@ -1184,9 +1185,9 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public <T> T getObject(int parameterIndex, Class<T> type) throws SQLException {
+  public <T> @Nullable T getObject(int parameterIndex, Class<T> type) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_GETOBJECT)) {
-      return WrapperUtils.executeWithPlugins(
+      return WrapperUtils.<@Nullable T, SQLException>executeWithPlugins(
           type,
           SQLException.class,
           this.connectionWrapper,
@@ -1202,9 +1203,9 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public <T> T getObject(String parameterName, Class<T> type) throws SQLException {
+  public <T> @Nullable T getObject(String parameterName, Class<T> type) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_GETOBJECT)) {
-      return WrapperUtils.executeWithPlugins(
+      return WrapperUtils.<@Nullable T, SQLException>executeWithPlugins(
           type,
           SQLException.class,
           this.connectionWrapper,
@@ -1248,7 +1249,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public Ref getRef(int parameterIndex) throws SQLException {
+  public @Nullable Ref getRef(int parameterIndex) throws SQLException {
     return WrapperUtils.executeWithPlugins(
         Ref.class,
         SQLException.class,
@@ -1261,7 +1262,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public Ref getRef(String parameterName) throws SQLException {
+  public @Nullable Ref getRef(String parameterName) throws SQLException {
     return WrapperUtils.executeWithPlugins(
         Ref.class,
         SQLException.class,
@@ -1336,7 +1337,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public RowId getRowId(int parameterIndex) throws SQLException {
+  public @Nullable RowId getRowId(int parameterIndex) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_GETROWID)) {
       return WrapperUtils.executeWithPlugins(
           RowId.class,
@@ -1353,7 +1354,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public RowId getRowId(String parameterName) throws SQLException {
+  public @Nullable RowId getRowId(String parameterName) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_GETROWID)) {
       return WrapperUtils.executeWithPlugins(
           RowId.class,
@@ -1370,7 +1371,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public SQLXML getSQLXML(int parameterIndex) throws SQLException {
+  public @Nullable SQLXML getSQLXML(int parameterIndex) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_GETSQLXML)) {
       return WrapperUtils.executeWithPlugins(
           SQLXML.class,
@@ -1387,7 +1388,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public SQLXML getSQLXML(String parameterName) throws SQLException {
+  public @Nullable SQLXML getSQLXML(String parameterName) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_GETSQLXML)) {
       return WrapperUtils.executeWithPlugins(
           SQLXML.class,
@@ -1438,7 +1439,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public String getString(int parameterIndex) throws SQLException {
+  public @Nullable String getString(int parameterIndex) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_GETSTRING)) {
       return WrapperUtils.executeWithPlugins(
           String.class,
@@ -1455,7 +1456,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public String getString(String parameterName) throws SQLException {
+  public @Nullable String getString(String parameterName) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_GETSTRING)) {
       return WrapperUtils.executeWithPlugins(
           String.class,
@@ -1472,7 +1473,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public Time getTime(int parameterIndex) throws SQLException {
+  public @Nullable Time getTime(int parameterIndex) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_GETTIME)) {
       return WrapperUtils.executeWithPlugins(
           Time.class,
@@ -1489,7 +1490,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public Time getTime(int parameterIndex, Calendar cal) throws SQLException {
+  public @Nullable Time getTime(int parameterIndex, @Nullable Calendar cal) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_GETTIME)) {
       return WrapperUtils.executeWithPlugins(
           Time.class,
@@ -1507,7 +1508,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public Time getTime(String parameterName) throws SQLException {
+  public @Nullable Time getTime(String parameterName) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_GETTIME)) {
       return WrapperUtils.executeWithPlugins(
           Time.class,
@@ -1524,7 +1525,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public Time getTime(String parameterName, Calendar cal) throws SQLException {
+  public @Nullable Time getTime(String parameterName, @Nullable Calendar cal) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_GETTIME)) {
       return WrapperUtils.executeWithPlugins(
           Time.class,
@@ -1542,7 +1543,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public Timestamp getTimestamp(int parameterIndex) throws SQLException {
+  public @Nullable Timestamp getTimestamp(int parameterIndex) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_GETTIMESTAMP)) {
       return WrapperUtils.executeWithPlugins(
           Timestamp.class,
@@ -1559,7 +1560,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public Timestamp getTimestamp(int parameterIndex, Calendar cal) throws SQLException {
+  public @Nullable Timestamp getTimestamp(int parameterIndex, @Nullable Calendar cal) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_GETTIMESTAMP)) {
       return WrapperUtils.executeWithPlugins(
           Timestamp.class,
@@ -1577,7 +1578,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public Timestamp getTimestamp(String parameterName) throws SQLException {
+  public @Nullable Timestamp getTimestamp(String parameterName) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_GETTIMESTAMP)) {
       return WrapperUtils.executeWithPlugins(
           Timestamp.class,
@@ -1594,7 +1595,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public Timestamp getTimestamp(String parameterName, Calendar cal) throws SQLException {
+  public @Nullable Timestamp getTimestamp(String parameterName, @Nullable Calendar cal) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_GETTIMESTAMP)) {
       return WrapperUtils.executeWithPlugins(
           Timestamp.class,
@@ -1612,7 +1613,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public URL getURL(int parameterIndex) throws SQLException {
+  public @Nullable URL getURL(int parameterIndex) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_GETURL)) {
       return WrapperUtils.executeWithPlugins(
           URL.class,
@@ -1629,7 +1630,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public URL getURL(String parameterName) throws SQLException {
+  public @Nullable URL getURL(String parameterName) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_GETURL)) {
       return WrapperUtils.executeWithPlugins(
           URL.class,
@@ -1967,7 +1968,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setAsciiStream(String parameterName, InputStream x, int length) throws SQLException {
+  public void setAsciiStream(String parameterName, @Nullable InputStream x, int length) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETASCIISTREAM)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -1985,7 +1986,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setAsciiStream(String parameterName, InputStream x, long length) throws SQLException {
+  public void setAsciiStream(String parameterName, @Nullable InputStream x, long length) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETASCIISTREAM)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -2003,7 +2004,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setAsciiStream(String parameterName, InputStream x) throws SQLException {
+  public void setAsciiStream(String parameterName, @Nullable InputStream x) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETASCIISTREAM)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -2020,7 +2021,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setAsciiStream(int parameterIndex, InputStream x, int length) throws SQLException {
+  public void setAsciiStream(int parameterIndex, @Nullable InputStream x, int length) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETASCIISTREAM)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -2038,7 +2039,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setAsciiStream(int parameterIndex, InputStream x, long length) throws SQLException {
+  public void setAsciiStream(int parameterIndex, @Nullable InputStream x, long length) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETASCIISTREAM)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -2056,7 +2057,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setAsciiStream(int parameterIndex, InputStream x) throws SQLException {
+  public void setAsciiStream(int parameterIndex, @Nullable InputStream x) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETASCIISTREAM)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -2073,7 +2074,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setBigDecimal(String parameterName, BigDecimal x) throws SQLException {
+  public void setBigDecimal(String parameterName, @Nullable BigDecimal x) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETBIGDECIMAL)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -2090,7 +2091,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setBigDecimal(int parameterIndex, BigDecimal x) throws SQLException {
+  public void setBigDecimal(int parameterIndex, @Nullable BigDecimal x) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETBIGDECIMAL)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -2107,7 +2108,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setBinaryStream(String parameterName, InputStream x, int length) throws SQLException {
+  public void setBinaryStream(String parameterName, @Nullable InputStream x, int length) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETBINARYSTREAM)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -2125,7 +2126,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setBinaryStream(String parameterName, InputStream x, long length)
+  public void setBinaryStream(String parameterName, @Nullable InputStream x, long length)
       throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETBINARYSTREAM)) {
       WrapperUtils.runWithPlugins(
@@ -2144,7 +2145,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setBinaryStream(String parameterName, InputStream x) throws SQLException {
+  public void setBinaryStream(String parameterName, @Nullable InputStream x) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETBINARYSTREAM)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -2161,7 +2162,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setBinaryStream(int parameterIndex, InputStream x, int length) throws SQLException {
+  public void setBinaryStream(int parameterIndex, @Nullable InputStream x, int length) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETBINARYSTREAM)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -2179,7 +2180,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setBinaryStream(int parameterIndex, InputStream x, long length) throws SQLException {
+  public void setBinaryStream(int parameterIndex, @Nullable InputStream x, long length) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETBINARYSTREAM)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -2197,7 +2198,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setBinaryStream(int parameterIndex, InputStream x) throws SQLException {
+  public void setBinaryStream(int parameterIndex, @Nullable InputStream x) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETBINARYSTREAM)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -2214,7 +2215,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setBlob(String parameterName, InputStream inputStream, long length)
+  public void setBlob(String parameterName, @Nullable InputStream inputStream, long length)
       throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETBLOB)) {
       WrapperUtils.runWithPlugins(
@@ -2233,7 +2234,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setBlob(String parameterName, Blob x) throws SQLException {
+  public void setBlob(String parameterName, @Nullable Blob x) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETBLOB)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -2250,7 +2251,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setBlob(String parameterName, InputStream inputStream) throws SQLException {
+  public void setBlob(String parameterName, @Nullable InputStream inputStream) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETBLOB)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -2267,7 +2268,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setBlob(int parameterIndex, Blob x) throws SQLException {
+  public void setBlob(int parameterIndex, @Nullable Blob x) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETBLOB)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -2284,7 +2285,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setBlob(int parameterIndex, InputStream inputStream, long length)
+  public void setBlob(int parameterIndex, @Nullable InputStream inputStream, long length)
       throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETBLOB)) {
       WrapperUtils.runWithPlugins(
@@ -2303,7 +2304,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setBlob(int parameterIndex, InputStream inputStream) throws SQLException {
+  public void setBlob(int parameterIndex, @Nullable InputStream inputStream) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETBLOB)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -2388,7 +2389,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setBytes(String parameterName, byte[] x) throws SQLException {
+  public void setBytes(String parameterName, byte @Nullable [] x) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETBYTES)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -2405,7 +2406,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setBytes(int parameterIndex, byte[] x) throws SQLException {
+  public void setBytes(int parameterIndex, byte @Nullable [] x) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETBYTES)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -2422,7 +2423,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setCharacterStream(String parameterName, Reader reader, int length)
+  public void setCharacterStream(String parameterName, @Nullable Reader reader, int length)
       throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETCHARACTERSTREAM)) {
       WrapperUtils.runWithPlugins(
@@ -2441,7 +2442,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setCharacterStream(String parameterName, Reader reader, long length)
+  public void setCharacterStream(String parameterName, @Nullable Reader reader, long length)
       throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETCHARACTERSTREAM)) {
       WrapperUtils.runWithPlugins(
@@ -2460,7 +2461,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setCharacterStream(String parameterName, Reader reader) throws SQLException {
+  public void setCharacterStream(String parameterName, @Nullable Reader reader) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETCHARACTERSTREAM)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -2477,7 +2478,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setCharacterStream(int parameterIndex, Reader reader, int length)
+  public void setCharacterStream(int parameterIndex, @Nullable Reader reader, int length)
       throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETCHARACTERSTREAM)) {
       WrapperUtils.runWithPlugins(
@@ -2496,7 +2497,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setCharacterStream(int parameterIndex, Reader reader, long length)
+  public void setCharacterStream(int parameterIndex, @Nullable Reader reader, long length)
       throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETCHARACTERSTREAM)) {
       WrapperUtils.runWithPlugins(
@@ -2515,7 +2516,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setCharacterStream(int parameterIndex, Reader reader) throws SQLException {
+  public void setCharacterStream(int parameterIndex, @Nullable Reader reader) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETCHARACTERSTREAM)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -2532,7 +2533,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setClob(String parameterName, Reader reader, long length) throws SQLException {
+  public void setClob(String parameterName, @Nullable Reader reader, long length) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETCLOB)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -2550,7 +2551,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setClob(String parameterName, Clob x) throws SQLException {
+  public void setClob(String parameterName, @Nullable Clob x) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETCLOB)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -2567,7 +2568,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setClob(String parameterName, Reader reader) throws SQLException {
+  public void setClob(String parameterName, @Nullable Reader reader) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETCLOB)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -2584,7 +2585,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setClob(int parameterIndex, Clob x) throws SQLException {
+  public void setClob(int parameterIndex, @Nullable Clob x) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETCLOB)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -2601,7 +2602,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setClob(int parameterIndex, Reader reader, long length) throws SQLException {
+  public void setClob(int parameterIndex, @Nullable Reader reader, long length) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETCLOB)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -2619,7 +2620,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setClob(int parameterIndex, Reader reader) throws SQLException {
+  public void setClob(int parameterIndex, @Nullable Reader reader) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETCLOB)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -2652,7 +2653,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setDate(String parameterName, Date x) throws SQLException {
+  public void setDate(String parameterName, @Nullable Date x) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETDATE)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -2669,7 +2670,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setDate(String parameterName, Date x, Calendar cal) throws SQLException {
+  public void setDate(String parameterName, @Nullable Date x, @Nullable Calendar cal) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETDATE)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -2687,7 +2688,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setDate(int parameterIndex, Date x) throws SQLException {
+  public void setDate(int parameterIndex, @Nullable Date x) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETDATE)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -2704,7 +2705,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setDate(int parameterIndex, Date x, Calendar cal) throws SQLException {
+  public void setDate(int parameterIndex, @Nullable Date x, @Nullable Calendar cal) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETDATE)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -2938,7 +2939,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setNCharacterStream(String parameterName, Reader value, long length)
+  public void setNCharacterStream(String parameterName, @Nullable Reader value, long length)
       throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETNCHARACTERSTREAM)) {
       WrapperUtils.runWithPlugins(
@@ -2957,7 +2958,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setNCharacterStream(String parameterName, Reader value) throws SQLException {
+  public void setNCharacterStream(String parameterName, @Nullable Reader value) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETNCHARACTERSTREAM)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -2974,7 +2975,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setNCharacterStream(int parameterIndex, Reader value, long length)
+  public void setNCharacterStream(int parameterIndex, @Nullable Reader value, long length)
       throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETNCHARACTERSTREAM)) {
       WrapperUtils.runWithPlugins(
@@ -2993,7 +2994,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setNCharacterStream(int parameterIndex, Reader value) throws SQLException {
+  public void setNCharacterStream(int parameterIndex, @Nullable Reader value) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETNCHARACTERSTREAM)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -3010,7 +3011,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setNClob(String parameterName, NClob value) throws SQLException {
+  public void setNClob(String parameterName, @Nullable NClob value) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETNCLOB)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -3027,7 +3028,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setNClob(String parameterName, Reader reader, long length) throws SQLException {
+  public void setNClob(String parameterName, @Nullable Reader reader, long length) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETNCLOB)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -3045,7 +3046,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setNClob(String parameterName, Reader reader) throws SQLException {
+  public void setNClob(String parameterName, @Nullable Reader reader) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETNCLOB)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -3062,7 +3063,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setNClob(int parameterIndex, NClob value) throws SQLException {
+  public void setNClob(int parameterIndex, @Nullable NClob value) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETNCLOB)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -3079,7 +3080,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setNClob(int parameterIndex, Reader reader, long length) throws SQLException {
+  public void setNClob(int parameterIndex, @Nullable Reader reader, long length) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETNCLOB)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -3097,7 +3098,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setNClob(int parameterIndex, Reader reader) throws SQLException {
+  public void setNClob(int parameterIndex, @Nullable Reader reader) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETNCLOB)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -3114,7 +3115,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setNString(String parameterName, String value) throws SQLException {
+  public void setNString(String parameterName, @Nullable String value) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETNSTRING)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -3131,7 +3132,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setNString(int parameterIndex, String value) throws SQLException {
+  public void setNString(int parameterIndex, @Nullable String value) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETNSTRING)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -3218,7 +3219,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setObject(String parameterName, Object x, int targetSqlType, int scale)
+  public void setObject(String parameterName, @Nullable Object x, int targetSqlType, int scale)
       throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETOBJECT)) {
       WrapperUtils.runWithPlugins(
@@ -3238,7 +3239,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setObject(String parameterName, Object x, int targetSqlType) throws SQLException {
+  public void setObject(String parameterName, @Nullable Object x, int targetSqlType) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETOBJECT)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -3256,7 +3257,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setObject(String parameterName, Object x) throws SQLException {
+  public void setObject(String parameterName, @Nullable Object x) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETOBJECT)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -3273,7 +3274,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setObject(String parameterName, Object x, SQLType targetSqlType, int scaleOrLength)
+  public void setObject(String parameterName, @Nullable Object x, SQLType targetSqlType, int scaleOrLength)
       throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETOBJECT)) {
       WrapperUtils.runWithPlugins(
@@ -3293,7 +3294,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setObject(String parameterName, Object x, SQLType targetSqlType) throws SQLException {
+  public void setObject(String parameterName, @Nullable Object x, SQLType targetSqlType) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETOBJECT)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -3311,7 +3312,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setObject(int parameterIndex, Object x, int targetSqlType) throws SQLException {
+  public void setObject(int parameterIndex, @Nullable Object x, int targetSqlType) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETOBJECT)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -3329,7 +3330,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setObject(int parameterIndex, Object x) throws SQLException {
+  public void setObject(int parameterIndex, @Nullable Object x) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETOBJECT)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -3346,7 +3347,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setObject(int parameterIndex, Object x, int targetSqlType, int scaleOrLength)
+  public void setObject(int parameterIndex, @Nullable Object x, int targetSqlType, int scaleOrLength)
       throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETOBJECT)) {
       WrapperUtils.runWithPlugins(
@@ -3366,7 +3367,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setObject(int parameterIndex, Object x, SQLType targetSqlType, int scaleOrLength)
+  public void setObject(int parameterIndex, @Nullable Object x, SQLType targetSqlType, int scaleOrLength)
       throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETOBJECT)) {
       WrapperUtils.runWithPlugins(
@@ -3386,7 +3387,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setObject(int parameterIndex, Object x, SQLType targetSqlType) throws SQLException {
+  public void setObject(int parameterIndex, @Nullable Object x, SQLType targetSqlType) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETOBJECT)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -3454,7 +3455,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setRowId(String parameterName, RowId x) throws SQLException {
+  public void setRowId(String parameterName, @Nullable RowId x) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETROWID)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -3488,7 +3489,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setSQLXML(String parameterName, SQLXML xmlObject) throws SQLException {
+  public void setSQLXML(String parameterName, @Nullable SQLXML xmlObject) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETSQLXML)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -3556,7 +3557,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setString(String parameterName, String x) throws SQLException {
+  public void setString(String parameterName, @Nullable String x) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETSTRING)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -3573,7 +3574,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setString(int parameterIndex, String x) throws SQLException {
+  public void setString(int parameterIndex, @Nullable String x) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETSTRING)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -3590,7 +3591,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setTime(String parameterName, Time x) throws SQLException {
+  public void setTime(String parameterName, @Nullable Time x) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETTIME)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -3607,7 +3608,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setTime(String parameterName, Time x, Calendar cal) throws SQLException {
+  public void setTime(String parameterName, @Nullable Time x, @Nullable Calendar cal) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETTIME)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -3625,7 +3626,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setTime(int parameterIndex, Time x) throws SQLException {
+  public void setTime(int parameterIndex, @Nullable Time x) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETTIME)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -3642,7 +3643,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setTime(int parameterIndex, Time x, Calendar cal) throws SQLException {
+  public void setTime(int parameterIndex, @Nullable Time x, @Nullable Calendar cal) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETTIME)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -3660,7 +3661,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setTimestamp(String parameterName, Timestamp x) throws SQLException {
+  public void setTimestamp(String parameterName, @Nullable Timestamp x) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETTIMESTAMP)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -3677,7 +3678,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setTimestamp(String parameterName, Timestamp x, Calendar cal) throws SQLException {
+  public void setTimestamp(String parameterName, @Nullable Timestamp x, @Nullable Calendar cal) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETTIMESTAMP)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -3695,7 +3696,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setTimestamp(int parameterIndex, Timestamp x) throws SQLException {
+  public void setTimestamp(int parameterIndex, @Nullable Timestamp x) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETTIMESTAMP)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -3712,7 +3713,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setTimestamp(int parameterIndex, Timestamp x, Calendar cal) throws SQLException {
+  public void setTimestamp(int parameterIndex, @Nullable Timestamp x, @Nullable Calendar cal) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETTIMESTAMP)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -3730,7 +3731,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setURL(String parameterName, URL val) throws SQLException {
+  public void setURL(String parameterName, @Nullable URL val) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETURL)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -3747,7 +3748,7 @@ public class CallableStatementWrapper implements CallableStatement {
   }
 
   @Override
-  public void setURL(int parameterIndex, URL x) throws SQLException {
+  public void setURL(int parameterIndex, @Nullable URL x) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETURL)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -3765,7 +3766,7 @@ public class CallableStatementWrapper implements CallableStatement {
 
   @Override
   @SuppressWarnings("deprecation")
-  public void setUnicodeStream(int parameterIndex, InputStream x, int length) throws SQLException {
+  public void setUnicodeStream(int parameterIndex, @Nullable InputStream x, int length) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.CALLABLESTATEMENT_SETUNICODESTREAM)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,

--- a/wrapper/src/main/java/software/amazon/jdbc/wrapper/DatabaseMetaDataWrapper.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/wrapper/DatabaseMetaDataWrapper.java
@@ -23,6 +23,7 @@ import java.sql.RowIdLifetime;
 import java.sql.SQLException;
 import java.util.StringJoiner;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import software.amazon.jdbc.ConnectionPluginManager;
 import software.amazon.jdbc.JdbcMethod;
 import software.amazon.jdbc.util.DriverInfo;
@@ -76,9 +77,9 @@ public class DatabaseMetaDataWrapper implements DatabaseMetaData {
   }
 
   @Override
-  public String getURL() throws SQLException {
+  public @Nullable String getURL() throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.DATABASEMETADATA_GETURL)) {
-      return WrapperUtils.executeWithPlugins(
+      return WrapperUtils.<@Nullable String, SQLException>executeWithPlugins(
           String.class,
           SQLException.class,
           this.connectionWrapper,
@@ -1908,7 +1909,8 @@ public class DatabaseMetaDataWrapper implements DatabaseMetaData {
   }
 
   @Override
-  public ResultSet getProcedures(String catalog, String schemaPattern, String procedureNamePattern)
+  public ResultSet getProcedures(@Nullable String catalog, @Nullable String schemaPattern,
+      @Nullable String procedureNamePattern)
       throws SQLException {
     return WrapperUtils.executeWithPlugins(
         ResultSet.class,
@@ -1925,7 +1927,8 @@ public class DatabaseMetaDataWrapper implements DatabaseMetaData {
 
   @Override
   public ResultSet getProcedureColumns(
-      String catalog, String schemaPattern, String procedureNamePattern, String columnNamePattern)
+      @Nullable String catalog, @Nullable String schemaPattern, @Nullable String procedureNamePattern,
+      @Nullable String columnNamePattern)
       throws SQLException {
     return WrapperUtils.executeWithPlugins(
         ResultSet.class,
@@ -1945,7 +1948,8 @@ public class DatabaseMetaDataWrapper implements DatabaseMetaData {
 
   @Override
   public ResultSet getTables(
-      String catalog, String schemaPattern, String tableNamePattern, String[] types)
+      @Nullable String catalog, @Nullable String schemaPattern, @Nullable String tableNamePattern,
+      String @Nullable [] types)
       throws SQLException {
     return WrapperUtils.executeWithPlugins(
         ResultSet.class,
@@ -1974,7 +1978,7 @@ public class DatabaseMetaDataWrapper implements DatabaseMetaData {
   }
 
   @Override
-  public ResultSet getSchemas(String catalog, String schemaPattern) throws SQLException {
+  public ResultSet getSchemas(@Nullable String catalog, String schemaPattern) throws SQLException {
     return WrapperUtils.executeWithPlugins(
         ResultSet.class,
         SQLException.class,
@@ -2013,7 +2017,8 @@ public class DatabaseMetaDataWrapper implements DatabaseMetaData {
 
   @Override
   public ResultSet getColumns(
-      String catalog, String schemaPattern, String tableNamePattern, String columnNamePattern)
+      @Nullable String catalog, @Nullable String schemaPattern, @Nullable String tableNamePattern,
+      @Nullable String columnNamePattern)
       throws SQLException {
     return WrapperUtils.executeWithPlugins(
         ResultSet.class,
@@ -2033,7 +2038,8 @@ public class DatabaseMetaDataWrapper implements DatabaseMetaData {
 
   @Override
   public ResultSet getColumnPrivileges(
-      String catalog, String schema, String table, String columnNamePattern) throws SQLException {
+      @Nullable String catalog, @Nullable String schema, String table, @Nullable String columnNamePattern)
+      throws SQLException {
     return WrapperUtils.executeWithPlugins(
         ResultSet.class,
         SQLException.class,
@@ -2049,7 +2055,8 @@ public class DatabaseMetaDataWrapper implements DatabaseMetaData {
   }
 
   @Override
-  public ResultSet getTablePrivileges(String catalog, String schemaPattern, String tableNamePattern)
+  public ResultSet getTablePrivileges(@Nullable String catalog, @Nullable String schemaPattern,
+      @Nullable String tableNamePattern)
       throws SQLException {
     return WrapperUtils.executeWithPlugins(
         ResultSet.class,
@@ -2066,7 +2073,7 @@ public class DatabaseMetaDataWrapper implements DatabaseMetaData {
 
   @Override
   public ResultSet getBestRowIdentifier(
-      String catalog, String schema, String table, int scope, boolean nullable)
+      @Nullable String catalog, @Nullable String schema, String table, int scope, boolean nullable)
       throws SQLException {
     return WrapperUtils.executeWithPlugins(
         ResultSet.class,
@@ -2084,7 +2091,7 @@ public class DatabaseMetaDataWrapper implements DatabaseMetaData {
   }
 
   @Override
-  public ResultSet getVersionColumns(String catalog, String schema, String table)
+  public ResultSet getVersionColumns(@Nullable String catalog, @Nullable String schema, String table)
       throws SQLException {
     return WrapperUtils.executeWithPlugins(
         ResultSet.class,
@@ -2100,7 +2107,7 @@ public class DatabaseMetaDataWrapper implements DatabaseMetaData {
   }
 
   @Override
-  public ResultSet getPrimaryKeys(String catalog, String schema, String table) throws SQLException {
+  public ResultSet getPrimaryKeys(@Nullable String catalog, @Nullable String schema, String table) throws SQLException {
     return WrapperUtils.executeWithPlugins(
         ResultSet.class,
         SQLException.class,
@@ -2115,7 +2122,7 @@ public class DatabaseMetaDataWrapper implements DatabaseMetaData {
   }
 
   @Override
-  public ResultSet getImportedKeys(String catalog, String schema, String table)
+  public ResultSet getImportedKeys(@Nullable String catalog, @Nullable String schema, String table)
       throws SQLException {
     return WrapperUtils.executeWithPlugins(
         ResultSet.class,
@@ -2131,7 +2138,7 @@ public class DatabaseMetaDataWrapper implements DatabaseMetaData {
   }
 
   @Override
-  public ResultSet getExportedKeys(String catalog, String schema, String table)
+  public ResultSet getExportedKeys(@Nullable String catalog, @Nullable String schema, String table)
       throws SQLException {
     return WrapperUtils.executeWithPlugins(
         ResultSet.class,
@@ -2148,11 +2155,11 @@ public class DatabaseMetaDataWrapper implements DatabaseMetaData {
 
   @Override
   public ResultSet getCrossReference(
-      String parentCatalog,
-      String parentSchema,
+      @Nullable String parentCatalog,
+      @Nullable String parentSchema,
       String parentTable,
-      String foreignCatalog,
-      String foreignSchema,
+      @Nullable String foreignCatalog,
+      @Nullable String foreignSchema,
       String foreignTable)
       throws SQLException {
     return WrapperUtils.executeWithPlugins(
@@ -2192,7 +2199,7 @@ public class DatabaseMetaDataWrapper implements DatabaseMetaData {
 
   @Override
   public ResultSet getIndexInfo(
-      String catalog, String schema, String table, boolean unique, boolean approximate)
+      @Nullable String catalog, @Nullable String schema, String table, boolean unique, boolean approximate)
       throws SQLException {
     return WrapperUtils.executeWithPlugins(
         ResultSet.class,
@@ -2415,7 +2422,8 @@ public class DatabaseMetaDataWrapper implements DatabaseMetaData {
 
   @Override
   public ResultSet getUDTs(
-      String catalog, String schemaPattern, String typeNamePattern, int[] types)
+      @Nullable String catalog, @Nullable String schemaPattern, @Nullable String typeNamePattern,
+      int @Nullable [] types)
       throws SQLException {
     return WrapperUtils.executeWithPlugins(
         ResultSet.class,
@@ -2508,7 +2516,8 @@ public class DatabaseMetaDataWrapper implements DatabaseMetaData {
   }
 
   @Override
-  public ResultSet getSuperTypes(String catalog, String schemaPattern, String typeNamePattern)
+  public ResultSet getSuperTypes(@Nullable String catalog, @Nullable String schemaPattern,
+      @Nullable String typeNamePattern)
       throws SQLException {
     return WrapperUtils.executeWithPlugins(
         ResultSet.class,
@@ -2524,7 +2533,8 @@ public class DatabaseMetaDataWrapper implements DatabaseMetaData {
   }
 
   @Override
-  public ResultSet getSuperTables(String catalog, String schemaPattern, String tableNamePattern)
+  public ResultSet getSuperTables(@Nullable String catalog, @Nullable String schemaPattern,
+      @Nullable String tableNamePattern)
       throws SQLException {
     return WrapperUtils.executeWithPlugins(
         ResultSet.class,
@@ -2541,7 +2551,8 @@ public class DatabaseMetaDataWrapper implements DatabaseMetaData {
 
   @Override
   public ResultSet getAttributes(
-      String catalog, String schemaPattern, String typeNamePattern, String attributeNamePattern)
+      @Nullable String catalog, @Nullable String schemaPattern, @Nullable String typeNamePattern,
+      @Nullable String attributeNamePattern)
       throws SQLException {
     return WrapperUtils.executeWithPlugins(
         ResultSet.class,
@@ -2766,7 +2777,8 @@ public class DatabaseMetaDataWrapper implements DatabaseMetaData {
   }
 
   @Override
-  public ResultSet getFunctions(String catalog, String schemaPattern, String functionNamePattern)
+  public ResultSet getFunctions(@Nullable String catalog, @Nullable String schemaPattern,
+      @Nullable String functionNamePattern)
       throws SQLException {
     return WrapperUtils.executeWithPlugins(
         ResultSet.class,
@@ -2783,7 +2795,8 @@ public class DatabaseMetaDataWrapper implements DatabaseMetaData {
 
   @Override
   public ResultSet getFunctionColumns(
-      String catalog, String schemaPattern, String functionNamePattern, String columnNamePattern)
+      @Nullable String catalog, @Nullable String schemaPattern, @Nullable String functionNamePattern,
+      @Nullable String columnNamePattern)
       throws SQLException {
     return WrapperUtils.executeWithPlugins(
         ResultSet.class,
@@ -2803,7 +2816,8 @@ public class DatabaseMetaDataWrapper implements DatabaseMetaData {
 
   @Override
   public ResultSet getPseudoColumns(
-      String catalog, String schemaPattern, String tableNamePattern, String columnNamePattern)
+      @Nullable String catalog, @Nullable String schemaPattern, @Nullable String tableNamePattern,
+      @Nullable String columnNamePattern)
       throws SQLException {
     return WrapperUtils.executeWithPlugins(
         ResultSet.class,

--- a/wrapper/src/main/java/software/amazon/jdbc/wrapper/PreparedStatementWrapper.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/wrapper/PreparedStatementWrapper.java
@@ -40,6 +40,7 @@ import java.sql.Time;
 import java.sql.Timestamp;
 import java.util.Calendar;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import software.amazon.jdbc.ConnectionPluginManager;
 import software.amazon.jdbc.JdbcMethod;
 import software.amazon.jdbc.util.WrapperUtils;
@@ -501,8 +502,8 @@ public class PreparedStatementWrapper implements PreparedStatement {
   }
 
   @Override
-  public ResultSetMetaData getMetaData() throws SQLException {
-    return WrapperUtils.executeWithPlugins(
+  public @Nullable ResultSetMetaData getMetaData() throws SQLException {
+    return WrapperUtils.<@Nullable ResultSetMetaData, SQLException>executeWithPlugins(
         ResultSetMetaData.class,
         SQLException.class,
         this.connectionWrapper,
@@ -738,7 +739,7 @@ public class PreparedStatementWrapper implements PreparedStatement {
   }
 
   @Override
-  public void setAsciiStream(int parameterIndex, InputStream x, int length) throws SQLException {
+  public void setAsciiStream(int parameterIndex, @Nullable InputStream x, int length) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.PREPAREDSTATEMENT_SETASCIISTREAM)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -756,7 +757,7 @@ public class PreparedStatementWrapper implements PreparedStatement {
   }
 
   @Override
-  public void setAsciiStream(int parameterIndex, InputStream x, long length) throws SQLException {
+  public void setAsciiStream(int parameterIndex, @Nullable InputStream x, long length) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.PREPAREDSTATEMENT_SETASCIISTREAM)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -774,7 +775,7 @@ public class PreparedStatementWrapper implements PreparedStatement {
   }
 
   @Override
-  public void setAsciiStream(int parameterIndex, InputStream x) throws SQLException {
+  public void setAsciiStream(int parameterIndex, @Nullable InputStream x) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.PREPAREDSTATEMENT_SETASCIISTREAM)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -791,7 +792,7 @@ public class PreparedStatementWrapper implements PreparedStatement {
   }
 
   @Override
-  public void setBigDecimal(int parameterIndex, BigDecimal x) throws SQLException {
+  public void setBigDecimal(int parameterIndex, @Nullable BigDecimal x) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.PREPAREDSTATEMENT_SETBIGDECIMAL)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -808,7 +809,7 @@ public class PreparedStatementWrapper implements PreparedStatement {
   }
 
   @Override
-  public void setBinaryStream(int parameterIndex, InputStream x, int length) throws SQLException {
+  public void setBinaryStream(int parameterIndex, @Nullable InputStream x, int length) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.PREPAREDSTATEMENT_SETBINARYSTREAM)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -826,7 +827,7 @@ public class PreparedStatementWrapper implements PreparedStatement {
   }
 
   @Override
-  public void setBinaryStream(int parameterIndex, InputStream x, long length) throws SQLException {
+  public void setBinaryStream(int parameterIndex, @Nullable InputStream x, long length) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.PREPAREDSTATEMENT_SETBINARYSTREAM)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -844,7 +845,7 @@ public class PreparedStatementWrapper implements PreparedStatement {
   }
 
   @Override
-  public void setBinaryStream(int parameterIndex, InputStream x) throws SQLException {
+  public void setBinaryStream(int parameterIndex, @Nullable InputStream x) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.PREPAREDSTATEMENT_SETBINARYSTREAM)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -861,7 +862,7 @@ public class PreparedStatementWrapper implements PreparedStatement {
   }
 
   @Override
-  public void setBlob(int parameterIndex, Blob x) throws SQLException {
+  public void setBlob(int parameterIndex, @Nullable Blob x) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.PREPAREDSTATEMENT_SETBLOB)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -878,7 +879,7 @@ public class PreparedStatementWrapper implements PreparedStatement {
   }
 
   @Override
-  public void setBlob(int parameterIndex, InputStream inputStream, long length)
+  public void setBlob(int parameterIndex, @Nullable InputStream inputStream, long length)
       throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.PREPAREDSTATEMENT_SETBLOB)) {
       WrapperUtils.runWithPlugins(
@@ -897,7 +898,7 @@ public class PreparedStatementWrapper implements PreparedStatement {
   }
 
   @Override
-  public void setBlob(int parameterIndex, InputStream inputStream) throws SQLException {
+  public void setBlob(int parameterIndex, @Nullable InputStream inputStream) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.PREPAREDSTATEMENT_SETBLOB)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -948,7 +949,7 @@ public class PreparedStatementWrapper implements PreparedStatement {
   }
 
   @Override
-  public void setBytes(int parameterIndex, byte[] x) throws SQLException {
+  public void setBytes(int parameterIndex, byte @Nullable [] x) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.PREPAREDSTATEMENT_SETBYTES)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -965,7 +966,7 @@ public class PreparedStatementWrapper implements PreparedStatement {
   }
 
   @Override
-  public void setCharacterStream(int parameterIndex, Reader reader, int length)
+  public void setCharacterStream(int parameterIndex, @Nullable Reader reader, int length)
       throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.PREPAREDSTATEMENT_SETCHARACTERSTREAM)) {
       WrapperUtils.runWithPlugins(
@@ -984,7 +985,7 @@ public class PreparedStatementWrapper implements PreparedStatement {
   }
 
   @Override
-  public void setCharacterStream(int parameterIndex, Reader reader, long length)
+  public void setCharacterStream(int parameterIndex, @Nullable Reader reader, long length)
       throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.PREPAREDSTATEMENT_SETCHARACTERSTREAM)) {
       WrapperUtils.runWithPlugins(
@@ -1003,7 +1004,7 @@ public class PreparedStatementWrapper implements PreparedStatement {
   }
 
   @Override
-  public void setCharacterStream(int parameterIndex, Reader reader) throws SQLException {
+  public void setCharacterStream(int parameterIndex, @Nullable Reader reader) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.PREPAREDSTATEMENT_SETCHARACTERSTREAM)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -1020,7 +1021,7 @@ public class PreparedStatementWrapper implements PreparedStatement {
   }
 
   @Override
-  public void setClob(int parameterIndex, Clob x) throws SQLException {
+  public void setClob(int parameterIndex, @Nullable Clob x) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.PREPAREDSTATEMENT_SETCLOB)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -1037,7 +1038,7 @@ public class PreparedStatementWrapper implements PreparedStatement {
   }
 
   @Override
-  public void setClob(int parameterIndex, Reader reader, long length) throws SQLException {
+  public void setClob(int parameterIndex, @Nullable Reader reader, long length) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.PREPAREDSTATEMENT_SETCLOB)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -1055,7 +1056,7 @@ public class PreparedStatementWrapper implements PreparedStatement {
   }
 
   @Override
-  public void setClob(int parameterIndex, Reader reader) throws SQLException {
+  public void setClob(int parameterIndex, @Nullable Reader reader) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.PREPAREDSTATEMENT_SETCLOB)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -1088,7 +1089,7 @@ public class PreparedStatementWrapper implements PreparedStatement {
   }
 
   @Override
-  public void setDate(int parameterIndex, Date x) throws SQLException {
+  public void setDate(int parameterIndex, @Nullable Date x) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.PREPAREDSTATEMENT_SETDATE)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -1105,7 +1106,7 @@ public class PreparedStatementWrapper implements PreparedStatement {
   }
 
   @Override
-  public void setDate(int parameterIndex, Date x, Calendar cal) throws SQLException {
+  public void setDate(int parameterIndex, @Nullable Date x, @Nullable Calendar cal) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.PREPAREDSTATEMENT_SETDATE)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -1271,7 +1272,7 @@ public class PreparedStatementWrapper implements PreparedStatement {
   }
 
   @Override
-  public void setNCharacterStream(int parameterIndex, Reader value, long length)
+  public void setNCharacterStream(int parameterIndex, @Nullable Reader value, long length)
       throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.PREPAREDSTATEMENT_SETNCHARACTERSTREAM)) {
       WrapperUtils.runWithPlugins(
@@ -1290,7 +1291,7 @@ public class PreparedStatementWrapper implements PreparedStatement {
   }
 
   @Override
-  public void setNCharacterStream(int parameterIndex, Reader value) throws SQLException {
+  public void setNCharacterStream(int parameterIndex, @Nullable Reader value) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.PREPAREDSTATEMENT_SETNCHARACTERSTREAM)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -1307,7 +1308,7 @@ public class PreparedStatementWrapper implements PreparedStatement {
   }
 
   @Override
-  public void setNClob(int parameterIndex, NClob value) throws SQLException {
+  public void setNClob(int parameterIndex, @Nullable NClob value) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.PREPAREDSTATEMENT_SETNCLOB)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -1324,7 +1325,7 @@ public class PreparedStatementWrapper implements PreparedStatement {
   }
 
   @Override
-  public void setNClob(int parameterIndex, Reader reader, long length) throws SQLException {
+  public void setNClob(int parameterIndex, @Nullable Reader reader, long length) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.PREPAREDSTATEMENT_SETNCLOB)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -1342,7 +1343,7 @@ public class PreparedStatementWrapper implements PreparedStatement {
   }
 
   @Override
-  public void setNClob(int parameterIndex, Reader reader) throws SQLException {
+  public void setNClob(int parameterIndex, @Nullable Reader reader) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.PREPAREDSTATEMENT_SETNCLOB)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -1359,7 +1360,7 @@ public class PreparedStatementWrapper implements PreparedStatement {
   }
 
   @Override
-  public void setNString(int parameterIndex, String value) throws SQLException {
+  public void setNString(int parameterIndex, @Nullable String value) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.PREPAREDSTATEMENT_SETNSTRING)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -1411,7 +1412,7 @@ public class PreparedStatementWrapper implements PreparedStatement {
   }
 
   @Override
-  public void setObject(int parameterIndex, Object x, int targetSqlType) throws SQLException {
+  public void setObject(int parameterIndex, @Nullable Object x, int targetSqlType) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.PREPAREDSTATEMENT_SETOBJECT)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -1429,7 +1430,7 @@ public class PreparedStatementWrapper implements PreparedStatement {
   }
 
   @Override
-  public void setObject(int parameterIndex, Object x) throws SQLException {
+  public void setObject(int parameterIndex, @Nullable Object x) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.PREPAREDSTATEMENT_SETOBJECT)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -1446,7 +1447,7 @@ public class PreparedStatementWrapper implements PreparedStatement {
   }
 
   @Override
-  public void setObject(int parameterIndex, Object x, int targetSqlType, int scaleOrLength)
+  public void setObject(int parameterIndex, @Nullable Object x, int targetSqlType, int scaleOrLength)
       throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.PREPAREDSTATEMENT_SETOBJECT)) {
       WrapperUtils.runWithPlugins(
@@ -1466,7 +1467,7 @@ public class PreparedStatementWrapper implements PreparedStatement {
   }
 
   @Override
-  public void setObject(int parameterIndex, Object x, SQLType targetSqlType, int scaleOrLength)
+  public void setObject(int parameterIndex, @Nullable Object x, SQLType targetSqlType, int scaleOrLength)
       throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.PREPAREDSTATEMENT_SETOBJECT)) {
       WrapperUtils.runWithPlugins(
@@ -1486,7 +1487,7 @@ public class PreparedStatementWrapper implements PreparedStatement {
   }
 
   @Override
-  public void setObject(int parameterIndex, Object x, SQLType targetSqlType) throws SQLException {
+  public void setObject(int parameterIndex, @Nullable Object x, SQLType targetSqlType) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.PREPAREDSTATEMENT_SETOBJECT)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -1605,7 +1606,7 @@ public class PreparedStatementWrapper implements PreparedStatement {
   }
 
   @Override
-  public void setString(int parameterIndex, String x) throws SQLException {
+  public void setString(int parameterIndex, @Nullable String x) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.PREPAREDSTATEMENT_SETSTRING)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -1622,7 +1623,7 @@ public class PreparedStatementWrapper implements PreparedStatement {
   }
 
   @Override
-  public void setTime(int parameterIndex, Time x) throws SQLException {
+  public void setTime(int parameterIndex, @Nullable Time x) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.PREPAREDSTATEMENT_SETTIME)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -1639,7 +1640,7 @@ public class PreparedStatementWrapper implements PreparedStatement {
   }
 
   @Override
-  public void setTime(int parameterIndex, Time x, Calendar cal) throws SQLException {
+  public void setTime(int parameterIndex, @Nullable Time x, @Nullable Calendar cal) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.PREPAREDSTATEMENT_SETTIME)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -1657,7 +1658,7 @@ public class PreparedStatementWrapper implements PreparedStatement {
   }
 
   @Override
-  public void setTimestamp(int parameterIndex, Timestamp x) throws SQLException {
+  public void setTimestamp(int parameterIndex, @Nullable Timestamp x) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.PREPAREDSTATEMENT_SETTIMESTAMP)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -1674,7 +1675,7 @@ public class PreparedStatementWrapper implements PreparedStatement {
   }
 
   @Override
-  public void setTimestamp(int parameterIndex, Timestamp x, Calendar cal) throws SQLException {
+  public void setTimestamp(int parameterIndex, @Nullable Timestamp x, @Nullable Calendar cal) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.PREPAREDSTATEMENT_SETTIMESTAMP)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -1692,7 +1693,7 @@ public class PreparedStatementWrapper implements PreparedStatement {
   }
 
   @Override
-  public void setURL(int parameterIndex, URL x) throws SQLException {
+  public void setURL(int parameterIndex, @Nullable URL x) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.PREPAREDSTATEMENT_SETURL)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -1710,7 +1711,7 @@ public class PreparedStatementWrapper implements PreparedStatement {
 
   @Override
   @SuppressWarnings("deprecation")
-  public void setUnicodeStream(int parameterIndex, InputStream x, int length) throws SQLException {
+  public void setUnicodeStream(int parameterIndex, @Nullable InputStream x, int length) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.PREPAREDSTATEMENT_SETUNICODESTREAM)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,

--- a/wrapper/src/main/java/software/amazon/jdbc/wrapper/ResultSetWrapper.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/wrapper/ResultSetWrapper.java
@@ -1894,7 +1894,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public void updateAsciiStream(int columnIndex, @Nullable InputStream x) throws SQLException {
+  public void updateAsciiStream(int columnIndex, InputStream x) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATEASCIISTREAM)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -2352,7 +2352,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public void updateCharacterStream(int columnIndex, @Nullable Reader x) throws SQLException {
+  public void updateCharacterStream(int columnIndex, Reader x) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATECHARACTERSTREAM)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,

--- a/wrapper/src/main/java/software/amazon/jdbc/wrapper/ResultSetWrapper.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/wrapper/ResultSetWrapper.java
@@ -39,6 +39,7 @@ import java.sql.Timestamp;
 import java.util.Calendar;
 import java.util.Map;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import software.amazon.jdbc.ConnectionPluginManager;
 import software.amazon.jdbc.JdbcMethod;
 import software.amazon.jdbc.util.WrapperUtils;
@@ -199,7 +200,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public Array getArray(int columnIndex) throws SQLException {
+  public @Nullable Array getArray(int columnIndex) throws SQLException {
     return WrapperUtils.executeWithPlugins(
         Array.class,
         SQLException.class,
@@ -212,7 +213,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public Array getArray(String columnLabel) throws SQLException {
+  public @Nullable Array getArray(String columnLabel) throws SQLException {
     return WrapperUtils.executeWithPlugins(
         Array.class,
         SQLException.class,
@@ -225,7 +226,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public InputStream getAsciiStream(int columnIndex) throws SQLException {
+  public @Nullable InputStream getAsciiStream(int columnIndex) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_GETASCIISTREAM)) {
       return WrapperUtils.executeWithPlugins(
           InputStream.class,
@@ -242,7 +243,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public InputStream getAsciiStream(String columnLabel) throws SQLException {
+  public @Nullable InputStream getAsciiStream(String columnLabel) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_GETASCIISTREAM)) {
       return WrapperUtils.executeWithPlugins(
           InputStream.class,
@@ -261,7 +262,7 @@ public class ResultSetWrapper implements ResultSet {
   @Override
   @Deprecated
   @SuppressWarnings("deprecation")
-  public BigDecimal getBigDecimal(int columnIndex, int scale) throws SQLException {
+  public @Nullable BigDecimal getBigDecimal(int columnIndex, int scale) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_GETBIGDECIMAL)) {
       return WrapperUtils.executeWithPlugins(
           BigDecimal.class,
@@ -299,7 +300,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public BigDecimal getBigDecimal(int columnIndex) throws SQLException {
+  public @Nullable BigDecimal getBigDecimal(int columnIndex) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_GETBIGDECIMAL)) {
       return WrapperUtils.executeWithPlugins(
           BigDecimal.class,
@@ -316,7 +317,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public BigDecimal getBigDecimal(String columnLabel) throws SQLException {
+  public @Nullable BigDecimal getBigDecimal(String columnLabel) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_GETBIGDECIMAL)) {
       return WrapperUtils.executeWithPlugins(
           BigDecimal.class,
@@ -333,7 +334,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public InputStream getBinaryStream(int columnIndex) throws SQLException {
+  public @Nullable InputStream getBinaryStream(int columnIndex) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_GETBINARYSTREAM)) {
       return WrapperUtils.executeWithPlugins(
           InputStream.class,
@@ -380,7 +381,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public Blob getBlob(String columnLabel) throws SQLException {
+  public @Nullable Blob getBlob(String columnLabel) throws SQLException {
     return WrapperUtils.executeWithPlugins(
         Blob.class,
         SQLException.class,
@@ -461,7 +462,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public byte[] getBytes(int columnIndex) throws SQLException {
+  public byte @Nullable [] getBytes(int columnIndex) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_GETBYTES)) {
       return WrapperUtils.executeWithPlugins(
           byte[].class,
@@ -478,7 +479,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public byte[] getBytes(String columnLabel) throws SQLException {
+  public byte @Nullable [] getBytes(String columnLabel) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_GETBYTES)) {
       return WrapperUtils.executeWithPlugins(
           byte[].class,
@@ -495,7 +496,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public Reader getCharacterStream(int columnIndex) throws SQLException {
+  public @Nullable Reader getCharacterStream(int columnIndex) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_GETCHARACTERSTREAM)) {
       return WrapperUtils.executeWithPlugins(
           Reader.class,
@@ -512,7 +513,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public Reader getCharacterStream(String columnLabel) throws SQLException {
+  public @Nullable Reader getCharacterStream(String columnLabel) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_GETCHARACTERSTREAM)) {
       return WrapperUtils.executeWithPlugins(
           Reader.class,
@@ -529,7 +530,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public Clob getClob(int columnIndex) throws SQLException {
+  public @Nullable Clob getClob(int columnIndex) throws SQLException {
     return WrapperUtils.executeWithPlugins(
         Clob.class,
         SQLException.class,
@@ -542,7 +543,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public Clob getClob(String columnLabel) throws SQLException {
+  public @Nullable Clob getClob(String columnLabel) throws SQLException {
     return WrapperUtils.executeWithPlugins(
         Clob.class,
         SQLException.class,
@@ -588,7 +589,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public Date getDate(int columnIndex) throws SQLException {
+  public @Nullable Date getDate(int columnIndex) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_GETDATE)) {
       return WrapperUtils.executeWithPlugins(
           Date.class,
@@ -605,7 +606,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public Date getDate(String columnLabel) throws SQLException {
+  public @Nullable Date getDate(String columnLabel) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_GETDATE)) {
       return WrapperUtils.executeWithPlugins(
           Date.class,
@@ -622,7 +623,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public Date getDate(int columnIndex, Calendar cal) throws SQLException {
+  public @Nullable Date getDate(int columnIndex, @Nullable Calendar cal) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_GETDATE)) {
       return WrapperUtils.executeWithPlugins(
           Date.class,
@@ -640,7 +641,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public Date getDate(String columnLabel, Calendar cal) throws SQLException {
+  public @Nullable Date getDate(String columnLabel, @Nullable Calendar cal) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_GETDATE)) {
       return WrapperUtils.executeWithPlugins(
           Date.class,
@@ -856,7 +857,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public Reader getNCharacterStream(int columnIndex) throws SQLException {
+  public @Nullable Reader getNCharacterStream(int columnIndex) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_GETNCHARACTERSTREAM)) {
       return WrapperUtils.executeWithPlugins(
           Reader.class,
@@ -873,7 +874,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public Reader getNCharacterStream(String columnLabel) throws SQLException {
+  public @Nullable Reader getNCharacterStream(String columnLabel) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_GETNCHARACTERSTREAM)) {
       return WrapperUtils.executeWithPlugins(
           Reader.class,
@@ -890,7 +891,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public NClob getNClob(int columnIndex) throws SQLException {
+  public @Nullable NClob getNClob(int columnIndex) throws SQLException {
     return WrapperUtils.executeWithPlugins(
         NClob.class,
         SQLException.class,
@@ -903,7 +904,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public NClob getNClob(String columnLabel) throws SQLException {
+  public @Nullable NClob getNClob(String columnLabel) throws SQLException {
     return WrapperUtils.executeWithPlugins(
         NClob.class,
         SQLException.class,
@@ -916,7 +917,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public String getNString(int columnIndex) throws SQLException {
+  public @Nullable String getNString(int columnIndex) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_GETNSTRING)) {
       return WrapperUtils.executeWithPlugins(
           String.class,
@@ -933,7 +934,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public String getNString(String columnLabel) throws SQLException {
+  public @Nullable String getNString(String columnLabel) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_GETNSTRING)) {
       return WrapperUtils.executeWithPlugins(
           String.class,
@@ -950,7 +951,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public Object getObject(int columnIndex) throws SQLException {
+  public @Nullable Object getObject(int columnIndex) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_GETOBJECT)) {
       return WrapperUtils.executeWithPlugins(
           Object.class,
@@ -967,7 +968,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public Object getObject(String columnLabel) throws SQLException {
+  public @Nullable Object getObject(String columnLabel) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_GETOBJECT)) {
       return WrapperUtils.executeWithPlugins(
           Object.class,
@@ -984,7 +985,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public Object getObject(int columnIndex, Map<String, Class<?>> map) throws SQLException {
+  public @Nullable Object getObject(int columnIndex, Map<String, Class<?>> map) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_GETOBJECT)) {
       return WrapperUtils.executeWithPlugins(
           Object.class,
@@ -1002,7 +1003,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public Object getObject(String columnLabel, Map<String, Class<?>> map) throws SQLException {
+  public @Nullable Object getObject(String columnLabel, Map<String, Class<?>> map) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_GETOBJECT)) {
       return WrapperUtils.executeWithPlugins(
           Object.class,
@@ -1020,9 +1021,9 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public <T> T getObject(int columnIndex, Class<T> type) throws SQLException {
+  public <T> @Nullable T getObject(int columnIndex, Class<T> type) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_GETOBJECT)) {
-      return WrapperUtils.executeWithPlugins(
+      return WrapperUtils.<@Nullable T, SQLException>executeWithPlugins(
           type,
           SQLException.class,
           this.connectionWrapper,
@@ -1038,9 +1039,9 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public <T> T getObject(String columnLabel, Class<T> type) throws SQLException {
+  public <T> @Nullable T getObject(String columnLabel, Class<T> type) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_GETOBJECT)) {
-      return WrapperUtils.executeWithPlugins(
+      return WrapperUtils.<@Nullable T, SQLException>executeWithPlugins(
           type,
           SQLException.class,
           this.connectionWrapper,
@@ -1056,7 +1057,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public Ref getRef(int columnIndex) throws SQLException {
+  public @Nullable Ref getRef(int columnIndex) throws SQLException {
     return WrapperUtils.executeWithPlugins(
         Ref.class,
         SQLException.class,
@@ -1069,7 +1070,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public Ref getRef(String columnLabel) throws SQLException {
+  public @Nullable Ref getRef(String columnLabel) throws SQLException {
     return WrapperUtils.executeWithPlugins(
         Ref.class,
         SQLException.class,
@@ -1098,7 +1099,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public RowId getRowId(int columnIndex) throws SQLException {
+  public @Nullable RowId getRowId(int columnIndex) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_GETROWID)) {
       return WrapperUtils.executeWithPlugins(
           RowId.class,
@@ -1115,7 +1116,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public RowId getRowId(String columnLabel) throws SQLException {
+  public @Nullable RowId getRowId(String columnLabel) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_GETROWID)) {
       return WrapperUtils.executeWithPlugins(
           RowId.class,
@@ -1132,7 +1133,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public SQLXML getSQLXML(int columnIndex) throws SQLException {
+  public @Nullable SQLXML getSQLXML(int columnIndex) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_GETSQLXML)) {
       return WrapperUtils.executeWithPlugins(
           SQLXML.class,
@@ -1149,7 +1150,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public SQLXML getSQLXML(String columnLabel) throws SQLException {
+  public @Nullable SQLXML getSQLXML(String columnLabel) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_GETSQLXML)) {
       return WrapperUtils.executeWithPlugins(
           SQLXML.class,
@@ -1200,7 +1201,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public Statement getStatement() throws SQLException {
+  public @Nullable Statement getStatement() throws SQLException {
     return WrapperUtils.executeWithPlugins(
         Statement.class,
         SQLException.class,
@@ -1212,7 +1213,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public String getString(int columnIndex) throws SQLException {
+  public @Nullable String getString(int columnIndex) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_GETSTRING)) {
       return WrapperUtils.executeWithPlugins(
           String.class,
@@ -1229,7 +1230,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public String getString(String columnLabel) throws SQLException {
+  public @Nullable String getString(String columnLabel) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_GETSTRING)) {
       return WrapperUtils.executeWithPlugins(
           String.class,
@@ -1246,7 +1247,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public Time getTime(int columnIndex) throws SQLException {
+  public @Nullable Time getTime(int columnIndex) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_GETTIME)) {
       return WrapperUtils.executeWithPlugins(
           Time.class,
@@ -1263,7 +1264,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public Time getTime(String columnLabel) throws SQLException {
+  public @Nullable Time getTime(String columnLabel) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_GETTIME)) {
       return WrapperUtils.executeWithPlugins(
           Time.class,
@@ -1280,7 +1281,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public Time getTime(int columnIndex, Calendar cal) throws SQLException {
+  public @Nullable Time getTime(int columnIndex, @Nullable Calendar cal) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_GETTIME)) {
       return WrapperUtils.executeWithPlugins(
           Time.class,
@@ -1298,7 +1299,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public Time getTime(String columnLabel, Calendar cal) throws SQLException {
+  public @Nullable Time getTime(String columnLabel, @Nullable Calendar cal) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_GETTIME)) {
       return WrapperUtils.executeWithPlugins(
           Time.class,
@@ -1316,7 +1317,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public Timestamp getTimestamp(int columnIndex) throws SQLException {
+  public @Nullable Timestamp getTimestamp(int columnIndex) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_GETTIMESTAMP)) {
       return WrapperUtils.executeWithPlugins(
           Timestamp.class,
@@ -1333,7 +1334,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public Timestamp getTimestamp(String columnLabel) throws SQLException {
+  public @Nullable Timestamp getTimestamp(String columnLabel) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_GETTIMESTAMP)) {
       return WrapperUtils.executeWithPlugins(
           Timestamp.class,
@@ -1350,7 +1351,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public Timestamp getTimestamp(int columnIndex, Calendar cal) throws SQLException {
+  public @Nullable Timestamp getTimestamp(int columnIndex, @Nullable Calendar cal) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_GETTIMESTAMP)) {
       return WrapperUtils.executeWithPlugins(
           Timestamp.class,
@@ -1368,7 +1369,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public Timestamp getTimestamp(String columnLabel, Calendar cal) throws SQLException {
+  public @Nullable Timestamp getTimestamp(String columnLabel, @Nullable Calendar cal) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_GETTIMESTAMP)) {
       return WrapperUtils.executeWithPlugins(
           Timestamp.class,
@@ -1403,7 +1404,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public URL getURL(int columnIndex) throws SQLException {
+  public @Nullable URL getURL(int columnIndex) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_GETURL)) {
       return WrapperUtils.executeWithPlugins(
           URL.class,
@@ -1420,7 +1421,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public URL getURL(String columnLabel) throws SQLException {
+  public @Nullable URL getURL(String columnLabel) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_GETURL)) {
       return WrapperUtils.executeWithPlugins(
           URL.class,
@@ -1439,7 +1440,7 @@ public class ResultSetWrapper implements ResultSet {
   @Override
   @Deprecated
   @SuppressWarnings("deprecation")
-  public InputStream getUnicodeStream(int columnIndex) throws SQLException {
+  public @Nullable InputStream getUnicodeStream(int columnIndex) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_GETUNICODESTREAM)) {
       return WrapperUtils.executeWithPlugins(
           InputStream.class,
@@ -1458,7 +1459,7 @@ public class ResultSetWrapper implements ResultSet {
   @Override
   @Deprecated
   @SuppressWarnings("deprecation")
-  public InputStream getUnicodeStream(String columnLabel) throws SQLException {
+  public @Nullable InputStream getUnicodeStream(String columnLabel) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_GETUNICODESTREAM)) {
       return WrapperUtils.executeWithPlugins(
           InputStream.class,
@@ -1475,7 +1476,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public SQLWarning getWarnings() throws SQLException {
+  public @Nullable SQLWarning getWarnings() throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_GETWARNINGS)) {
       return WrapperUtils.executeWithPlugins(
           SQLWarning.class,
@@ -1786,7 +1787,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public void updateArray(int columnIndex, Array x) throws SQLException {
+  public void updateArray(int columnIndex, @Nullable Array x) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATEARRAY)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -1803,7 +1804,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public void updateArray(String columnLabel, Array x) throws SQLException {
+  public void updateArray(String columnLabel, @Nullable Array x) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATEARRAY)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -1820,7 +1821,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public void updateAsciiStream(int columnIndex, InputStream x, int length) throws SQLException {
+  public void updateAsciiStream(int columnIndex, @Nullable InputStream x, int length) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATEASCIISTREAM)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -1838,7 +1839,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public void updateAsciiStream(String columnLabel, InputStream x, int length) throws SQLException {
+  public void updateAsciiStream(String columnLabel, @Nullable InputStream x, int length) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATEASCIISTREAM)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -1856,7 +1857,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public void updateAsciiStream(int columnIndex, InputStream x, long length) throws SQLException {
+  public void updateAsciiStream(int columnIndex, @Nullable InputStream x, long length) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATEASCIISTREAM)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -1874,7 +1875,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public void updateAsciiStream(String columnLabel, InputStream x, long length)
+  public void updateAsciiStream(String columnLabel, @Nullable InputStream x, long length)
       throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATEASCIISTREAM)) {
       WrapperUtils.runWithPlugins(
@@ -1893,7 +1894,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public void updateAsciiStream(int columnIndex, InputStream x) throws SQLException {
+  public void updateAsciiStream(int columnIndex, @Nullable InputStream x) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATEASCIISTREAM)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -1910,7 +1911,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public void updateAsciiStream(String columnLabel, InputStream x) throws SQLException {
+  public void updateAsciiStream(String columnLabel, @Nullable InputStream x) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATEASCIISTREAM)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -1927,7 +1928,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public void updateBigDecimal(int columnIndex, BigDecimal x) throws SQLException {
+  public void updateBigDecimal(int columnIndex, @Nullable BigDecimal x) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATEBIGDECIMAL)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -1944,7 +1945,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public void updateBigDecimal(String columnLabel, BigDecimal x) throws SQLException {
+  public void updateBigDecimal(String columnLabel, @Nullable BigDecimal x) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATEBIGDECIMAL)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -1961,7 +1962,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public void updateBinaryStream(int columnIndex, InputStream x, int length) throws SQLException {
+  public void updateBinaryStream(int columnIndex, @Nullable InputStream x, int length) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATEBINARYSTREAM)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -1979,7 +1980,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public void updateBinaryStream(String columnLabel, InputStream x, int length)
+  public void updateBinaryStream(String columnLabel, @Nullable InputStream x, int length)
       throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATEBINARYSTREAM)) {
       WrapperUtils.runWithPlugins(
@@ -1998,7 +1999,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public void updateBinaryStream(int columnIndex, InputStream x, long length) throws SQLException {
+  public void updateBinaryStream(int columnIndex, @Nullable InputStream x, long length) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATEBINARYSTREAM)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -2016,7 +2017,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public void updateBinaryStream(String columnLabel, InputStream x, long length)
+  public void updateBinaryStream(String columnLabel, @Nullable InputStream x, long length)
       throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATEBINARYSTREAM)) {
       WrapperUtils.runWithPlugins(
@@ -2035,7 +2036,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public void updateBinaryStream(int columnIndex, InputStream x) throws SQLException {
+  public void updateBinaryStream(int columnIndex, @Nullable InputStream x) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATEBINARYSTREAM)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -2052,7 +2053,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public void updateBinaryStream(String columnLabel, InputStream x) throws SQLException {
+  public void updateBinaryStream(String columnLabel, @Nullable InputStream x) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATEBINARYSTREAM)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -2069,7 +2070,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public void updateBlob(int columnIndex, Blob x) throws SQLException {
+  public void updateBlob(int columnIndex, @Nullable Blob x) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATEBLOB)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -2086,7 +2087,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public void updateBlob(String columnLabel, Blob x) throws SQLException {
+  public void updateBlob(String columnLabel, @Nullable Blob x) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATEBLOB)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -2103,7 +2104,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public void updateBlob(int columnIndex, InputStream inputStream, long length)
+  public void updateBlob(int columnIndex, @Nullable InputStream inputStream, long length)
       throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATEBLOB)) {
       WrapperUtils.runWithPlugins(
@@ -2122,7 +2123,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public void updateBlob(String columnLabel, InputStream inputStream, long length)
+  public void updateBlob(String columnLabel, @Nullable InputStream inputStream, long length)
       throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATEBLOB)) {
       WrapperUtils.runWithPlugins(
@@ -2141,7 +2142,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public void updateBlob(int columnIndex, InputStream inputStream) throws SQLException {
+  public void updateBlob(int columnIndex, @Nullable InputStream inputStream) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATEBLOB)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -2158,7 +2159,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public void updateBlob(String columnLabel, InputStream inputStream) throws SQLException {
+  public void updateBlob(String columnLabel, @Nullable InputStream inputStream) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATEBLOB)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -2243,7 +2244,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public void updateBytes(int columnIndex, byte[] x) throws SQLException {
+  public void updateBytes(int columnIndex, byte @Nullable [] x) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATEBYTES)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -2260,7 +2261,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public void updateBytes(String columnLabel, byte[] x) throws SQLException {
+  public void updateBytes(String columnLabel, byte @Nullable [] x) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATEBYTES)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -2277,7 +2278,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public void updateCharacterStream(int columnIndex, Reader x, int length) throws SQLException {
+  public void updateCharacterStream(int columnIndex, @Nullable Reader x, int length) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATECHARACTERSTREAM)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -2295,7 +2296,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public void updateCharacterStream(String columnLabel, Reader reader, int length)
+  public void updateCharacterStream(String columnLabel, @Nullable Reader reader, int length)
       throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATECHARACTERSTREAM)) {
       WrapperUtils.runWithPlugins(
@@ -2314,7 +2315,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public void updateCharacterStream(int columnIndex, Reader x, long length) throws SQLException {
+  public void updateCharacterStream(int columnIndex, @Nullable Reader x, long length) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATECHARACTERSTREAM)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -2332,7 +2333,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public void updateCharacterStream(String columnLabel, Reader reader, long length)
+  public void updateCharacterStream(String columnLabel, @Nullable Reader reader, long length)
       throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATECHARACTERSTREAM)) {
       WrapperUtils.runWithPlugins(
@@ -2351,7 +2352,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public void updateCharacterStream(int columnIndex, Reader x) throws SQLException {
+  public void updateCharacterStream(int columnIndex, @Nullable Reader x) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATECHARACTERSTREAM)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -2368,7 +2369,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public void updateCharacterStream(String columnLabel, Reader reader) throws SQLException {
+  public void updateCharacterStream(String columnLabel, @Nullable Reader reader) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATECHARACTERSTREAM)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -2385,7 +2386,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public void updateClob(int columnIndex, Clob x) throws SQLException {
+  public void updateClob(int columnIndex, @Nullable Clob x) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATECLOB)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -2402,7 +2403,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public void updateClob(String columnLabel, Clob x) throws SQLException {
+  public void updateClob(String columnLabel, @Nullable Clob x) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATECLOB)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -2419,7 +2420,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public void updateClob(int columnIndex, Reader reader, long length) throws SQLException {
+  public void updateClob(int columnIndex, @Nullable Reader reader, long length) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATECLOB)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -2437,7 +2438,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public void updateClob(String columnLabel, Reader reader, long length) throws SQLException {
+  public void updateClob(String columnLabel, @Nullable Reader reader, long length) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATECLOB)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -2455,7 +2456,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public void updateClob(int columnIndex, Reader reader) throws SQLException {
+  public void updateClob(int columnIndex, @Nullable Reader reader) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATECLOB)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -2472,7 +2473,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public void updateClob(String columnLabel, Reader reader) throws SQLException {
+  public void updateClob(String columnLabel, @Nullable Reader reader) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATECLOB)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -2489,7 +2490,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public void updateDate(int columnIndex, Date x) throws SQLException {
+  public void updateDate(int columnIndex, @Nullable Date x) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATEDATE)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -2506,7 +2507,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public void updateDate(String columnLabel, Date x) throws SQLException {
+  public void updateDate(String columnLabel, @Nullable Date x) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATEDATE)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -2659,7 +2660,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public void updateNCharacterStream(int columnIndex, Reader x, long length) throws SQLException {
+  public void updateNCharacterStream(int columnIndex, @Nullable Reader x, long length) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATENCHARACTERSTREAM)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -2677,7 +2678,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public void updateNCharacterStream(String columnLabel, Reader reader, long length)
+  public void updateNCharacterStream(String columnLabel, @Nullable Reader reader, long length)
       throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATENCHARACTERSTREAM)) {
       WrapperUtils.runWithPlugins(
@@ -2696,7 +2697,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public void updateNCharacterStream(int columnIndex, Reader x) throws SQLException {
+  public void updateNCharacterStream(int columnIndex, @Nullable Reader x) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATENCHARACTERSTREAM)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -2713,7 +2714,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public void updateNCharacterStream(String columnLabel, Reader reader) throws SQLException {
+  public void updateNCharacterStream(String columnLabel, @Nullable Reader reader) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATENCHARACTERSTREAM)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -2731,7 +2732,7 @@ public class ResultSetWrapper implements ResultSet {
 
   @SuppressWarnings("checkstyle:ParameterName")
   @Override
-  public void updateNClob(int columnIndex, NClob nClob) throws SQLException {
+  public void updateNClob(int columnIndex, @Nullable NClob nClob) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATENCLOB)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -2749,7 +2750,7 @@ public class ResultSetWrapper implements ResultSet {
 
   @SuppressWarnings("checkstyle:ParameterName")
   @Override
-  public void updateNClob(String columnLabel, NClob nClob) throws SQLException {
+  public void updateNClob(String columnLabel, @Nullable NClob nClob) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATENCLOB)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -2766,7 +2767,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public void updateNClob(int columnIndex, Reader reader, long length) throws SQLException {
+  public void updateNClob(int columnIndex, @Nullable Reader reader, long length) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATENCLOB)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -2784,7 +2785,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public void updateNClob(String columnLabel, Reader reader, long length) throws SQLException {
+  public void updateNClob(String columnLabel, @Nullable Reader reader, long length) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATENCLOB)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -2802,7 +2803,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public void updateNClob(int columnIndex, Reader reader) throws SQLException {
+  public void updateNClob(int columnIndex, @Nullable Reader reader) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATENCLOB)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -2819,7 +2820,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public void updateNClob(String columnLabel, Reader reader) throws SQLException {
+  public void updateNClob(String columnLabel, @Nullable Reader reader) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATENCLOB)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -2837,7 +2838,7 @@ public class ResultSetWrapper implements ResultSet {
 
   @SuppressWarnings("checkstyle:ParameterName")
   @Override
-  public void updateNString(int columnIndex, String nString) throws SQLException {
+  public void updateNString(int columnIndex, @Nullable String nString) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATENSTRING)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -2855,7 +2856,7 @@ public class ResultSetWrapper implements ResultSet {
 
   @SuppressWarnings("checkstyle:ParameterName")
   @Override
-  public void updateNString(String columnLabel, String nString) throws SQLException {
+  public void updateNString(String columnLabel, @Nullable String nString) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATENSTRING)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -2904,7 +2905,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public void updateObject(int columnIndex, Object x, int scaleOrLength) throws SQLException {
+  public void updateObject(int columnIndex, @Nullable Object x, int scaleOrLength) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATEOBJECT)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -2922,7 +2923,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public void updateObject(int columnIndex, Object x) throws SQLException {
+  public void updateObject(int columnIndex, @Nullable Object x) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATEOBJECT)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -2939,7 +2940,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public void updateObject(String columnLabel, Object x, int scaleOrLength) throws SQLException {
+  public void updateObject(String columnLabel, @Nullable Object x, int scaleOrLength) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATEOBJECT)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -2957,7 +2958,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public void updateObject(String columnLabel, Object x) throws SQLException {
+  public void updateObject(String columnLabel, @Nullable Object x) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATEOBJECT)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -2974,7 +2975,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public void updateObject(int columnIndex, Object x, SQLType targetSqlType, int scaleOrLength)
+  public void updateObject(int columnIndex, @Nullable Object x, SQLType targetSqlType, int scaleOrLength)
       throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATEOBJECT)) {
       WrapperUtils.runWithPlugins(
@@ -2994,7 +2995,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public void updateObject(String columnLabel, Object x, SQLType targetSqlType, int scaleOrLength)
+  public void updateObject(String columnLabel, @Nullable Object x, SQLType targetSqlType, int scaleOrLength)
       throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATEOBJECT)) {
       WrapperUtils.runWithPlugins(
@@ -3014,7 +3015,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public void updateObject(int columnIndex, Object x, SQLType targetSqlType) throws SQLException {
+  public void updateObject(int columnIndex, @Nullable Object x, SQLType targetSqlType) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATEOBJECT)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -3032,7 +3033,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public void updateObject(String columnLabel, Object x, SQLType targetSqlType)
+  public void updateObject(String columnLabel, @Nullable Object x, SQLType targetSqlType)
       throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATEOBJECT)) {
       WrapperUtils.runWithPlugins(
@@ -3051,7 +3052,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public void updateRef(int columnIndex, Ref x) throws SQLException {
+  public void updateRef(int columnIndex, @Nullable Ref x) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATEREF)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -3068,7 +3069,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public void updateRef(String columnLabel, Ref x) throws SQLException {
+  public void updateRef(String columnLabel, @Nullable Ref x) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATEREF)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -3100,7 +3101,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public void updateRowId(int columnIndex, RowId x) throws SQLException {
+  public void updateRowId(int columnIndex, @Nullable RowId x) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATEROWID)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -3117,7 +3118,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public void updateRowId(String columnLabel, RowId x) throws SQLException {
+  public void updateRowId(String columnLabel, @Nullable RowId x) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATEROWID)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -3134,7 +3135,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public void updateSQLXML(int columnIndex, SQLXML xmlObject) throws SQLException {
+  public void updateSQLXML(int columnIndex, @Nullable SQLXML xmlObject) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATESQLXML)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -3151,7 +3152,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public void updateSQLXML(String columnLabel, SQLXML xmlObject) throws SQLException {
+  public void updateSQLXML(String columnLabel, @Nullable SQLXML xmlObject) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATESQLXML)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -3202,7 +3203,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public void updateString(int columnIndex, String x) throws SQLException {
+  public void updateString(int columnIndex, @Nullable String x) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATESTRING)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -3219,7 +3220,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public void updateString(String columnLabel, String x) throws SQLException {
+  public void updateString(String columnLabel, @Nullable String x) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATESTRING)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -3236,7 +3237,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public void updateTime(int columnIndex, Time x) throws SQLException {
+  public void updateTime(int columnIndex, @Nullable Time x) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATETIME)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -3253,7 +3254,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public void updateTime(String columnLabel, Time x) throws SQLException {
+  public void updateTime(String columnLabel, @Nullable Time x) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATETIME)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -3270,7 +3271,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public void updateTimestamp(int columnIndex, Timestamp x) throws SQLException {
+  public void updateTimestamp(int columnIndex, @Nullable Timestamp x) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATETIMESTAMP)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,
@@ -3287,7 +3288,7 @@ public class ResultSetWrapper implements ResultSet {
   }
 
   @Override
-  public void updateTimestamp(String columnLabel, Timestamp x) throws SQLException {
+  public void updateTimestamp(String columnLabel, @Nullable Timestamp x) throws SQLException {
     if (this.pluginManager.mustUsePipeline(JdbcMethod.RESULTSET_UPDATETIMESTAMP)) {
       WrapperUtils.runWithPlugins(
           SQLException.class,


### PR DESCRIPTION
## Summary

Parts 6 & 7 of the incremental Checker Framework (NullnessChecker) adoption, continuing the warn-only, scope-by-scope approach from #1981, #1998 and #1999. With this PR the **entire `software.amazon.jdbc.wrapper` package is in scope** (plus `LazyCleanerImpl`), alongside the core connection/plugin path and util classes from the earlier parts.

Verified in the JDK17 container: **0 real / 0 style / 0 checker crashes**, full wrapper unit suite **1152 passed, 0 failed**. All changes are annotation-only (erased at runtime), so no behavior change is intended.

## Part 6 — LazyCleanerImpl + the already-clean wrapper classes

- Raised javac's default 100-warning cap (`-Xmaxwarns`) so the true finding count is visible (the prior cap was masking it).
- Brought `LazyCleanerImpl` and every already-null-clean wrapper class (factories, `StatementWrapper`, and the small/medium wrappers) into scope. Only `LazyCleanerImpl` needed fixes: `RefQueueBlocker.ref`/`drainOne` are genuinely `@Nullable`, and `queue` widened to `ReferenceQueue<@Nullable Object>` so the `PhantomReference(T, ReferenceQueue<? super T>)` constructor is satisfied.

## Part 7 — the four large JDBC wrapper classes

`PreparedStatementWrapper`, `DatabaseMetaDataWrapper`, `CallableStatementWrapper`, `ResultSetWrapper` (≈547 findings total). Two recurring patterns:

- **`@Nullable` getters** — JDBC getters that return `null` for a SQL NULL column (`getString`, `getObject`, `getDate`, `getURL`, `getWarnings`, …). Annotating the method return `@Nullable` resolves both the `return` and `type.arguments.not.inferred` findings via return-target inference; only the generic `getObject(…, Class<T>)` overloads need an explicit `WrapperUtils.<@Nullable T, SQLException>` type witness.
- **`@Nullable` setter/updater params** — `setX`/`updateX`/`registerOutParameter` value params and `Calendar cal` args, annotated exactly as the JDK stubs mark them (e.g. exact-name `table` params and the int-index `setRowId`/`setSQLXML` stay `@NonNull`).

Supporting central change: `jdbcMethodArgs` varargs are now `@Nullable Object...` across `WrapperUtils.runWithPlugins`/`executeWithPlugins`, `ConnectionPluginManager.execute`, and the `ConnectionPlugin.execute` interface, since setters legitimately pass `null` values. More-permissive params don't affect existing non-null callers, and out-of-scope plugin implementations aren't checked.
