### PR TITLE
chore: adopt checker-framework (parts 11-13)

### DIFF
--- a/wrapper/build.gradle.kts
+++ b/wrapper/build.gradle.kts
@@ -322,7 +322,10 @@ if (project.hasProperty("enableCheckerFramework")) {
         // WrapperUtils (part 5: the generic plugin-execution / proxy-wrapping helpers),
         // (part 6) all of the per-object JDBC wrapper classes plus LazyCleanerImpl, and
         // (parts 8-10) the whole util package plus the exceptions, cleanup, authentication,
-        // hostavailability, osgi, profile, states and ds packages.
+        // hostavailability, osgi, profile, states and ds packages,
+        // (part 11) the targetdriverdialect and dialect packages,
+        // (part 12) the hostlistprovider package, and
+        // (part 13) the remaining top-level software.amazon.jdbc classes.
         // No end-anchor: matching an outer class also covers its nested classes (and, for
         // "pkg\.\w+", the classes of nested sub-packages such as util.telemetry.*).
         extraJavacArgs = listOf(
@@ -331,7 +334,10 @@ if (project.hasProperty("enableCheckerFramework")) {
                 + "|util\\.\\w+"
                 + "|exceptions\\.\\w+|cleanup\\.\\w+|authentication\\.\\w+"
                 + "|hostavailability\\.\\w+|osgi\\.\\w+|profile\\.\\w+"
-                + "|states\\.\\w+|ds\\.\\w+)",
+                + "|states\\.\\w+|ds\\.\\w+"
+                + "|targetdriverdialect\\.\\w+|dialect\\.\\w+"
+                + "|hostlistprovider\\.\\w+"
+                + "|[A-Z]\\w*)",
             // Warning mode: report issues but do not fail the build.
             "-Awarns",
             // Keep the output focused and avoid drowning in framework boilerplate.

--- a/wrapper/src/main/java/software/amazon/jdbc/AllowedAndBlockedHosts.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/AllowedAndBlockedHosts.java
@@ -25,9 +25,9 @@ import software.amazon.jdbc.util.Utils;
  * Represents the allowed and blocked hosts for connections.
  */
 public class AllowedAndBlockedHosts {
-  @Nullable private final Set<String> allowedHostIds;
-  @Nullable private final Set<String> blockedHostIds;
-  @Nullable private final HostRole requiredRole;
+  private final @Nullable Set<String> allowedHostIds;
+  private final @Nullable Set<String> blockedHostIds;
+  private final @Nullable HostRole requiredRole;
 
   /**
    * Constructs an AllowedAndBlockedHosts instance with the specified allowed and blocked host IDs.
@@ -55,8 +55,7 @@ public class AllowedAndBlockedHosts {
    *
    * @return the set of allowed host IDs for connections.
    */
-  @Nullable
-  public Set<String> getAllowedHostIds() {
+  public @Nullable Set<String> getAllowedHostIds() {
     return this.allowedHostIds;
   }
 
@@ -66,8 +65,7 @@ public class AllowedAndBlockedHosts {
    *
    * @return the set of blocked host IDs for connections.
    */
-  @Nullable
-  public Set<String> getBlockedHostIds() {
+  public @Nullable Set<String> getBlockedHostIds() {
     return this.blockedHostIds;
   }
 
@@ -78,8 +76,7 @@ public class AllowedAndBlockedHosts {
    *
    * @return the required role of instances in the custom endpoint, or null if there is no strict role requirement.
    */
-  @Nullable
-  public HostRole getRequiredRole() {
+  public @Nullable HostRole getRequiredRole() {
     return this.requiredRole;
   }
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/AtomicConnection.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/AtomicConnection.java
@@ -32,10 +32,10 @@ public class AtomicConnection {
 
   private static final Logger LOGGER = Logger.getLogger(AtomicConnection.class.getName());
 
-  protected final AtomicReference<Connection> atomicReference = new AtomicReference<>();
+  protected final AtomicReference<@Nullable Connection> atomicReference = new AtomicReference<>();
   protected boolean logUnclosedConnections = false;
   protected LazyCleaner.Cleanable cleanable;
-  protected ConnectionCleanupAction cleanupAction;
+  protected @Nullable ConnectionCleanupAction cleanupAction;
 
   public AtomicConnection(final @NonNull Object referent) {
     this(referent, false);
@@ -57,7 +57,7 @@ public class AtomicConnection {
     }
   }
 
-  public Connection get() {
+  public @Nullable Connection get() {
     return this.atomicReference.get();
   }
 
@@ -74,7 +74,9 @@ public class AtomicConnection {
       final @Nullable Throwable openConnectionStacktrace,
       final boolean closePreviousConnection) {
 
-    if (this.cleanupAction == null) {
+    // Capture the field into a local so its non-null narrowing survives the getAndSet() call below.
+    final ConnectionCleanupAction action = this.cleanupAction;
+    if (action == null) {
       if (connection == null) {
         // Everything is already cleaned up
         return;
@@ -82,19 +84,19 @@ public class AtomicConnection {
       throw new IllegalStateException(Messages.get("AtomicConnection.alreadyClean"));
     }
 
-    Connection prevConnection = null;
+    @Nullable Connection prevConnection = null;
     try {
       prevConnection = this.atomicReference.getAndSet(connection);
 
       if (this.logUnclosedConnections) {
-        this.cleanupAction.setOpenConnectionStacktrace(
+        action.setOpenConnectionStacktrace(
             connection == null
                 ? null
                 : (openConnectionStacktrace == null
                     ? new UnclosedConnectionException()
                     : new UnclosedConnectionException(openConnectionStacktrace)));
       } else {
-        this.cleanupAction.setOpenConnectionStacktrace(null);
+        action.setOpenConnectionStacktrace(null);
       }
     } finally {
       if (closePreviousConnection && prevConnection != null && prevConnection != connection) {
@@ -107,8 +109,8 @@ public class AtomicConnection {
     }
   }
 
-  public boolean compareAndSet(Connection expected, Connection updated) {
-    final Connection prevConnection = this.atomicReference.get();
+  public boolean compareAndSet(final @Nullable Connection expected, final @Nullable Connection updated) {
+    final @Nullable Connection prevConnection = this.atomicReference.get();
     boolean result = false;
     try {
       result = this.atomicReference.compareAndSet(expected, updated);
@@ -125,21 +127,21 @@ public class AtomicConnection {
   }
 
   public static class ConnectionCleanupAction implements LazyCleaner.CleaningAction {
-    private Throwable openConnectionStacktrace;
+    private @Nullable Throwable openConnectionStacktrace;
     private String threadName;
-    private AtomicReference<Connection> atomicReference;
+    private @Nullable AtomicReference<@Nullable Connection> atomicReference;
     protected boolean logUnclosedConnections = false;
     private volatile boolean cleaned = false;
 
     ConnectionCleanupAction(
-        final AtomicReference<Connection> atomicReference,
+        final AtomicReference<@Nullable Connection> atomicReference,
         boolean logUnclosedConnections) {
       this.atomicReference = atomicReference;
       this.logUnclosedConnections = logUnclosedConnections;
       this.threadName = Thread.currentThread().getName();
     }
 
-    public void setOpenConnectionStacktrace(Throwable openConnectionStacktrace) {
+    public void setOpenConnectionStacktrace(final @Nullable Throwable openConnectionStacktrace) {
       this.openConnectionStacktrace = openConnectionStacktrace;
       this.threadName = Thread.currentThread().getName();
     }
@@ -151,7 +153,10 @@ public class AtomicConnection {
       }
       this.cleaned = true;
 
-      final Connection prevConnection = this.atomicReference.getAndSet(null);
+      // atomicReference is only nulled at the end of onClean, and the 'cleaned' guard above
+      // prevents re-entry, so it is non-null here; the local guard is defensive.
+      final AtomicReference<@Nullable Connection> ref = this.atomicReference;
+      final @Nullable Connection prevConnection = ref == null ? null : ref.getAndSet(null);
 
       if (prevConnection == null) {
         this.atomicReference = null;

--- a/wrapper/src/main/java/software/amazon/jdbc/AwsWrapperProperty.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/AwsWrapperProperty.java
@@ -26,26 +26,29 @@ public class AwsWrapperProperty extends DriverPropertyInfo {
   public final @Nullable String defaultValue;
 
   public AwsWrapperProperty(
-      @NonNull final String name,
-      @Nullable final String defaultValue,
+      final @NonNull String name,
+      final @Nullable String defaultValue,
       final String description) {
     this(name, defaultValue, description, false);
   }
 
   public AwsWrapperProperty(
-      @NonNull final String name,
-      @Nullable final String defaultValue,
+      final @NonNull String name,
+      final @Nullable String defaultValue,
       final String description,
       final boolean required) {
     this(name, defaultValue, description, required, null);
   }
 
+  // DriverPropertyInfo's stub types the constructor 'value' parameter as @NonNull (a null initial
+  // value is valid here) and its 'choices' field as @NonNull (a null choices array is valid).
+  @SuppressWarnings({"argument", "assignment"})
   public AwsWrapperProperty(
-      @NonNull final String name,
-      @Nullable final String defaultValue,
+      final @NonNull String name,
+      final @Nullable String defaultValue,
       final String description,
       final boolean required,
-      @Nullable final String [] choices) {
+      final String @Nullable [] choices) {
     super(name, null);
     this.defaultValue = defaultValue;
     this.required = required;
@@ -70,7 +73,12 @@ public class AwsWrapperProperty extends DriverPropertyInfo {
     if (value instanceof Integer) {
       return (Integer) value;
     }
-    return Integer.parseInt(properties.getProperty(name, defaultValue));
+    final @Nullable String stringValue = properties.getProperty(name, defaultValue);
+    // Integer.parseInt throws NumberFormatException on null, matching prior behavior when the
+    // property is unset and has no default value.
+    @SuppressWarnings("argument")
+    final int result = Integer.parseInt(stringValue);
+    return result;
   }
 
   public long getLong(final Properties properties) {
@@ -78,10 +86,15 @@ public class AwsWrapperProperty extends DriverPropertyInfo {
     if (value instanceof Long) {
       return (Long) value;
     }
-    return Long.parseLong(properties.getProperty(name, defaultValue));
+    final @Nullable String stringValue = properties.getProperty(name, defaultValue);
+    // Long.parseLong throws NumberFormatException on null, matching prior behavior when the
+    // property is unset and has no default value.
+    @SuppressWarnings("argument")
+    final long result = Long.parseLong(stringValue);
+    return result;
   }
 
-  public void set(final Properties properties, @Nullable final String value) {
+  public void set(final Properties properties, final @Nullable String value) {
     if (value == null) {
       properties.remove(name);
     } else {
@@ -94,7 +107,11 @@ public class AwsWrapperProperty extends DriverPropertyInfo {
   }
 
   public DriverPropertyInfo toDriverPropertyInfo(final Properties properties) {
-    final DriverPropertyInfo propertyInfo = new DriverPropertyInfo(name, getString(properties));
+    final @Nullable String value = getString(properties);
+    // DriverPropertyInfo's stub types the constructor 'value' parameter as @NonNull, but a null
+    // value is valid (indicates the property is unset).
+    @SuppressWarnings("argument")
+    final DriverPropertyInfo propertyInfo = new DriverPropertyInfo(name, value);
     propertyInfo.required = required;
     propertyInfo.description = description;
     propertyInfo.choices = choices;

--- a/wrapper/src/main/java/software/amazon/jdbc/C3P0PooledConnectionProvider.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/C3P0PooledConnectionProvider.java
@@ -46,6 +46,9 @@ public class C3P0PooledConnectionProvider implements PooledConnectionProvider, C
 
   private static final String CONNECTION_POOL_PROPERTY_PREFIX = "cp-";
 
+  // A null shouldDisposeFunc is valid (SlidingExpirationCache stores it in a @Nullable field); only
+  // the constructor parameter is typed @NonNull, so the argument is suppressed here.
+  @SuppressWarnings("argument")
   protected static final SlidingExpirationCache<String, ComboPooledDataSource> databasePools =
       new SlidingExpirationCache<>(null, ComboPooledDataSource::close);
 
@@ -82,19 +85,23 @@ public class C3P0PooledConnectionProvider implements PooledConnectionProvider, C
   }
 
   @Override
-  public HostSpec getHostSpecByStrategy(
+  public @Nullable HostSpec getHostSpecByStrategy(
       @NonNull List<HostSpec> hosts, @Nullable HostRole role, @NonNull String strategy, @Nullable Properties props)
       throws SQLException, UnsupportedOperationException {
-    if (!acceptsStrategy(role, strategy)) {
+    final HostSelector hostSelector = acceptedStrategies.get(strategy);
+    if (hostSelector == null) {
       throw new UnsupportedOperationException(
           Messages.get(
               "ConnectionProvider.unsupportedHostSpecSelectorStrategy",
               new Object[] {strategy, C3P0PooledConnectionProvider.class}));
     }
 
-    return acceptedStrategies.get(strategy).getHost(hosts, role, props);
+    return hostSelector.getHost(hosts, role, props);
   }
 
+  // c3p0's setPassword accepts a null password (only the stub types it @NonNull); the
+  // unconditional call with a possibly-null value is preserved.
+  @SuppressWarnings("argument")
   @Override
   public @NonNull ConnectionInfo connect(@NonNull String protocol, @NonNull Dialect dialect,
       @NonNull TargetDriverDialect targetDriverDialect, @NonNull HostSpec hostSpec,
@@ -113,6 +120,9 @@ public class C3P0PooledConnectionProvider implements PooledConnectionProvider, C
     return new ConnectionInfo(ds.getConnection(), true);
   }
 
+  // Values come from stringPropertyNames(), so getProperty(p) is non-null; only the stub types
+  // Properties.put's value @NonNull.
+  @SuppressWarnings("argument")
   protected ComboPooledDataSource createDataSource(
       @NonNull String protocol,
       @NonNull HostSpec hostSpec,

--- a/wrapper/src/main/java/software/amazon/jdbc/ConnectionPluginChainBuilder.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/ConnectionPluginChainBuilder.java
@@ -25,7 +25,6 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -177,38 +176,35 @@ public class ConnectionPluginChainBuilder {
     List<ConnectionPlugin> plugins;
     List<ConnectionPluginFactory> pluginFactories;
 
-    if (configurationProfile != null && configurationProfile.getPluginFactories() != null) {
-      List<Class<? extends ConnectionPluginFactory>> pluginFactoryClasses = configurationProfile.getPluginFactories();
+    final List<Class<? extends ConnectionPluginFactory>> pluginFactoryClasses =
+        configurationProfile == null ? null : configurationProfile.getPluginFactories();
+    if (pluginFactoryClasses != null) {
       pluginFactories = new ArrayList<>(pluginFactoryClasses.size());
 
       for (final Class<? extends ConnectionPluginFactory> factoryClazz : pluginFactoryClasses) {
-        final AtomicReference<InstantiationException> lastException = new AtomicReference<>(null);
-        final ConnectionPluginFactory factory = pluginFactoriesByClass.computeIfAbsent(factoryClazz, (key) -> {
+        // Resolve (and cache) the factory instance. This replaces a previous computeIfAbsent call
+        // whose mapping lambda returned null on failure; here the checked InstantiationException is
+        // rethrown directly, preserving the same SQLException on error. The factory instances are
+        // stateless singletons, so a rare concurrent double-create is harmless.
+        ConnectionPluginFactory factory = pluginFactoriesByClass.get(factoryClazz);
+        if (factory == null) {
           try {
-            return WrapperUtils.createInstance(
+            factory = WrapperUtils.createInstance(
                 factoryClazz,
                 ConnectionPluginFactory.class,
-                null,
-                (Object) null);
-
-          } catch (InstantiationException ex) {
-            lastException.set(ex);
+                (Class<?>[]) null);
+          } catch (final InstantiationException ex) {
+            throw new SQLException(
+                Messages.get(
+                    "ConnectionPluginManager.unableToLoadPlugin",
+                    new Object[] {factoryClazz.getName()}),
+                SqlState.UNKNOWN_STATE.getState(),
+                ex);
           }
-          return null;
-        });
-
-        if (lastException.get() != null) {
-          throw new SQLException(
-              Messages.get(
-                  "ConnectionPluginManager.unableToLoadPlugin",
-                  new Object[] {factoryClazz.getName()}),
-              SqlState.UNKNOWN_STATE.getState(),
-              lastException.get());
+          pluginFactoriesByClass.put(factoryClazz, factory);
         }
 
-        if (factory != null) {
-          pluginFactories.add(factory);
-        }
+        pluginFactories.add(factory);
       }
     } else {
 

--- a/wrapper/src/main/java/software/amazon/jdbc/ConnectionProvider.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/ConnectionProvider.java
@@ -64,11 +64,11 @@ public interface ConnectionProvider extends StateSnapshotProvider {
    * @param strategy the strategy determining how the {@link HostSpec} should be selected, e.g.,
    *                 random or round-robin
    * @param props    any properties that are required by the provided strategy to select a host
-   * @return the {@link HostSpec} selected using the specified strategy
+   * @return the {@link HostSpec} selected using the specified strategy, or null if no host matches
    * @throws SQLException                  if an error occurred while returning the hosts
    * @throws UnsupportedOperationException if the strategy is unsupported by the provider
    */
-  HostSpec getHostSpecByStrategy(
+  @Nullable HostSpec getHostSpecByStrategy(
       @NonNull List<HostSpec> hosts, @Nullable HostRole role, @NonNull String strategy, @Nullable Properties props)
       throws SQLException, UnsupportedOperationException;
 

--- a/wrapper/src/main/java/software/amazon/jdbc/ConnectionProviderManager.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/ConnectionProviderManager.java
@@ -67,7 +67,7 @@ public class ConnectionProviderManager implements StateSnapshotProvider {
   public ConnectionProvider getConnectionProvider(
       String driverProtocol, HostSpec host, Properties props) {
 
-    final ConnectionProvider customConnectionProvider = Driver.getCustomConnectionProvider();
+    final @Nullable ConnectionProvider customConnectionProvider = Driver.getCustomConnectionProvider();
     if (customConnectionProvider != null && customConnectionProvider.acceptsUrl(driverProtocol, host, props)) {
       return customConnectionProvider;
     }
@@ -99,7 +99,7 @@ public class ConnectionProviderManager implements StateSnapshotProvider {
    *     return false
    */
   public boolean acceptsStrategy(HostRole role, String strategy) {
-    final ConnectionProvider customConnectionProvider = Driver.getCustomConnectionProvider();
+    final @Nullable ConnectionProvider customConnectionProvider = Driver.getCustomConnectionProvider();
     if (customConnectionProvider != null && customConnectionProvider.acceptsStrategy(role, strategy)) {
       return true;
     }
@@ -129,10 +129,11 @@ public class ConnectionProviderManager implements StateSnapshotProvider {
    * @throws UnsupportedOperationException if the available {@link ConnectionProvider} instances do
    *                                       not support the requested strategy
    */
-  public HostSpec getHostSpecByStrategy(List<HostSpec> hosts, HostRole role, String strategy, Properties props)
+  public @Nullable HostSpec getHostSpecByStrategy(
+      List<HostSpec> hosts, HostRole role, String strategy, Properties props)
       throws SQLException, UnsupportedOperationException {
-    HostSpec host = null;
-    final ConnectionProvider customConnectionProvider = Driver.getCustomConnectionProvider();
+    @Nullable HostSpec host = null;
+    final @Nullable ConnectionProvider customConnectionProvider = Driver.getCustomConnectionProvider();
     try {
       if (customConnectionProvider != null && customConnectionProvider.acceptsStrategy(role, strategy)) {
         host = customConnectionProvider.getHostSpecByStrategy(hosts, role, strategy, props);
@@ -159,7 +160,7 @@ public class ConnectionProviderManager implements StateSnapshotProvider {
    * Releases any resources held by the available {@link ConnectionProvider} instances.
    */
   public static void releaseResources() {
-    final ConnectionProvider customConnectionProvider = Driver.getCustomConnectionProvider();
+    final @Nullable ConnectionProvider customConnectionProvider = Driver.getCustomConnectionProvider();
     if (customConnectionProvider instanceof CanReleaseResources) {
       ((CanReleaseResources) customConnectionProvider).releaseResources();
     }
@@ -171,7 +172,7 @@ public class ConnectionProviderManager implements StateSnapshotProvider {
       final @NonNull HostSpec hostSpec,
       final @NonNull Properties props) throws SQLException {
 
-    final ConnectionInitFunc connectionInitFunc = Driver.getConnectionInitFunc();
+    final @Nullable ConnectionInitFunc connectionInitFunc = Driver.getConnectionInitFunc();
     if (connectionInitFunc == null) {
       return;
     }
@@ -188,7 +189,7 @@ public class ConnectionProviderManager implements StateSnapshotProvider {
   }
 
   @Override
-  public List<Pair<String, Object>> getSnapshotState() {
+  public @Nullable List<Pair<String, Object>> getSnapshotState() {
     List<Pair<String, Object>> state = new ArrayList<>();
     WrapperUtils.addSnapshotState(state, "defaultProvider", this.defaultProvider);
     WrapperUtils.addSnapshotState(state, "effectiveConnProvider", this.effectiveConnProvider);

--- a/wrapper/src/main/java/software/amazon/jdbc/DataSourceConnectionProvider.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/DataSourceConnectionProvider.java
@@ -99,17 +99,18 @@ public class DataSourceConnectionProvider implements ConnectionProvider {
   }
 
   @Override
-  public HostSpec getHostSpecByStrategy(
+  public @Nullable HostSpec getHostSpecByStrategy(
       @NonNull List<HostSpec> hosts, @Nullable HostRole role, @NonNull String strategy, @Nullable Properties props)
       throws SQLException {
-    if (!acceptedStrategies.containsKey(strategy)) {
+    final HostSelector hostSelector = acceptedStrategies.get(strategy);
+    if (hostSelector == null) {
       throw new UnsupportedOperationException(
           Messages.get(
               "ConnectionProvider.unsupportedHostSpecSelectorStrategy",
               new Object[] {strategy, DataSourceConnectionProvider.class}));
     }
 
-    return acceptedStrategies.get(strategy).getHost(hosts, role, props);
+    return hostSelector.getHost(hosts, role, props);
   }
 
   /**

--- a/wrapper/src/main/java/software/amazon/jdbc/Driver.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/Driver.java
@@ -76,24 +76,24 @@ public class Driver implements java.sql.Driver {
   private static final Logger LOGGER = Logger.getLogger("software.amazon.jdbc.Driver");
   private static @Nullable Driver registeredDriver;
 
-  private static final AtomicReference<ResetSessionStateOnCloseCallable> resetSessionStateOnCloseCallable =
+  private static final AtomicReference<@Nullable ResetSessionStateOnCloseCallable> resetSessionStateOnCloseCallable =
       new AtomicReference<>(null);
-  private static final AtomicReference<TransferSessionStateOnSwitchCallable> transferSessionStateOnSwitchCallable =
+  private static final AtomicReference<@Nullable TransferSessionStateOnSwitchCallable>
+      transferSessionStateOnSwitchCallable = new AtomicReference<>(null);
+
+  private static final AtomicReference<@Nullable ExceptionHandler> customExceptionHandler =
       new AtomicReference<>(null);
 
-  private static final AtomicReference<ExceptionHandler> customExceptionHandler =
+  private static final AtomicReference<@Nullable Dialect> customDialect =
       new AtomicReference<>(null);
 
-  private static final AtomicReference<Dialect> customDialect =
+  private static final AtomicReference<@Nullable TargetDriverDialect> customTargetDriverDialect =
       new AtomicReference<>(null);
 
-  private static final AtomicReference<TargetDriverDialect> customTargetDriverDialect =
+  private static final AtomicReference<@Nullable ConnectionProvider> customConnectionProvider =
       new AtomicReference<>(null);
 
-  private static final AtomicReference<ConnectionProvider> customConnectionProvider =
-      new AtomicReference<>(null);
-
-  private static final AtomicReference<ConnectionInitFunc> connectionInitFunc =
+  private static final AtomicReference<@Nullable ConnectionInitFunc> connectionInitFunc =
       new AtomicReference<>(null);
 
   static {
@@ -153,8 +153,11 @@ public class Driver implements java.sql.Driver {
     return false;
   }
 
+  // java.sql.Driver.connect returns null when the driver does not understand the URL (per the JDBC
+  // contract), but the annotated JDK stub types the return as @NonNull; keep @Nullable here.
+  @SuppressWarnings("override.return")
   @Override
-  public Connection connect(final String url, final Properties info) throws SQLException {
+  public @Nullable Connection connect(final String url, final Properties info) throws SQLException {
     if (!acceptsURL(url)) {
       return null;
     }
@@ -339,7 +342,7 @@ public class Driver implements java.sql.Driver {
     resetSessionStateOnCloseCallable.set(null);
   }
 
-  public static ResetSessionStateOnCloseCallable getResetSessionStateOnCloseFunc() {
+  public static @Nullable ResetSessionStateOnCloseCallable getResetSessionStateOnCloseFunc() {
     return resetSessionStateOnCloseCallable.get();
   }
 
@@ -351,7 +354,7 @@ public class Driver implements java.sql.Driver {
     transferSessionStateOnSwitchCallable.set(null);
   }
 
-  public static TransferSessionStateOnSwitchCallable getTransferSessionStateOnSwitchFunc() {
+  public static @Nullable TransferSessionStateOnSwitchCallable getTransferSessionStateOnSwitchFunc() {
     return transferSessionStateOnSwitchCallable.get();
   }
 
@@ -367,7 +370,7 @@ public class Driver implements java.sql.Driver {
     customExceptionHandler.set(exceptionHandler);
   }
 
-  public static ExceptionHandler getCustomExceptionHandler() {
+  public static @Nullable ExceptionHandler getCustomExceptionHandler() {
     return customExceptionHandler.get();
   }
 
@@ -379,7 +382,7 @@ public class Driver implements java.sql.Driver {
     customDialect.set(dialect);
   }
 
-  public static Dialect getCustomDialect() {
+  public static @Nullable Dialect getCustomDialect() {
     return customDialect.get();
   }
 
@@ -391,7 +394,7 @@ public class Driver implements java.sql.Driver {
     customTargetDriverDialect.set(targetDriverDialect);
   }
 
-  public static TargetDriverDialect getCustomTargetDriverDialect() {
+  public static @Nullable TargetDriverDialect getCustomTargetDriverDialect() {
     return customTargetDriverDialect.get();
   }
 
@@ -411,7 +414,7 @@ public class Driver implements java.sql.Driver {
     customConnectionProvider.set(connProvider);
   }
 
-  public static ConnectionProvider getCustomConnectionProvider() {
+  public static @Nullable ConnectionProvider getCustomConnectionProvider() {
     return customConnectionProvider.get();
   }
 
@@ -428,7 +431,7 @@ public class Driver implements java.sql.Driver {
     connectionInitFunc.set(func);
   }
 
-  public static ConnectionInitFunc getConnectionInitFunc() {
+  public static @Nullable ConnectionInitFunc getConnectionInitFunc() {
     return connectionInitFunc.get();
   }
 

--- a/wrapper/src/main/java/software/amazon/jdbc/DriverConnectionProvider.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/DriverConnectionProvider.java
@@ -95,17 +95,18 @@ public class DriverConnectionProvider implements ConnectionProvider {
   }
 
   @Override
-  public HostSpec getHostSpecByStrategy(
+  public @Nullable HostSpec getHostSpecByStrategy(
       @NonNull List<HostSpec> hosts, @Nullable HostRole role, @NonNull String strategy, @Nullable Properties props)
       throws SQLException {
-    if (!acceptedStrategies.containsKey(strategy)) {
+    final HostSelector hostSelector = acceptedStrategies.get(strategy);
+    if (hostSelector == null) {
       throw new UnsupportedOperationException(
           Messages.get(
               "ConnectionProvider.unsupportedHostSpecSelectorStrategy",
               new Object[] {strategy, DriverConnectionProvider.class}));
     }
 
-    return acceptedStrategies.get(strategy).getHost(hosts, role, props);
+    return hostSelector.getHost(hosts, role, props);
   }
 
   /**
@@ -216,7 +217,8 @@ public class DriverConnectionProvider implements ConnectionProvider {
   @Override
   public List<Pair<String, Object>> getSnapshotState() {
     List<Pair<String, Object>> state = new ArrayList<>();
-    state.add(Pair.create("driver", this.driver != null ? this.driver.getClass().getName() : null));
+    // this.driver is a non-null final field, so the class name is always available.
+    state.add(Pair.create("driver", this.driver.getClass().getName()));
     state.add(Pair.create("targetDriverClassName", this.targetDriverClassName));
     return state;
   }

--- a/wrapper/src/main/java/software/amazon/jdbc/HighestLoadHostSelector.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/HighestLoadHostSelector.java
@@ -76,10 +76,10 @@ public class HighestLoadHostSelector implements HostSelector {
   }
 
   @Override
-  public HostSpec getHost(
-      @NonNull final List<HostSpec> hosts,
-      @Nullable final HostRole role,
-      @Nullable final Properties props) throws SQLException {
+  public @Nullable HostSpec getHost(
+      final @NonNull List<HostSpec> hosts,
+      final @Nullable HostRole role,
+      final @Nullable Properties props) throws SQLException {
 
     final List<HostSpec> eligible = hosts.stream()
         .filter(h -> (role == null || role.equals(h.getRole()))
@@ -90,7 +90,7 @@ public class HighestLoadHostSelector implements HostSelector {
       return null;
     }
 
-    HostSpec highestLoadHost = null;
+    @Nullable HostSpec highestLoadHost = null;
     long highestLoad = -1;
     for (final HostSpec host : eligible) {
       final long currentLoad = calculateLoad(host, props);
@@ -106,24 +106,26 @@ public class HighestLoadHostSelector implements HostSelector {
     return highestLoadHost;
   }
 
-  private long calculateLoad(final HostSpec host, @Nullable final Properties props) {
+  private long calculateLoad(final HostSpec host, final @Nullable Properties props) {
     final long cpuWeight = getCpuWeight(props);
     final long lagWeight = getLagWeight(props);
-    final long cpuPercentWeighted = (host.getCpuPercent() == null ? CPU_DEFAULT : Math.round(host.getCpuPercent()))
+    final Float cpuPercent = host.getCpuPercent();
+    final Float lagMs = host.getLagMs();
+    final long cpuPercentWeighted = (cpuPercent == null ? CPU_DEFAULT : Math.round(cpuPercent))
         * cpuWeight;
-    final long lagWeighted = (host.getLagMs() == null ? LAG_MS_DEFAULT : Math.round(host.getLagMs()))
+    final long lagWeighted = (lagMs == null ? LAG_MS_DEFAULT : Math.round(lagMs))
         * lagWeight;
     return cpuPercentWeighted + lagWeighted;
   }
 
-  private long getCpuWeight(@Nullable final Properties props) {
+  private long getCpuWeight(final @Nullable Properties props) {
     if (props != null && props.containsKey(HIGHEST_LOAD_CPU_WEIGHT.name)) {
       return HIGHEST_LOAD_CPU_WEIGHT.getLong(props);
     }
     return this.defaultCpuWeight;
   }
 
-  private long getLagWeight(@Nullable final Properties props) {
+  private long getLagWeight(final @Nullable Properties props) {
     if (props != null && props.containsKey(HIGHEST_LOAD_LAG_WEIGHT.name)) {
       return HIGHEST_LOAD_LAG_WEIGHT.getLong(props);
     }

--- a/wrapper/src/main/java/software/amazon/jdbc/HighestWeightHostSelector.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/HighestWeightHostSelector.java
@@ -30,9 +30,9 @@ public class HighestWeightHostSelector implements HostSelector {
   public static final String STRATEGY_HIGHEST_WEIGHT = "highestWeight";
 
   @Override
-  public HostSpec getHost(@NonNull final List<HostSpec> hosts,
-      @Nullable final HostRole role,
-      @Nullable final Properties props) throws SQLException {
+  public @Nullable HostSpec getHost(final @NonNull List<HostSpec> hosts,
+      final @Nullable HostRole role,
+      final @Nullable Properties props) throws SQLException {
 
     final List<HostSpec> eligibleHosts = hosts.stream()
         .filter(hostSpec ->

--- a/wrapper/src/main/java/software/amazon/jdbc/HikariPooledConnectionProvider.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/HikariPooledConnectionProvider.java
@@ -75,7 +75,7 @@ public class HikariPooledConnectionProvider implements PooledConnectionProvider,
   protected static long poolExpirationCheckNanos = TimeUnit.MINUTES.toNanos(30);
   protected final HikariPoolConfigurator poolConfigurator;
   protected final @Nullable HikariPoolMapping poolMapping;
-  protected final AcceptsUrlFunc acceptsUrlFunc;
+  protected final @Nullable AcceptsUrlFunc acceptsUrlFunc;
   protected LeastConnectionsHostSelector leastConnectionsHostSelector;
 
   static {
@@ -88,6 +88,9 @@ public class HikariPooledConnectionProvider implements PooledConnectionProvider,
         });
   }
 
+  // Pool property values come from stringPropertyNames(), so getProperty(p) is non-null; only the
+  // stub types Properties.put's value @NonNull.
+  @SuppressWarnings("argument")
   public HikariPooledConnectionProvider() {
     this((hostSpec, originalProps) -> {
       HikariConfig config = new HikariConfig();
@@ -257,24 +260,27 @@ public class HikariPooledConnectionProvider implements PooledConnectionProvider,
   }
 
   @Override
-  public HostSpec getHostSpecByStrategy(
+  public @Nullable HostSpec getHostSpecByStrategy(
       @NonNull List<HostSpec> hosts,
       @Nullable HostRole role,
       @NonNull String strategy,
       @Nullable Properties props) throws SQLException {
-    if (!acceptsStrategy(role, strategy)) {
+    if (LeastConnectionsHostSelector.STRATEGY_LEAST_CONNECTIONS.equals(strategy)) {
+      return this.leastConnectionsHostSelector.getHost(hosts, role, props);
+    }
+    final HostSelector hostSelector = acceptedStrategies.get(strategy);
+    if (hostSelector == null) {
       throw new UnsupportedOperationException(
           Messages.get(
               "ConnectionProvider.unsupportedHostSpecSelectorStrategy",
               new Object[] {strategy, DataSourceConnectionProvider.class}));
     }
-    if (LeastConnectionsHostSelector.STRATEGY_LEAST_CONNECTIONS.equals(strategy)) {
-      return this.leastConnectionsHostSelector.getHost(hosts, role, props);
-    } else {
-      return acceptedStrategies.get(strategy).getHost(hosts, role, props);
-    }
+    return hostSelector.getHost(hosts, role, props);
   }
 
+  // HikariConfig's setPassword accepts a null password (only the stub types it @NonNull); the
+  // unconditional call with a possibly-null value is preserved.
+  @SuppressWarnings("argument")
   @Override
   public @NonNull ConnectionInfo connect(
       @NonNull String protocol,
@@ -419,9 +425,11 @@ public class HikariPooledConnectionProvider implements PooledConnectionProvider,
    * @return a set containing every host URL for which there are one or more connection pool(s).
    */
   public Set<String> getHosts() {
+    // value1 is the pool's host URL (always a non-null String); String.valueOf yields a non-null
+    // element type so the resulting Set<String> is non-null.
     return Collections.unmodifiableSet(
         HikariPoolsHolder.databasePools.getEntries().keySet().stream()
-            .map(poolKey -> (String) poolKey.getValue1())
+            .map(poolKey -> String.valueOf(poolKey.getValue1()))
             .collect(Collectors.toSet()));
   }
 
@@ -430,6 +438,9 @@ public class HikariPooledConnectionProvider implements PooledConnectionProvider,
    *
    * @return a set containing every key associated with an active connection pool
    */
+  // keySet() returns the (non-null) pool keys; the raw Pair element type triggers a spurious
+  // nullness mismatch against the declared Set<Pair> return.
+  @SuppressWarnings("return")
   public Set<Pair> getKeys() {
     return HikariPoolsHolder.databasePools.getEntries().keySet();
   }

--- a/wrapper/src/main/java/software/amazon/jdbc/HikariPoolsHolder.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/HikariPoolsHolder.java
@@ -20,6 +20,9 @@ import software.amazon.jdbc.util.Pair;
 import software.amazon.jdbc.util.storage.SlidingExpirationCache;
 
 public class HikariPoolsHolder {
+  // A null shouldDisposeFunc is valid (SlidingExpirationCache stores it in a @Nullable field); only
+  // the constructor parameter is typed @NonNull, so the argument is suppressed here.
+  @SuppressWarnings("argument")
   static SlidingExpirationCache<Pair, AutoCloseable> databasePools =
       new SlidingExpirationCache<>(
           null,

--- a/wrapper/src/main/java/software/amazon/jdbc/HostRole.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/HostRole.java
@@ -18,6 +18,7 @@ package software.amazon.jdbc;
 
 import java.util.HashMap;
 import java.util.Map;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 public enum HostRole {
   UNKNOWN,
@@ -33,7 +34,7 @@ public enum HostRole {
         }
       };
 
-  public static HostRole verifyConnectionTypeFromValue(String value) {
+  public static @Nullable HostRole verifyConnectionTypeFromValue(final @Nullable String value) {
     if (value == null) {
       return null;
     }

--- a/wrapper/src/main/java/software/amazon/jdbc/HostSelector.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/HostSelector.java
@@ -33,6 +33,6 @@ public interface HostSelector {
    * @return a host matching the requested role, or null if no hosts match the requested role
    * @throws SQLException if an error occurs while selecting a host
    */
-  HostSpec getHost(
+  @Nullable HostSpec getHost(
       @NonNull List<HostSpec> hosts, @Nullable HostRole role, @Nullable Properties props) throws SQLException;
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/HostSpec.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/HostSpec.java
@@ -35,25 +35,26 @@ public class HostSpec {
 
   protected final String host; // full domain name
   protected final int port;
-  protected final HostRole role;
+  protected final @Nullable HostRole role;
   protected final Timestamp lastUpdateTime;
   protected volatile HostAvailability availability;
   protected long weight; // Greater or equal 0. Lesser the weight, the healthier node.
-  protected Float cpuPercent;
-  protected Float lagMs;
-  protected final String hostId; // id; could be a node name, node domain name, or some gibberish code
+  protected @Nullable Float cpuPercent;
+  protected @Nullable Float lagMs;
+  // id; could be a node name, node domain name, or some gibberish code
+  protected final @Nullable String hostId;
   protected HostAvailabilityStrategy hostAvailabilityStrategy;
 
   protected final ResourceLock resourceLock = new ResourceLock();
-  protected volatile String hostAndPort = null;
-  protected volatile String url = null;
-  protected volatile String toString = null;
+  protected volatile @Nullable String hostAndPort = null;
+  protected volatile @Nullable String url = null;
+  protected volatile @Nullable String toString = null;
 
   private HostSpec(
       final String host,
       final int port,
-      final String hostId,
-      final HostRole role,
+      final @Nullable String hostId,
+      final @Nullable HostRole role,
       final HostAvailability availability,
       final HostAvailabilityStrategy hostAvailabilityStrategy) {
 
@@ -64,8 +65,8 @@ public class HostSpec {
   HostSpec(
       final String host,
       final int port,
-      final String hostId,
-      final HostRole role,
+      final @Nullable String hostId,
+      final @Nullable HostRole role,
       final HostAvailability availability,
       final long weight,
       final Timestamp lastUpdateTime,
@@ -77,12 +78,12 @@ public class HostSpec {
   HostSpec(
       final String host,
       final int port,
-      final String hostId,
-      final HostRole role,
+      final @Nullable String hostId,
+      final @Nullable HostRole role,
       final HostAvailability availability,
       final long weight,
-      final Float cpuPercent,
-      final Float lagMs,
+      final @Nullable Float cpuPercent,
+      final @Nullable Float lagMs,
       final Timestamp lastUpdateTime,
       final HostAvailabilityStrategy hostAvailabilityStrategy) {
 
@@ -121,7 +122,7 @@ public class HostSpec {
     return port != NO_PORT;
   }
 
-  public HostRole getRole() {
+  public @Nullable HostRole getRole() {
     return this.role;
   }
 
@@ -169,55 +170,64 @@ public class HostSpec {
     }
   }
 
-  public Float getCpuPercent() {
+  public @Nullable Float getCpuPercent() {
     return this.cpuPercent;
   }
 
-  public Float getLagMs() {
+  public @Nullable Float getLagMs() {
     return this.lagMs;
   }
 
   public String getUrl() {
-    if (this.url == null) {
+    String result = this.url;
+    if (result == null) {
       try (ResourceLock ignored = this.resourceLock.obtain()) {
-        if (this.url == null) {
-          this.url = this.getHostAndPort() + "/";
+        result = this.url;
+        if (result == null) {
+          result = this.getHostAndPort() + "/";
+          this.url = result;
         }
       }
     }
-    return this.url;
+    return result;
   }
 
   public String getHostAndPort() {
-    if (this.hostAndPort == null) {
+    String result = this.hostAndPort;
+    if (result == null) {
       try (ResourceLock ignored = this.resourceLock.obtain()) {
-        if (this.hostAndPort == null) {
-          this.hostAndPort = this.isPortSpecified() ? host + ":" + port : host;
+        result = this.hostAndPort;
+        if (result == null) {
+          result = this.isPortSpecified() ? host + ":" + port : host;
+          this.hostAndPort = result;
         }
       }
     }
-    return this.hostAndPort;
+    return result;
   }
 
-  public String getHostId() {
+  public @Nullable String getHostId() {
     return this.hostId;
   }
 
   public String toString() {
-    if (this.toString == null) {
+    String result = this.toString;
+    if (result == null) {
       try (ResourceLock ignored = this.resourceLock.obtain()) {
-        if (this.toString == null) {
-          this.toString = String.format(
+        result = this.toString;
+        if (result == null) {
+          result = String.format(
               "HostSpec@%s [hostId=%s, host=%s, port=%d, %s, %s, weight=%d, cpuPercent=%s, lagMs=%s, %s]",
               Integer.toHexString(System.identityHashCode(this)),
               this.hostId, this.host, this.port, this.role, this.availability, this.weight,
               this.cpuPercent != null ? String.format("%.2f", this.cpuPercent) : "N/A",
               this.lagMs != null ? String.format("%.2f", this.lagMs) : "N/A",
               this.lastUpdateTime);
+          this.toString = result;
         }
       }
     }
-    return this.toString;
+    return result;
   }
 
   @Override
@@ -226,7 +236,7 @@ public class HostSpec {
   }
 
   @Override
-  public boolean equals(final Object obj) {
+  public boolean equals(final @Nullable Object obj) {
     if (obj == this) {
       return true;
     }

--- a/wrapper/src/main/java/software/amazon/jdbc/HostSpecBuilder.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/HostSpecBuilder.java
@@ -24,13 +24,13 @@ import software.amazon.jdbc.hostavailability.HostAvailabilityStrategy;
 
 public class HostSpecBuilder {
   private String host;
-  private String hostId;
+  private @Nullable String hostId;
   private int port = HostSpec.NO_PORT;
   private HostAvailability availability = HostAvailability.AVAILABLE;
-  private HostRole role = HostRole.WRITER;
+  private @Nullable HostRole role = HostRole.WRITER;
   private long weight = HostSpec.DEFAULT_WEIGHT; // Greater than or equal to 0. Healthier nodes have lower weights.
-  private Float cpuPercent;
-  private Float lagMs;
+  private @Nullable Float cpuPercent;
+  private @Nullable Float lagMs;
   private Timestamp lastUpdateTime;
   private HostAvailabilityStrategy hostAvailabilityStrategy;
 
@@ -94,12 +94,12 @@ public class HostSpecBuilder {
     return this;
   }
 
-  public HostSpecBuilder cpuPercent(Float cpuPercent) {
+  public HostSpecBuilder cpuPercent(@Nullable Float cpuPercent) {
     this.cpuPercent = cpuPercent;
     return this;
   }
 
-  public HostSpecBuilder lagMs(Float lag) {
+  public HostSpecBuilder lagMs(@Nullable Float lag) {
     this.lagMs = lag;
     return this;
   }

--- a/wrapper/src/main/java/software/amazon/jdbc/InternalConnectionPoolService.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/InternalConnectionPoolService.java
@@ -22,6 +22,7 @@ import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Logger;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import software.amazon.jdbc.cleanup.CanReleaseResources;
 import software.amazon.jdbc.hostlistprovider.RdsHostListProvider;
 import software.amazon.jdbc.util.StringUtils;
@@ -31,7 +32,8 @@ public class InternalConnectionPoolService {
 
   private static final Logger LOGGER = Logger.getLogger(InternalConnectionPoolService.class.getName());
 
-  private static final AtomicReference<InternalConnectionPoolService> INSTANCE = new AtomicReference<>(null);
+  private static final AtomicReference<@Nullable InternalConnectionPoolService> INSTANCE =
+      new AtomicReference<>(null);
 
   private final Map<String, PooledConnectionProvider> pooledProviderMap = new ConcurrentHashMap<>();
 
@@ -39,20 +41,21 @@ public class InternalConnectionPoolService {
   }
 
   public static InternalConnectionPoolService getInstance() {
-    InternalConnectionPoolService instance = INSTANCE.get();
-    if (instance == null) {
-      InternalConnectionPoolService newInstance = new InternalConnectionPoolService();
-      if (INSTANCE.compareAndSet(null, newInstance)) {
-        instance = newInstance;
-      } else {
-        instance = INSTANCE.get();
-      }
+    final InternalConnectionPoolService instance = INSTANCE.get();
+    if (instance != null) {
+      return instance;
     }
-    return instance;
+    final InternalConnectionPoolService newInstance = new InternalConnectionPoolService();
+    if (INSTANCE.compareAndSet(null, newInstance)) {
+      return newInstance;
+    }
+    // Another thread won the race and stored its instance, which is therefore non-null.
+    final InternalConnectionPoolService current = INSTANCE.get();
+    return current != null ? current : newInstance;
   }
 
   public static void releaseResources() {
-    InternalConnectionPoolService instance = INSTANCE.getAndSet(null);
+    final @Nullable InternalConnectionPoolService instance = INSTANCE.getAndSet(null);
     if (instance != null) {
       instance.pooledProviderMap.values().forEach((x) -> {
         if (x instanceof CanReleaseResources) {
@@ -63,40 +66,53 @@ public class InternalConnectionPoolService {
     }
   }
 
-  public ConnectionProvider getEffectiveConnectionProvider(final Properties props) {
+  public @Nullable ConnectionProvider getEffectiveConnectionProvider(final Properties props) {
 
     final String clusterId = RdsHostListProvider.CLUSTER_ID.getString(props);
-    return this.pooledProviderMap.computeIfAbsent(clusterId, (key) -> {
-      final String connectionPoolType = PropertyDefinition.CONNECTION_POOL_TYPE.getString(props);
-      if (StringUtils.isNullOrEmpty(connectionPoolType)) {
-        return null;
-      }
-      PooledConnectionProvider provider = null;
-      switch (connectionPoolType.toLowerCase()) {
-        case "c3p0":
-          try {
-            provider = WrapperUtils.createInstance(
-                "software.amazon.jdbc.C3P0PooledConnectionProvider", PooledConnectionProvider.class);
-          } catch (InstantiationException e) {
-            throw new RuntimeException("Can't create connection pool provider.", e);
-          }
-          break;
-        case "hikari":
-          try {
-            provider = WrapperUtils.createInstance(
-                "software.amazon.jdbc.HikariPooledConnectionProvider", PooledConnectionProvider.class);
-          } catch (InstantiationException e) {
-            throw new RuntimeException("Can't create connection pool provider.", e);
-          }
-          break;
-        default:
-          throw new RuntimeException("Unknown connection pool type: " + connectionPoolType);
-      }
+    // CLUSTER_ID resolves to a non-null value (it has a default), so this guard never triggers in
+    // practice; it mirrors ConcurrentHashMap's rejection of null keys used by the prior
+    // computeIfAbsent call.
+    if (clusterId == null) {
+      return null;
+    }
 
-      LOGGER.finest(() -> String.format(
-          "[clusterId: %s] Created a new connection pool (%s).", clusterId, connectionPoolType));
+    final PooledConnectionProvider existing = this.pooledProviderMap.get(clusterId);
+    if (existing != null) {
+      return existing;
+    }
 
-      return provider;
-    });
+    final String connectionPoolType = PropertyDefinition.CONNECTION_POOL_TYPE.getString(props);
+    if (StringUtils.isNullOrEmpty(connectionPoolType)) {
+      return null;
+    }
+    final PooledConnectionProvider provider;
+    switch (connectionPoolType.toLowerCase()) {
+      case "c3p0":
+        try {
+          provider = WrapperUtils.createInstance(
+              "software.amazon.jdbc.C3P0PooledConnectionProvider", PooledConnectionProvider.class);
+        } catch (InstantiationException e) {
+          throw new RuntimeException("Can't create connection pool provider.", e);
+        }
+        break;
+      case "hikari":
+        try {
+          provider = WrapperUtils.createInstance(
+              "software.amazon.jdbc.HikariPooledConnectionProvider", PooledConnectionProvider.class);
+        } catch (InstantiationException e) {
+          throw new RuntimeException("Can't create connection pool provider.", e);
+        }
+        break;
+      default:
+        throw new RuntimeException("Unknown connection pool type: " + connectionPoolType);
+    }
+
+    LOGGER.finest(() -> String.format(
+        "[clusterId: %s] Created a new connection pool (%s).", clusterId, connectionPoolType));
+
+    // putIfAbsent keeps a single provider per clusterId even under concurrent creation, matching
+    // the prior computeIfAbsent semantics.
+    final PooledConnectionProvider previous = this.pooledProviderMap.putIfAbsent(clusterId, provider);
+    return previous != null ? previous : provider;
   }
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/LeastConnectionsHostSelector.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/LeastConnectionsHostSelector.java
@@ -42,10 +42,10 @@ public class LeastConnectionsHostSelector implements HostSelector {
   }
 
   @Override
-  public HostSpec getHost(
-      @NonNull final List<HostSpec> hosts,
-      @Nullable final HostRole role,
-      @Nullable final Properties props) throws SQLException {
+  public @Nullable HostSpec getHost(
+      final @NonNull List<HostSpec> hosts,
+      final @Nullable HostRole role,
+      final @Nullable Properties props) throws SQLException {
 
     // Get all eligible hosts along with number of active connections
     final List<Pair<HostSpec, Integer>> eligibleHosts = hosts.stream()
@@ -62,6 +62,11 @@ public class LeastConnectionsHostSelector implements HostSelector {
     // Get min number of connections
     final Pair<HostSpec, Integer> minNumConnectionPair =
         eligibleHosts.stream().min(Comparator.comparingInt(Pair::getValue2)).orElse(null);
+    // eligibleHosts is non-empty (checked above), so min() is always present; guard preserves
+    // "no eligible host" semantics without changing observable behavior.
+    if (minNumConnectionPair == null) {
+      return null;
+    }
 
     // Get all hosts with found min number of connections
     final List<HostSpec> hostsWithMinConnections = eligibleHosts.stream()

--- a/wrapper/src/main/java/software/amazon/jdbc/LowestLoadHostSelector.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/LowestLoadHostSelector.java
@@ -76,10 +76,10 @@ public class LowestLoadHostSelector implements HostSelector {
   }
 
   @Override
-  public HostSpec getHost(
-      @NonNull final List<HostSpec> hosts,
-      @Nullable final HostRole role,
-      @Nullable final Properties props) throws SQLException {
+  public @Nullable HostSpec getHost(
+      final @NonNull List<HostSpec> hosts,
+      final @Nullable HostRole role,
+      final @Nullable Properties props) throws SQLException {
 
     final List<HostSpec> eligible = hosts.stream()
         .filter(h -> (role == null || role.equals(h.getRole()))
@@ -90,7 +90,7 @@ public class LowestLoadHostSelector implements HostSelector {
       return null;
     }
 
-    HostSpec lowestLoadHost = null;
+    @Nullable HostSpec lowestLoadHost = null;
     long lowestLoad = -1;
     for (final HostSpec host : eligible) {
       final long currentLoad = calculateLoad(host, props);
@@ -106,24 +106,26 @@ public class LowestLoadHostSelector implements HostSelector {
     return lowestLoadHost;
   }
 
-  private long calculateLoad(final HostSpec host, @Nullable final Properties props) {
+  private long calculateLoad(final HostSpec host, final @Nullable Properties props) {
     final long cpuWeight = getCpuWeight(props);
     final long lagWeight = getLagWeight(props);
-    final long cpuPercentWeighted = (host.getCpuPercent() == null ? CPU_DEFAULT : Math.round(host.getCpuPercent()))
+    final Float cpuPercent = host.getCpuPercent();
+    final Float lagMs = host.getLagMs();
+    final long cpuPercentWeighted = (cpuPercent == null ? CPU_DEFAULT : Math.round(cpuPercent))
         * cpuWeight;
-    final long lagWeighted = (host.getLagMs() == null ? LAG_MS_DEFAULT : Math.round(host.getLagMs()))
+    final long lagWeighted = (lagMs == null ? LAG_MS_DEFAULT : Math.round(lagMs))
         * lagWeight;
     return cpuPercentWeighted + lagWeighted;
   }
 
-  private long getCpuWeight(@Nullable final Properties props) {
+  private long getCpuWeight(final @Nullable Properties props) {
     if (props != null && props.containsKey(LOWEST_LOAD_CPU_WEIGHT.name)) {
       return LOWEST_LOAD_CPU_WEIGHT.getLong(props);
     }
     return this.defaultCpuWeight;
   }
 
-  private long getLagWeight(@Nullable final Properties props) {
+  private long getLagWeight(final @Nullable Properties props) {
     if (props != null && props.containsKey(LOWEST_LOAD_LAG_WEIGHT.name)) {
       return LOWEST_LOAD_LAG_WEIGHT.getLong(props);
     }

--- a/wrapper/src/main/java/software/amazon/jdbc/PartialPluginService.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/PartialPluginService.java
@@ -85,18 +85,21 @@ public class PartialPluginService implements PluginService, CanReleaseResources,
   protected final String driverProtocol;
   protected TargetDriverDialect targetDriverDialect;
   protected Dialect dbDialect;
-  protected @Nullable final ConfigurationProfile configurationProfile;
+  protected final @Nullable ConfigurationProfile configurationProfile;
   protected final ConnectionProviderManager connectionProviderManager;
 
+  // The constructor publishes 'this' to the services container (setHostListProviderService, etc.)
+  // before the instance is fully initialized; this is intentional and safe here.
+  @SuppressWarnings({"argument", "method.invocation"})
   public PartialPluginService(
-      @NonNull final FullServicesContainer servicesContainer,
-      @NonNull final ExceptionManager exceptionManager,
-      @NonNull final Properties props,
-      @NonNull final String originalUrl,
-      @NonNull final String targetDriverProtocol,
-      @NonNull final TargetDriverDialect targetDriverDialect,
-      @NonNull final Dialect dbDialect,
-      @Nullable final ConfigurationProfile configurationProfile) throws SQLException {
+      final @NonNull FullServicesContainer servicesContainer,
+      final @NonNull ExceptionManager exceptionManager,
+      final @NonNull Properties props,
+      final @NonNull String originalUrl,
+      final @NonNull String targetDriverProtocol,
+      final @NonNull TargetDriverDialect targetDriverDialect,
+      final @NonNull Dialect dbDialect,
+      final @Nullable ConfigurationProfile configurationProfile) throws SQLException {
     this.servicesContainer = servicesContainer;
     this.servicesContainer.setHostListProviderService(this);
     this.servicesContainer.setPluginService(this);
@@ -129,6 +132,9 @@ public class PartialPluginService implements PluginService, CanReleaseResources,
         Messages.get("PartialPluginService.unexpectedMethodCall", new Object[] {"getCurrentConnection"}));
   }
 
+  // Utils.getWriter may return null; the null-guards in this method preserve prior behavior. The
+  // currentHostSpec field is typed @NonNull, so the possibly-null assignment is suppressed.
+  @SuppressWarnings("assignment")
   @Override
   public HostSpec getCurrentHostSpec() {
     if (this.currentHostSpec == null) {
@@ -228,7 +234,7 @@ public class PartialPluginService implements PluginService, CanReleaseResources,
   public EnumSet<NodeChangeOptions> setCurrentConnection(
       final @NonNull Connection connection,
       final @NonNull HostSpec hostSpec,
-      @Nullable final ConnectionPlugin skipNotificationForThisPlugin)
+      final @Nullable ConnectionPlugin skipNotificationForThisPlugin)
       throws SQLException {
     throw new UnsupportedOperationException(
         Messages.get("PartialPluginService.unexpectedMethodCall", new Object[] {"setCurrentConnection"}));
@@ -300,14 +306,20 @@ public class PartialPluginService implements PluginService, CanReleaseResources,
 
     if (!Utils.isNullOrEmpty(allowedHostIds)) {
       hosts = hosts.stream()
-          .filter((hostSpec -> allowedHostIds.contains(hostSpec.getHostId())))
+          .filter((hostSpec -> {
+            final String hostId = hostSpec.getHostId();
+            return hostId != null && allowedHostIds.contains(hostId);
+          }))
           .filter(hostSpec -> requiredRole == null || requiredRole == hostSpec.getRole())
           .collect(Collectors.toList());
     }
 
     if (!Utils.isNullOrEmpty(blockedHostIds)) {
       hosts = hosts.stream()
-          .filter((hostSpec -> !blockedHostIds.contains(hostSpec.getHostId())))
+          .filter((hostSpec -> {
+            final String hostId = hostSpec.getHostId();
+            return hostId == null || !blockedHostIds.contains(hostId);
+          }))
           .filter(hostSpec -> requiredRole == null || requiredRole == hostSpec.getRole())
           .collect(Collectors.toList());
     }
@@ -319,7 +331,7 @@ public class PartialPluginService implements PluginService, CanReleaseResources,
   public void setAvailability(final @NonNull HostSpec hostSpec, final @NonNull HostAvailability availability) {
 
     final List<HostSpec> hostsToChange = this.getAllHosts().stream()
-        .filter((host) -> hostSpec.getHostId().equals(host.getHostId())
+        .filter((host) -> Objects.equals(hostSpec.getHostId(), host.getHostId())
             || hostSpec.getHost().equalsIgnoreCase(host.getHost()))
         .distinct()
         .collect(Collectors.toList());
@@ -405,8 +417,8 @@ public class PartialPluginService implements PluginService, CanReleaseResources,
     return false;
   }
 
-  void setNodeList(@Nullable final List<HostSpec> oldHosts,
-      @Nullable final List<HostSpec> newHosts) {
+  void setNodeList(final @Nullable List<HostSpec> oldHosts,
+      final @Nullable List<HostSpec> newHosts) {
 
     final Map<String, HostSpec> oldHostMap = oldHosts == null
         ? new HashMap<>()
@@ -513,7 +525,7 @@ public class PartialPluginService implements PluginService, CanReleaseResources,
   }
 
   @Override
-  public boolean isNetworkException(final String sqlState) {
+  public boolean isNetworkException(final @Nullable String sqlState) {
     if (this.exceptionHandler != null) {
       return this.exceptionHandler.isNetworkException(sqlState);
     }
@@ -529,7 +541,7 @@ public class PartialPluginService implements PluginService, CanReleaseResources,
   }
 
   @Override
-  public boolean isLoginException(final String sqlState) {
+  public boolean isLoginException(final @Nullable String sqlState) {
     if (this.exceptionHandler != null) {
       return this.exceptionHandler.isLoginException(sqlState);
     }
@@ -572,7 +584,7 @@ public class PartialPluginService implements PluginService, CanReleaseResources,
   public @Nullable HostSpec identifyConnection(Connection connection, final @NonNull HostSpec connectionHostSpec)
       throws SQLException {
 
-    final HostIdCacheService hostIdCacheService = this.servicesContainer.getHostIdCacheService();
+    final @Nullable HostIdCacheService hostIdCacheService = this.servicesContainer.getHostIdCacheService();
     if (hostIdCacheService == null) {
       return this.identifyConnection(connection);
     }
@@ -582,12 +594,13 @@ public class PartialPluginService implements PluginService, CanReleaseResources,
   @Override
   public @Nullable HostSpec identifyConnection(Connection connection) throws SQLException {
     try {
-      Pair<String, String> instanceIds = this.getDialect().getHostId(connection);
+      final @Nullable Pair<@Nullable String, @Nullable String> instanceIds =
+          this.getDialect().getHostId(connection);
       if (instanceIds == null) {
         throw new SQLException(Messages.get("PluginServiceImpl.errorIdentifyConnection"));
       }
 
-      List<HostSpec> topology = this.hostListProvider.refresh();
+      @Nullable List<HostSpec> topology = this.hostListProvider.refresh();
       boolean isForcedRefresh = false;
       if (topology == null) {
         topology = this.hostListProvider.forceRefresh();
@@ -598,8 +611,8 @@ public class PartialPluginService implements PluginService, CanReleaseResources,
         return null;
       }
 
-      String instanceId = instanceIds.getValue1();
-      String instanceName = instanceIds.getValue2();
+      final @Nullable String instanceId = instanceIds.getValue1();
+      final @Nullable String instanceName = instanceIds.getValue2();
       HostSpec foundHost = topology
           .stream()
           .filter(host -> Objects.equals(instanceId, host.getHostId())
@@ -709,6 +722,9 @@ public class PartialPluginService implements PluginService, CanReleaseResources,
         Messages.get("PartialPluginService.unexpectedMethodCall", new Object[] {"getSessionStateService"}));
   }
 
+  // Class.cast is @Nullable by its null-in/null-out contract, but 'this' is non-null so the cast
+  // result is non-null.
+  @SuppressWarnings("return")
   @Override
   public <T> T unwrap(Class<T> iface) throws SQLException {
     if (iface == PluginService.class) {
@@ -732,7 +748,7 @@ public class PartialPluginService implements PluginService, CanReleaseResources,
   }
 
   @Override
-  public List<Pair<String, Object>> getSnapshotState() {
+  public @Nullable List<Pair<String, Object>> getSnapshotState() {
     return null;
   }
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/PluginServiceImpl.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/PluginServiceImpl.java
@@ -457,14 +457,20 @@ public class PluginServiceImpl implements PluginService, CanReleaseResources,
 
     if (!Utils.isNullOrEmpty(allowedHostIds)) {
       hosts = hosts.stream()
-          .filter((hostSpec -> allowedHostIds.contains(hostSpec.getHostId())))
+          .filter((hostSpec -> {
+            final String hostId = hostSpec.getHostId();
+            return hostId != null && allowedHostIds.contains(hostId);
+          }))
           .filter(hostSpec -> requiredRole == null || requiredRole == hostSpec.getRole())
           .collect(Collectors.toList());
     }
 
     if (!Utils.isNullOrEmpty(blockedHostIds)) {
       hosts = hosts.stream()
-          .filter((hostSpec -> !blockedHostIds.contains(hostSpec.getHostId())))
+          .filter((hostSpec -> {
+            final String hostId = hostSpec.getHostId();
+            return hostId == null || !blockedHostIds.contains(hostId);
+          }))
           .filter(hostSpec -> requiredRole == null || requiredRole == hostSpec.getRole())
           .collect(Collectors.toList());
     }
@@ -476,8 +482,11 @@ public class PluginServiceImpl implements PluginService, CanReleaseResources,
   public void setAvailability(final @NonNull HostSpec hostSpec, final @NonNull HostAvailability availability) {
 
     final List<HostSpec> hostsToChange = this.getAllHosts().stream()
-        .filter((host) -> hostSpec.getHostId() != null && hostSpec.getHostId().equals(host.getHostId())
-            || hostSpec.getHost() != null && hostSpec.getHost().equalsIgnoreCase(host.getHost()))
+        .filter((host) -> {
+          final String hostId = hostSpec.getHostId();
+          return (hostId != null && hostId.equals(host.getHostId()))
+              || (hostSpec.getHost() != null && hostSpec.getHost().equalsIgnoreCase(host.getHost()));
+        })
         .distinct()
         .collect(Collectors.toList());
 
@@ -547,7 +556,7 @@ public class PluginServiceImpl implements PluginService, CanReleaseResources,
 
     final HostListProvider hostListProvider = this.getHostListProvider();
     try {
-      final List<HostSpec> updatedHostList = hostListProvider.forceRefresh(verifyTopology, timeoutMs);
+      final @Nullable List<HostSpec> updatedHostList = hostListProvider.forceRefresh(verifyTopology, timeoutMs);
       if (updatedHostList != null) {
         updateHostAvailability(updatedHostList);
         setNodeList(this.allHosts, updatedHostList);
@@ -767,7 +776,7 @@ public class PluginServiceImpl implements PluginService, CanReleaseResources,
         return null;
       }
 
-      List<HostSpec> topology = this.hostListProvider.refresh();
+      @Nullable List<HostSpec> topology = this.hostListProvider.refresh();
       if (topology == null) {
         topology = this.hostListProvider.forceRefresh();
       }

--- a/wrapper/src/main/java/software/amazon/jdbc/RandomHostSelector.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/RandomHostSelector.java
@@ -30,10 +30,10 @@ public class RandomHostSelector implements HostSelector {
   public static final String STRATEGY_RANDOM = "random";
 
   @Override
-  public HostSpec getHost(
-      @NonNull final List<HostSpec> hosts,
-      @Nullable final HostRole role,
-      @Nullable final Properties props) throws SQLException {
+  public @Nullable HostSpec getHost(
+      final @NonNull List<HostSpec> hosts,
+      final @Nullable HostRole role,
+      final @Nullable Properties props) throws SQLException {
     final List<HostSpec> eligibleHosts = hosts.stream()
         .filter(hostSpec ->
             (role == null || role.equals(hostSpec.getRole()))

--- a/wrapper/src/main/java/software/amazon/jdbc/RoundRobinHostSelector.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/RoundRobinHostSelector.java
@@ -71,7 +71,7 @@ public class RoundRobinHostSelector implements HostSelector {
   }
 
   @Override
-  public HostSpec getHost(
+  public @Nullable HostSpec getHost(
       final @NonNull List<HostSpec> hosts,
       final @Nullable HostRole role,
       final @Nullable Properties props) throws SQLException {
@@ -92,8 +92,13 @@ public class RoundRobinHostSelector implements HostSelector {
       createCacheEntryForHosts(eligibleHosts, props);
       final String currentClusterInfoKey = eligibleHosts.get(0).getHost();
       final RoundRobinClusterInfo clusterInfo = roundRobinCache.get(currentClusterInfoKey);
+      // createCacheEntryForHosts above always populates the cache for every eligible host, so
+      // clusterInfo is present here; the guard preserves "no host" semantics defensively.
+      if (clusterInfo == null) {
+        return null;
+      }
 
-      final HostSpec lastHost = clusterInfo.lastHost;
+      final @Nullable HostSpec lastHost = clusterInfo.lastHost;
       int lastHostIndex = -1;
 
       // Check if lastHost is in list of eligible hosts. Update lastHostIndex.
@@ -116,7 +121,8 @@ public class RoundRobinHostSelector implements HostSelector {
           targetHostIndex = 0;
         }
 
-        final Integer weight = clusterInfo.clusterWeightsMap.get(eligibleHosts.get(targetHostIndex).getHostId());
+        final @Nullable Integer weight =
+            clusterInfo.clusterWeightsMap.get(eligibleHosts.get(targetHostIndex).getHostId());
         clusterInfo.weightCounter = weight == null ? clusterInfo.defaultWeight : weight;
       }
 
@@ -142,23 +148,27 @@ public class RoundRobinHostSelector implements HostSelector {
     // If there is a host with an existing entry, update the cache entries for all hosts to point each to the same
     // RoundRobinClusterInfo object. If there are no cache entries, create a new RoundRobinClusterInfo.
     if (!hostsWithCacheEntry.isEmpty()) {
+      // hostsWithCacheEntry only contains hosts whose cache entry was non-null just above, so the
+      // lookup is present; the guard preserves behavior defensively for the (impossible) expiry race.
       final RoundRobinClusterInfo roundRobinClusterInfo = roundRobinCache.get(hostsWithCacheEntry.get(0).getHost());
-      if (hasPropertyChanged(roundRobinClusterInfo.lastClusterHostWeightPairPropertyValue,
-          ROUND_ROBIN_HOST_WEIGHT_PAIRS, props)) {
-        roundRobinClusterInfo.lastHost = null;
-        roundRobinClusterInfo.weightCounter = 0;
-        updateCachedHostWeightPairsPropertiesForRoundRobinClusterInfo(roundRobinClusterInfo, props);
-      }
-      if (hasPropertyChanged(roundRobinClusterInfo.lastClusterDefaultWeightPropertyValue, ROUND_ROBIN_DEFAULT_WEIGHT,
-          props)) {
-        roundRobinClusterInfo.defaultWeight = 1;
-        updateCachedDefaultWeightPropertiesForRoundRobinClusterInfo(roundRobinClusterInfo, props);
-      }
-      for (final HostSpec host : hosts) {
-        roundRobinCache.put(
-            host.getHost(),
-            roundRobinClusterInfo,
-            DEFAULT_ROUND_ROBIN_CACHE_EXPIRE_NANO);
+      if (roundRobinClusterInfo != null) {
+        if (hasPropertyChanged(roundRobinClusterInfo.lastClusterHostWeightPairPropertyValue,
+            ROUND_ROBIN_HOST_WEIGHT_PAIRS, props)) {
+          roundRobinClusterInfo.lastHost = null;
+          roundRobinClusterInfo.weightCounter = 0;
+          updateCachedHostWeightPairsPropertiesForRoundRobinClusterInfo(roundRobinClusterInfo, props);
+        }
+        if (hasPropertyChanged(roundRobinClusterInfo.lastClusterDefaultWeightPropertyValue, ROUND_ROBIN_DEFAULT_WEIGHT,
+            props)) {
+          roundRobinClusterInfo.defaultWeight = 1;
+          updateCachedDefaultWeightPropertiesForRoundRobinClusterInfo(roundRobinClusterInfo, props);
+        }
+        for (final HostSpec host : hosts) {
+          roundRobinCache.put(
+              host.getHost(),
+              roundRobinClusterInfo,
+              DEFAULT_ROUND_ROBIN_CACHE_EXPIRE_NANO);
+        }
       }
     } else {
       final RoundRobinClusterInfo roundRobinClusterInfo = new RoundRobinClusterInfo();
@@ -173,11 +183,14 @@ public class RoundRobinHostSelector implements HostSelector {
   }
 
   private boolean hasPropertyChanged(final String lastClusterHostWeightPairPropertyValue,
-      final AwsWrapperProperty wrapperProperty, final Properties props) {
-    if (props == null || wrapperProperty.getString(props) == null) {
+      final AwsWrapperProperty wrapperProperty, final @Nullable Properties props) {
+    if (props == null) {
       return false;
     }
     final String propValue = wrapperProperty.getString(props);
+    if (propValue == null) {
+      return false;
+    }
 
     return !propValue.equals(lastClusterHostWeightPairPropertyValue);
   }
@@ -194,7 +207,7 @@ public class RoundRobinHostSelector implements HostSelector {
       final @Nullable Properties props) throws SQLException {
     int defaultWeight = DEFAULT_WEIGHT;
     if (props != null) {
-      final String defaultWeightString = ROUND_ROBIN_DEFAULT_WEIGHT.getString(props);
+      final @Nullable String defaultWeightString = ROUND_ROBIN_DEFAULT_WEIGHT.getString(props);
       if (!StringUtils.isNullOrEmpty(defaultWeightString)) {
         try {
           final int parsedWeight = Integer.parseInt(defaultWeightString);
@@ -205,7 +218,7 @@ public class RoundRobinHostSelector implements HostSelector {
         } catch (NumberFormatException e) {
           throw new SQLException(Messages.get("HostSelector.roundRobinInvalidDefaultWeight"));
         }
-        roundRobinClusterInfo.lastClusterDefaultWeightPropertyValue = ROUND_ROBIN_DEFAULT_WEIGHT.getString(props);
+        roundRobinClusterInfo.lastClusterDefaultWeightPropertyValue = defaultWeightString;
       }
     }
     roundRobinClusterInfo.defaultWeight = defaultWeight;
@@ -215,7 +228,7 @@ public class RoundRobinHostSelector implements HostSelector {
       final @NonNull RoundRobinClusterInfo roundRobinClusterInfo,
       final @Nullable Properties props) throws SQLException {
     if (props != null) {
-      final String hostWeights = ROUND_ROBIN_HOST_WEIGHT_PAIRS.getString(props);
+      final @Nullable String hostWeights = ROUND_ROBIN_HOST_WEIGHT_PAIRS.getString(props);
       if (!StringUtils.isNullOrEmpty(hostWeights)) {
         final String[] hostWeightPairs = hostWeights.split(",");
         for (final String pair : hostWeightPairs) {
@@ -224,8 +237,11 @@ public class RoundRobinHostSelector implements HostSelector {
             throw new SQLException(Messages.get("HostSelector.roundRobinInvalidHostWeightPairs"));
           }
 
-          final String hostName = matcher.group("host").trim();
-          final String hostWeight = matcher.group("weight").trim();
+          // Named groups "host" and "weight" are always present when matches() is true.
+          final String hostGroup = matcher.group("host");
+          final String weightGroup = matcher.group("weight");
+          final String hostName = hostGroup == null ? "" : hostGroup.trim();
+          final String hostWeight = weightGroup == null ? "" : weightGroup.trim();
           if (hostName.isEmpty() || hostWeight.isEmpty()) {
             throw new SQLException(Messages.get("HostSelector.roundRobinInvalidHostWeightPairs"));
           }
@@ -240,10 +256,10 @@ public class RoundRobinHostSelector implements HostSelector {
             throw new SQLException(Messages.get("HostSelector.roundRobinInvalidHostWeightPairs"));
           }
         }
-        roundRobinClusterInfo.lastClusterHostWeightPairPropertyValue = ROUND_ROBIN_HOST_WEIGHT_PAIRS.getString(props);
+        roundRobinClusterInfo.lastClusterHostWeightPairPropertyValue = hostWeights;
       } else if (hostWeights != null && hostWeights.isEmpty()) {
         roundRobinClusterInfo.clusterWeightsMap.clear();
-        roundRobinClusterInfo.lastClusterHostWeightPairPropertyValue = ROUND_ROBIN_HOST_WEIGHT_PAIRS.getString(props);
+        roundRobinClusterInfo.lastClusterHostWeightPairPropertyValue = hostWeights;
       }
     }
   }
@@ -253,7 +269,7 @@ public class RoundRobinHostSelector implements HostSelector {
   }
 
   public static class RoundRobinClusterInfo {
-    public HostSpec lastHost;
+    public @Nullable HostSpec lastHost;
     public HashMap<String, Integer> clusterWeightsMap = new HashMap<>();
     public int defaultWeight = 1;
     public int weightCounter = 0;

--- a/wrapper/src/main/java/software/amazon/jdbc/WeightedRandomHostSelector.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/WeightedRandomHostSelector.java
@@ -55,22 +55,22 @@ public class WeightedRandomHostSelector implements HostSelector {
     this.random = random;
   }
 
-  public HostSpec getHost(
-      @NonNull List<HostSpec> hosts,
-      @Nullable HostRole role,
-      @Nullable Properties props) throws SQLException {
+  @Override
+  public @Nullable HostSpec getHost(
+      final @NonNull List<HostSpec> hosts,
+      final @Nullable HostRole role,
+      final @Nullable Properties props) throws SQLException {
 
-    String hostWeightPairsValue = props == null ? null : WEIGHTED_RANDOM_HOST_WEIGHT_PAIRS.getString(props);
+    final @Nullable String hostWeightPairsValue =
+        props == null ? null : WEIGHTED_RANDOM_HOST_WEIGHT_PAIRS.getString(props);
 
     // Parse property map if provided, otherwise use HostSpec.getWeight().
     // NOTE: If limitless plugin is used, weightedRandomHostWeightPairs must be null.
-    Map<String, Integer> hostWeightMap = StringUtils.isNullOrEmpty(hostWeightPairsValue)
+    final @Nullable Map<String, Integer> hostWeightMap = StringUtils.isNullOrEmpty(hostWeightPairsValue)
         ? null
         : getHostWeightPairMap(hostWeightPairsValue);
 
-    HostSpec selected = selectWeightedRandom(hosts, role, hostWeightMap);
-
-    return selected;
+    return selectWeightedRandom(hosts, role, hostWeightMap);
   }
 
   // Selects a host using cumulative weight selection algorithm.
@@ -148,8 +148,11 @@ public class WeightedRandomHostSelector implements HostSelector {
           throw new SQLException(Messages.get("HostSelector.weightedRandomInvalidHostWeightPairs"));
         }
 
-        final String hostName = matcher.group("host").trim();
-        final String hostWeight = matcher.group("weight").trim();
+        // Named groups "host" and "weight" are always present when matches() is true.
+        final String hostGroup = matcher.group("host");
+        final String weightGroup = matcher.group("weight");
+        final String hostName = hostGroup == null ? "" : hostGroup.trim();
+        final String hostWeight = weightGroup == null ? "" : weightGroup.trim();
         if (hostName.isEmpty() || hostWeight.isEmpty()) {
           throw new SQLException(Messages.get("HostSelector.weightedRandomInvalidHostWeightPairs"));
         }

--- a/wrapper/src/main/java/software/amazon/jdbc/dialect/AuroraMysqlDialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/dialect/AuroraMysqlDialect.java
@@ -75,7 +75,7 @@ public class AuroraMysqlDialect extends MysqlDialect implements TopologyDialect,
   }
 
   @Override
-  public @Nullable Pair<String, String> getHostId(Connection connection) throws SQLException {
+  public @Nullable Pair<@Nullable String, @Nullable String> getHostId(Connection connection) throws SQLException {
     return this.dialectUtils.getInstanceId(connection, INSTANCE_ID_QUERY);
   }
 

--- a/wrapper/src/main/java/software/amazon/jdbc/dialect/AuroraPgDialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/dialect/AuroraPgDialect.java
@@ -117,7 +117,7 @@ public class AuroraPgDialect extends PgDialect implements TopologyDialect, Auror
   }
 
   @Override
-  public @Nullable Pair<String, String> getHostId(Connection connection) throws SQLException {
+  public @Nullable Pair<@Nullable String, @Nullable String> getHostId(Connection connection) throws SQLException {
     return this.dialectUtils.getInstanceId(connection, INSTANCE_ID_QUERY);
   }
 

--- a/wrapper/src/main/java/software/amazon/jdbc/dialect/Dialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/dialect/Dialect.java
@@ -36,20 +36,20 @@ public interface Dialect {
 
   int getDefaultPort();
 
-  List</* dialect code */ String> getDialectUpdateCandidates();
+  @Nullable List</* dialect code */ String> getDialectUpdateCandidates();
 
   ExceptionHandler getExceptionHandler();
 
   HostListProviderSupplier getHostListProviderSupplier();
 
-  String getHostAliasQuery();
+  @Nullable String getHostAliasQuery();
 
   void prepareConnectProperties(
       final @NonNull Properties connectProperties, final @NonNull String protocol, final @NonNull HostSpec hostSpec);
 
   EnumSet<FailoverRestriction> getFailoverRestrictions();
 
-  String getServerVersionQuery();
+  @Nullable String getServerVersionQuery();
 
   HostRole getHostRole(Connection connection) throws SQLException;
 

--- a/wrapper/src/main/java/software/amazon/jdbc/dialect/DialectManager.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/dialect/DialectManager.java
@@ -25,6 +25,7 @@ import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import software.amazon.jdbc.AwsWrapperProperty;
 import software.amazon.jdbc.Driver;
 import software.amazon.jdbc.HostSpec;
@@ -81,7 +82,7 @@ public class DialectManager implements DialectProvider {
   private final RdsUtils rdsHelper = new RdsUtils();
   private final ConnectionUrlParser connectionUrlParser = new ConnectionUrlParser();
   private boolean canUpdate = false;
-  private Dialect dialect = null;
+  private @Nullable Dialect dialect = null;
   private String dialectCode;
   private boolean confirmed = false;
 
@@ -120,7 +121,7 @@ public class DialectManager implements DialectProvider {
       this.dialectCode = DialectCodes.CUSTOM;
       this.dialect = customDialect;
       this.logCurrentDialect();
-      return this.dialect;
+      return customDialect;
     }
 
     final String userDialectSetting = DIALECT.getString(props);
@@ -155,81 +156,102 @@ public class DialectManager implements DialectProvider {
     if (driverProtocol.contains("mysql")) {
       RdsUrlType type = this.rdsHelper.identifyRdsType(host);
       if (type == RdsUrlType.RDS_GLOBAL_WRITER_CLUSTER) {
+        final Dialect resolved = getDialectByCode(DialectCodes.GLOBAL_AURORA_MYSQL);
         this.canUpdate = false;
         this.dialectCode = DialectCodes.GLOBAL_AURORA_MYSQL;
-        this.dialect = knownDialectsByCode.get(DialectCodes.GLOBAL_AURORA_MYSQL);
+        this.dialect = resolved;
         this.confirmed = true;
-        return this.dialect;
+        return resolved;
       }
       if (type.isRdsCluster()) {
+        final Dialect resolved = getDialectByCode(DialectCodes.AURORA_MYSQL);
         this.canUpdate = true;
         this.dialectCode = DialectCodes.AURORA_MYSQL;
-        this.dialect = knownDialectsByCode.get(DialectCodes.AURORA_MYSQL);
-        return this.dialect;
+        this.dialect = resolved;
+        return resolved;
       }
       if (type.isRds()) {
+        final Dialect resolved = getDialectByCode(DialectCodes.RDS_MYSQL);
         this.canUpdate = true;
         this.dialectCode = DialectCodes.RDS_MYSQL;
-        this.dialect = knownDialectsByCode.get(DialectCodes.RDS_MYSQL);
+        this.dialect = resolved;
         this.logCurrentDialect();
-        return this.dialect;
+        return resolved;
       }
+      final Dialect resolved = getDialectByCode(DialectCodes.MYSQL);
       this.canUpdate = true;
       this.dialectCode = DialectCodes.MYSQL;
-      this.dialect = knownDialectsByCode.get(DialectCodes.MYSQL);
+      this.dialect = resolved;
       this.logCurrentDialect();
-      return this.dialect;
+      return resolved;
     }
 
     if (driverProtocol.contains("postgresql")) {
       RdsUrlType type = this.rdsHelper.identifyRdsType(host);
       if (RdsUrlType.RDS_AURORA_LIMITLESS_DB_SHARD_GROUP.equals(type)) {
+        final Dialect resolved = getDialectByCode(DialectCodes.AURORA_PG);
         this.canUpdate = false;
         this.dialectCode = DialectCodes.AURORA_PG;
-        this.dialect = knownDialectsByCode.get(DialectCodes.AURORA_PG);
+        this.dialect = resolved;
         this.confirmed = true;
-        return this.dialect;
+        return resolved;
       }
       if (RdsUrlType.RDS_GLOBAL_WRITER_CLUSTER.equals(type)) {
+        final Dialect resolved = getDialectByCode(DialectCodes.GLOBAL_AURORA_PG);
         this.canUpdate = false;
         this.dialectCode = DialectCodes.GLOBAL_AURORA_PG;
-        this.dialect = knownDialectsByCode.get(DialectCodes.GLOBAL_AURORA_PG);
+        this.dialect = resolved;
         this.confirmed = true;
-        return this.dialect;
+        return resolved;
       }
       if (type.isRdsCluster()) {
+        final Dialect resolved = getDialectByCode(DialectCodes.AURORA_PG);
         this.canUpdate = true;
         this.dialectCode = DialectCodes.AURORA_PG;
-        this.dialect = knownDialectsByCode.get(DialectCodes.AURORA_PG);
-        return this.dialect;
+        this.dialect = resolved;
+        return resolved;
       }
       if (type.isRds()) {
+        final Dialect resolved = getDialectByCode(DialectCodes.RDS_PG);
         this.canUpdate = true;
         this.dialectCode = DialectCodes.RDS_PG;
-        this.dialect = knownDialectsByCode.get(DialectCodes.RDS_PG);
+        this.dialect = resolved;
         this.logCurrentDialect();
-        return this.dialect;
+        return resolved;
       }
+      final Dialect resolved = getDialectByCode(DialectCodes.PG);
       this.canUpdate = true;
       this.dialectCode = DialectCodes.PG;
-      this.dialect = knownDialectsByCode.get(DialectCodes.PG);
+      this.dialect = resolved;
       this.logCurrentDialect();
-      return this.dialect;
+      return resolved;
     }
 
     if (driverProtocol.contains("mariadb")) {
+      final Dialect resolved = getDialectByCode(DialectCodes.MARIADB);
       this.canUpdate = true;
       this.dialectCode = DialectCodes.MARIADB;
-      this.dialect = knownDialectsByCode.get(DialectCodes.MARIADB);
+      this.dialect = resolved;
       this.logCurrentDialect();
-      return this.dialect;
+      return resolved;
     }
 
+    final Dialect resolved = getDialectByCode(DialectCodes.UNKNOWN);
     this.canUpdate = true;
     this.dialectCode = DialectCodes.UNKNOWN;
-    this.dialect = knownDialectsByCode.get(DialectCodes.UNKNOWN);
+    this.dialect = resolved;
     this.logCurrentDialect();
-    return this.dialect;
+    return resolved;
+  }
+
+  private static @NonNull Dialect getDialectByCode(final String dialectCode) throws SQLException {
+    // All codes passed here are constants that are registered in knownDialectsByCode, so this
+    // lookup never returns null in practice; the guard preserves the non-null return contract.
+    final Dialect resolved = knownDialectsByCode.get(dialectCode);
+    if (resolved == null) {
+      throw new SQLException(Messages.get("DialectManager.unknownDialectCode", new Object[] {dialectCode}));
+    }
+    return resolved;
   }
 
   @Override
@@ -238,13 +260,24 @@ public class DialectManager implements DialectProvider {
       final @NonNull HostSpec hostSpec,
       final @NonNull Connection connection) throws SQLException {
 
+    // this.dialect is always populated by a prior getDialect(protocol, url, props) call; guard
+    // for null here to preserve the non-null return contract of DialectProvider.getDialect.
+    final Dialect currentDialect = this.dialect;
+
     if (!this.canUpdate) {
       this.confirmed = true;
       this.logCurrentDialect();
-      return this.dialect;
+      if (currentDialect == null) {
+        throw new SQLException(Messages.get("DialectManager.unknownDialect"));
+      }
+      return currentDialect;
     }
 
-    final List<String> dialectCandidates = this.dialect.getDialectUpdateCandidates();
+    if (currentDialect == null) {
+      throw new SQLException(Messages.get("DialectManager.unknownDialect"));
+    }
+
+    final @Nullable List<String> dialectCandidates = currentDialect.getDialectUpdateCandidates();
     if (dialectCandidates != null) {
       for (String dialectCandidateCode : dialectCandidates) {
         Dialect dialectCandidate = knownDialectsByCode.get(dialectCandidateCode);
@@ -263,7 +296,7 @@ public class DialectManager implements DialectProvider {
           knownEndpointDialects.put(hostSpec.getUrl(), dialectCandidateCode, ENDPOINT_CACHE_EXPIRATION);
 
           this.logCurrentDialect();
-          return this.dialect;
+          return dialectCandidate;
         }
       }
     }
@@ -278,7 +311,7 @@ public class DialectManager implements DialectProvider {
     knownEndpointDialects.put(hostSpec.getUrl(), this.dialectCode, ENDPOINT_CACHE_EXPIRATION);
 
     this.logCurrentDialect();
-    return this.dialect;
+    return currentDialect;
   }
 
   private void logCurrentDialect() {

--- a/wrapper/src/main/java/software/amazon/jdbc/dialect/DialectManager.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/dialect/DialectManager.java
@@ -244,16 +244,6 @@ public class DialectManager implements DialectProvider {
     return resolved;
   }
 
-  private static @NonNull Dialect getDialectByCode(final String dialectCode) throws SQLException {
-    // All codes passed here are constants that are registered in knownDialectsByCode, so this
-    // lookup never returns null in practice; the guard preserves the non-null return contract.
-    final Dialect resolved = knownDialectsByCode.get(dialectCode);
-    if (resolved == null) {
-      throw new SQLException(Messages.get("DialectManager.unknownDialectCode", new Object[] {dialectCode}));
-    }
-    return resolved;
-  }
-
   @Override
   public Dialect getDialect(
       final @NonNull String originalUrl,
@@ -312,6 +302,16 @@ public class DialectManager implements DialectProvider {
 
     this.logCurrentDialect();
     return currentDialect;
+  }
+
+  private static @NonNull Dialect getDialectByCode(final String dialectCode) throws SQLException {
+    // All codes passed here are constants that are registered in knownDialectsByCode, so this
+    // lookup never returns null in practice; the guard preserves the non-null return contract.
+    final Dialect resolved = knownDialectsByCode.get(dialectCode);
+    if (resolved == null) {
+      throw new SQLException(Messages.get("DialectManager.unknownDialectCode", new Object[] {dialectCode}));
+    }
+    return resolved;
   }
 
   private void logCurrentDialect() {

--- a/wrapper/src/main/java/software/amazon/jdbc/dialect/DialectUtils.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/dialect/DialectUtils.java
@@ -86,13 +86,13 @@ public class DialectUtils {
 
    * @return a pair of instanceId and instanceName if successful, null otherwise.
    */
-  public @Nullable Pair<String /* instanceId */, String /* instanceName */> getInstanceId(
+  public @Nullable Pair<@Nullable String /* instanceId */, @Nullable String /* instanceName */> getInstanceId(
       final Connection connection, String instanceIdQuery) {
     try {
       try (final Statement stmt = connection.createStatement();
            final ResultSet rs = stmt.executeQuery(instanceIdQuery)) {
         if (rs.next()) {
-          return Pair.create(rs.getString(1), rs.getString(2));
+          return Pair.<@Nullable String, @Nullable String>create(rs.getString(1), rs.getString(2));
         }
       }
     } catch (SQLException ex) {

--- a/wrapper/src/main/java/software/amazon/jdbc/dialect/MariaDbDialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/dialect/MariaDbDialect.java
@@ -120,7 +120,7 @@ public class MariaDbDialect implements Dialect {
   }
 
   @Override
-  public @Nullable Pair<String, String> getHostId(Connection connection) throws SQLException {
+  public @Nullable Pair<@Nullable String, @Nullable String> getHostId(Connection connection) throws SQLException {
     return this.dialectUtils.getInstanceId(connection, HOST_ID_QUERY);
   }
 

--- a/wrapper/src/main/java/software/amazon/jdbc/dialect/MultiAzClusterMysqlDialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/dialect/MultiAzClusterMysqlDialect.java
@@ -79,7 +79,7 @@ public class MultiAzClusterMysqlDialect extends MysqlDialect implements MultiAzC
   }
 
   @Override
-  public List</* dialect code */ String> getDialectUpdateCandidates() {
+  public @Nullable List</* dialect code */ String> getDialectUpdateCandidates() {
     return null;
   }
 
@@ -114,7 +114,7 @@ public class MultiAzClusterMysqlDialect extends MysqlDialect implements MultiAzC
   }
 
   @Override
-  public @Nullable Pair<String, String> getHostId(Connection connection) throws SQLException {
+  public @Nullable Pair<@Nullable String, @Nullable String> getHostId(Connection connection) throws SQLException {
     return this.dialectUtils.getInstanceId(connection, INSTANCE_ID_QUERY);
   }
 

--- a/wrapper/src/main/java/software/amazon/jdbc/dialect/MultiAzClusterPgDialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/dialect/MultiAzClusterPgDialect.java
@@ -66,7 +66,7 @@ public class MultiAzClusterPgDialect extends PgDialect implements MultiAzCluster
   }
 
   @Override
-  public List</* dialect code */ String> getDialectUpdateCandidates() {
+  public @Nullable List</* dialect code */ String> getDialectUpdateCandidates() {
     return null;
   }
 
@@ -93,7 +93,7 @@ public class MultiAzClusterPgDialect extends PgDialect implements MultiAzCluster
   }
 
   @Override
-  public @Nullable Pair<String, String> getHostId(Connection connection) throws SQLException {
+  public @Nullable Pair<@Nullable String, @Nullable String> getHostId(Connection connection) throws SQLException {
     return this.dialectUtils.getInstanceId(connection, INSTANCE_ID_QUERY);
   }
 

--- a/wrapper/src/main/java/software/amazon/jdbc/dialect/MysqlDialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/dialect/MysqlDialect.java
@@ -81,7 +81,7 @@ public class MysqlDialect implements Dialect {
   }
 
   @Override
-  public List<String> getDialectUpdateCandidates() {
+  public @Nullable List<String> getDialectUpdateCandidates() {
     return dialectUpdateCandidates;
   }
 
@@ -121,7 +121,7 @@ public class MysqlDialect implements Dialect {
   }
 
   @Override
-  public @Nullable Pair<String, String> getHostId(Connection connection) throws SQLException {
+  public @Nullable Pair<@Nullable String, @Nullable String> getHostId(Connection connection) throws SQLException {
     return this.dialectUtils.getInstanceId(connection, HOST_ID_QUERY);
   }
 

--- a/wrapper/src/main/java/software/amazon/jdbc/dialect/PgDialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/dialect/PgDialect.java
@@ -72,7 +72,7 @@ public class PgDialect implements Dialect {
   }
 
   @Override
-  public List<String> getDialectUpdateCandidates() {
+  public @Nullable List<String> getDialectUpdateCandidates() {
     return dialectUpdateCandidates;
   }
 
@@ -118,7 +118,7 @@ public class PgDialect implements Dialect {
   }
 
   @Override
-  public @Nullable Pair<String, String> getHostId(Connection connection) throws SQLException {
+  public @Nullable Pair<@Nullable String, @Nullable String> getHostId(Connection connection) throws SQLException {
     return this.dialectUtils.getInstanceId(connection, HOST_ID_QUERY);
   }
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/dialect/RdsMysqlDialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/dialect/RdsMysqlDialect.java
@@ -105,7 +105,7 @@ public class RdsMysqlDialect extends MysqlDialect implements BlueGreenDialect {
   }
 
   @Override
-  public @Nullable Pair<String, String> getHostId(Connection connection) throws SQLException {
+  public @Nullable Pair<@Nullable String, @Nullable String> getHostId(Connection connection) throws SQLException {
     return this.dialectUtils.getInstanceId(connection, INSTANCE_ID_QUERY);
   }
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/dialect/RdsPgDialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/dialect/RdsPgDialect.java
@@ -95,7 +95,7 @@ public class RdsPgDialect extends PgDialect implements BlueGreenDialect {
   }
 
   @Override
-  public @Nullable Pair<String, String> getHostId(Connection connection) throws SQLException {
+  public @Nullable Pair<@Nullable String, @Nullable String> getHostId(Connection connection) throws SQLException {
     return this.dialectUtils.getInstanceId(connection, INSTANCE_ID_QUERY);
   }
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/dialect/UnknownDialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/dialect/UnknownDialect.java
@@ -67,12 +67,12 @@ public class UnknownDialect implements Dialect {
   }
 
   @Override
-  public String getHostAliasQuery() {
+  public @Nullable String getHostAliasQuery() {
     return null;
   }
 
   @Override
-  public String getServerVersionQuery() {
+  public @Nullable String getServerVersionQuery() {
     return null;
   }
 
@@ -83,7 +83,7 @@ public class UnknownDialect implements Dialect {
   }
 
   @Override
-  public @Nullable Pair<String, String> getHostId(Connection connection) throws SQLException {
+  public @Nullable Pair<@Nullable String, @Nullable String> getHostId(Connection connection) throws SQLException {
     throw new UnsupportedOperationException(
         "Unable to gather host id, connected to unknown DB type.");
   }

--- a/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/AbstractMonitoringConnectionHandler.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/AbstractMonitoringConnectionHandler.java
@@ -56,11 +56,15 @@ public abstract class AbstractMonitoringConnectionHandler<P> implements Monitori
   protected final @Nullable Runnable upgradeReadyNotifier;
 
   protected int currentPriorityIndex = -1;
-  protected volatile Future<?> upgradeFuture = null;
-  protected volatile HostSpec upgradeConnectedHost = null;
+  protected volatile @Nullable Future<?> upgradeFuture = null;
+  protected volatile @Nullable HostSpec upgradeConnectedHost = null;
   // A single long-lived executor for async upgrade attempts, created lazily on first use and shut down on close.
-  protected ExecutorService upgradeExecutor = null;
+  protected @Nullable ExecutorService upgradeExecutor = null;
 
+  // Publishing `this` to the AtomicConnection/LazyCleaner during construction is safe here: the cleaner only
+  // dereferences the referent for reachability tracking, not for state, so escape of the partially-initialized
+  // instance cannot observe uninitialized fields.
+  @SuppressWarnings({"argument", "assignment"})
   protected AbstractMonitoringConnectionHandler(
       final AtomicConnection monitoringConnection,
       final PluginService pluginService,
@@ -169,7 +173,7 @@ public abstract class AbstractMonitoringConnectionHandler<P> implements Monitori
   public @Nullable HostSpec acceptConnections(
       Map<HostSpec, AtomicConnection> connections,
       @Nullable HostSpec writerHostSpec,
-      List<HostSpec> topology) {
+      @Nullable List<HostSpec> topology) {
 
     if (connections == null || connections.isEmpty()) {
       return null;
@@ -199,7 +203,12 @@ public abstract class AbstractMonitoringConnectionHandler<P> implements Monitori
       return null;
     }
 
-    final AtomicConnection bestAtomic = connections.get(bestHost);
+    final @Nullable AtomicConnection bestAtomic = connections.get(bestHost);
+    if (bestAtomic == null) {
+      // bestHost was selected from connections' keys above; a null here could only arise from concurrent
+      // removal, in which case there is no connection to adopt.
+      return null;
+    }
     final Connection bestConn = bestAtomic.get();
     // Detach from the AtomicConnection so it doesn't close the connection when cleaned up.
     bestAtomic.set(null, false);
@@ -282,14 +291,16 @@ public abstract class AbstractMonitoringConnectionHandler<P> implements Monitori
         return;
       }
 
-      if (this.upgradeExecutor == null) {
-        this.upgradeExecutor = ExecutorFactory.newSingleThreadExecutor(getUpgradeThreadName());
+      ExecutorService executor = this.upgradeExecutor;
+      if (executor == null) {
+        executor = ExecutorFactory.newSingleThreadExecutor(getUpgradeThreadName());
+        this.upgradeExecutor = executor;
       }
       final int candidateCount = candidates.size();
       LOGGER.finest(() -> Messages.get(
           "ClusterTopologyMonitorImpl.upgradeTaskSubmitted",
           new Object[]{candidateCount}));
-      this.upgradeFuture = this.upgradeExecutor.submit(() -> {
+      this.upgradeFuture = executor.submit(() -> {
         for (HostSpec candidate : candidates) {
           if (Thread.currentThread().isInterrupted()) {
             return;

--- a/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/ClusterTopologyMonitor.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/ClusterTopologyMonitor.java
@@ -19,6 +19,7 @@ package software.amazon.jdbc.hostlistprovider;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.concurrent.TimeoutException;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import software.amazon.jdbc.HostSpec;
 import software.amazon.jdbc.util.events.EventSubscriber;
 import software.amazon.jdbc.util.monitoring.Monitor;
@@ -27,6 +28,6 @@ public interface ClusterTopologyMonitor extends Monitor, EventSubscriber {
 
   boolean canDispose();
 
-  List<HostSpec> forceRefresh(final boolean verifyTopology, final long timeoutMs)
+  @Nullable List<HostSpec> forceRefresh(final boolean verifyTopology, final long timeoutMs)
       throws SQLException, TimeoutException;
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/ClusterTopologyMonitorImpl.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/ClusterTopologyMonitorImpl.java
@@ -81,7 +81,7 @@ public class ClusterTopologyMonitorImpl extends AbstractMonitor
   private static final Random random = new Random();
   private static final long STABLE_TOPOLOGIES_DURATION_NANO = TimeUnit.SECONDS.toNanos(15);
 
-  protected final AtomicReference<HostSpec> writerHostSpec = new AtomicReference<>(null);
+  protected final AtomicReference<@Nullable HostSpec> writerHostSpec = new AtomicReference<>(null);
   /**
    * The last writer we believed to be the cluster's writer, retained even after {@link #writerHostSpec} is
    * cleared on errors. Used by panic-mode node threads as a baseline for writer-change detection.
@@ -95,8 +95,9 @@ public class ClusterTopologyMonitorImpl extends AbstractMonitor
 
   protected final ResourceLock nodeExecutorLock = new ResourceLock();
   protected final AtomicBoolean nodeThreadsStop = new AtomicBoolean(false);
-  protected final AtomicReference<HostSpec> nodeThreadsWriterHostSpec = new AtomicReference<>(null);
-  protected final AtomicReference<List<HostSpec>> nodeThreadsLatestTopology = new AtomicReference<>(null);
+  protected final AtomicReference<@Nullable HostSpec> nodeThreadsWriterHostSpec = new AtomicReference<>(null);
+  protected final AtomicReference<@Nullable List<HostSpec>> nodeThreadsLatestTopology =
+      new AtomicReference<>(null);
   // Stores connections opened by node monitoring threads, keyed by HostSpec.
   // These connections are harvested by the main loop when panic mode resolves and offered to the
   // connection handler so that monitoring can use the most-preferred one without re-opening connections.
@@ -110,8 +111,9 @@ public class ClusterTopologyMonitorImpl extends AbstractMonitor
   protected long stableTopologiesStartNano;
   // When comparing topologies, we don't want to check HostSpec.weight, which is used in HostSpec#equals. We will use
   // this function to compare the other fields.
-  protected Function<HostSpec, List<Object>> hostSpecExtractor =
-      host -> Arrays.asList(host.getHost(), host.getPort(), host.getAvailability(), host.getRole());
+  protected Function<HostSpec, List<@Nullable Object>> hostSpecExtractor =
+      host -> Arrays.<@Nullable Object>asList(
+          host.getHost(), host.getPort(), host.getAvailability(), host.getRole());
 
   protected final long refreshRateNano;
   protected final long highRefreshRateNano;
@@ -122,12 +124,15 @@ public class ClusterTopologyMonitorImpl extends AbstractMonitor
   protected final HostSpec initialHostSpec;
   protected final HostSpec instanceTemplate;
 
-  protected ExecutorService nodeExecutorService = null;
+  protected @Nullable ExecutorService nodeExecutorService = null;
   protected long highRefreshRateEndTimeNano = 0;
   protected String clusterId;
   protected boolean logUnclosedConnections = false;
   protected MonitoringConnectionHandler connectionHandler;
 
+  // Publishing `this` to the AtomicConnection/LazyCleaner during construction is safe here: the cleaner only
+  // tracks the referent for reachability, it does not read the partially-initialized instance's state.
+  @SuppressWarnings({"argument", "assignment"})
   public ClusterTopologyMonitorImpl(
       final FullServicesContainer servicesContainer,
       final TopologyUtils topologyUtils,
@@ -156,9 +161,12 @@ public class ClusterTopologyMonitorImpl extends AbstractMonitor
         .filter(p -> p.startsWith(MONITORING_PROPERTY_PREFIX))
         .forEach(
             p -> {
-              this.monitoringProperties.put(
-                  p.substring(MONITORING_PROPERTY_PREFIX.length()),
-                  this.properties.getProperty(p));
+              // p comes from stringPropertyNames(), so getProperty(p) is non-null; guard keeps the checker happy
+              // and preserves behavior (a missing value is simply not copied).
+              final String value = this.properties.getProperty(p);
+              if (value != null) {
+                this.monitoringProperties.put(p.substring(MONITORING_PROPERTY_PREFIX.length()), value);
+              }
               this.monitoringProperties.remove(p);
             });
 
@@ -191,7 +199,7 @@ public class ClusterTopologyMonitorImpl extends AbstractMonitor
   }
 
   @Override
-  public List<HostSpec> forceRefresh(final boolean verifyTopology, final long timeoutMs)
+  public @Nullable List<HostSpec> forceRefresh(final boolean verifyTopology, final long timeoutMs)
       throws SQLException, TimeoutException {
 
     final long currentTimeNano = System.nanoTime();
@@ -209,9 +217,9 @@ public class ClusterTopologyMonitorImpl extends AbstractMonitor
     }
   }
 
-  protected List<HostSpec> waitForTopologyUpdate(final long timeoutMs) throws TimeoutException {
-    List<HostSpec> currentHosts = getStoredHosts();
-    List<HostSpec> latestHosts;
+  protected @Nullable List<HostSpec> waitForTopologyUpdate(final long timeoutMs) throws TimeoutException {
+    @Nullable List<HostSpec> currentHosts = getStoredHosts();
+    @Nullable List<HostSpec> latestHosts;
 
     synchronized (this.requestToUpdateTopology) {
       this.requestToUpdateTopology.set(true);
@@ -249,7 +257,7 @@ public class ClusterTopologyMonitorImpl extends AbstractMonitor
     return latestHosts;
   }
 
-  protected List<HostSpec> getStoredHosts() {
+  protected @Nullable List<HostSpec> getStoredHosts() {
     Topology topology =
         this.servicesContainer.getStorageService().get(Topology.class, this.clusterId, false);
     return topology == null ? null : topology.getHosts();
@@ -324,21 +332,7 @@ public class ClusterTopologyMonitorImpl extends AbstractMonitor
                 // A list is used to store the exception since lambdas require references to outer variables to be
                 // final. This allows us to identify if an error occurred while creating the node monitoring worker.
                 final List<Exception> exceptionList = new ArrayList<>();
-                this.submittedNodes.computeIfAbsent(hostSpec.getHost(),
-                    (key) -> {
-                      final ExecutorService nodeExecutorServiceCopy = this.nodeExecutorService;
-                      if (nodeExecutorServiceCopy != null) {
-                        try {
-                          this.nodeExecutorService.submit(
-                              this.getNodeMonitoringWorker(
-                                  hostSpec, baselineWriter, someRegionsInaccessible));
-                        } catch (SQLException e) {
-                          exceptionList.add(e);
-                          return null;
-                        }
-                      }
-                      return true;
-                    });
+                this.submitNodeMonitorIfAbsent(hostSpec, baselineWriter, someRegionsInaccessible, exceptionList);
 
                 if (!exceptionList.isEmpty()) {
                   throw exceptionList.get(0);
@@ -395,19 +389,7 @@ public class ClusterTopologyMonitorImpl extends AbstractMonitor
                   // A list is used to store the exception since lambdas require references to outer variables to be
                   // final. This allows us to identify if an error occurred while creating the node monitoring worker.
                   final List<Exception> exceptionList = new ArrayList<>();
-                  this.submittedNodes.computeIfAbsent(hostSpec.getHost(),
-                      (key) -> {
-                        try {
-                          this.nodeExecutorService.submit(
-                              this.getNodeMonitoringWorker(
-                                  hostSpec, baselineWriter, someRegionsInaccessible));
-                        } catch (SQLException e) {
-                          exceptionList.add(e);
-                          return null;
-                        }
-
-                        return true;
-                      });
+                  this.submitNodeMonitorIfAbsent(hostSpec, baselineWriter, someRegionsInaccessible, exceptionList);
 
                   if (!exceptionList.isEmpty()) {
                     throw exceptionList.get(0);
@@ -506,9 +488,13 @@ public class ClusterTopologyMonitorImpl extends AbstractMonitor
     // Only check hosts we are actually monitoring. Subclasses may filter the topology (e.g., GDB filters out
     // hosts in non-accessible regions). Without this filter, hosts that we never spawned node workers for would
     // perpetually appear "incomplete" and prevent the stable-topology detection from ever succeeding.
-    List<String> readerIds = this.filterHostsForNodeMonitoring(latestHosts).stream()
-        .map(HostSpec::getHostId).collect(Collectors.toList());
-    for (String id : readerIds) {
+    for (HostSpec host : this.filterHostsForNodeMonitoring(latestHosts)) {
+      final String id = host.getHostId();
+      if (id == null) {
+        // A monitored host without a host id cannot be tracked in the completedOneCycle map (which is keyed by
+        // host id and cannot hold null keys), so there is nothing to check for it.
+        continue;
+      }
       Boolean completedOneCycle = this.completedOneCycle.getOrDefault(id, Boolean.FALSE);
       if (!completedOneCycle) {
         // Not all reader monitors have completed a cycle. We shouldn't conclude that reader topologies are stable until
@@ -643,17 +629,20 @@ public class ClusterTopologyMonitorImpl extends AbstractMonitor
 
       try (ResourceLock ignored = this.nodeExecutorLock.obtain()) {
 
-        if (this.nodeExecutorService == null) {
+        // Capture the field into a local so its non-null narrowing survives the shutdown calls below (the lock
+        // guarantees no other thread swaps the executor while we operate on it).
+        final ExecutorService svc = this.nodeExecutorService;
+        if (svc == null) {
           return;
         }
 
-        if (!this.nodeExecutorService.isShutdown()) {
-          this.nodeExecutorService.shutdown();
+        if (!svc.isShutdown()) {
+          svc.shutdown();
         }
 
         try {
-          if (!this.nodeExecutorService.awaitTermination(30, TimeUnit.SECONDS)) {
-            this.nodeExecutorService.shutdownNow();
+          if (!svc.awaitTermination(30, TimeUnit.SECONDS)) {
+            svc.shutdownNow();
           }
         } catch (InterruptedException e) {
           // Do nothing.
@@ -706,6 +695,35 @@ public class ClusterTopologyMonitorImpl extends AbstractMonitor
     return hosts;
   }
 
+  /**
+   * Submits a node-monitoring worker for {@code hostSpec} unless one has already been submitted for that host.
+   * Any {@link SQLException} raised while creating the worker is collected into {@code exceptionList} and the host
+   * is left unsubmitted so it can be retried on a later cycle.
+   */
+  // ConcurrentHashMap.computeIfAbsent permits the mapping function to return null (meaning "record no mapping"),
+  // but the annotated JDK stub types the function as returning @NonNull; suppress that stub asymmetry here.
+  @SuppressWarnings("return")
+  protected void submitNodeMonitorIfAbsent(
+      final HostSpec hostSpec,
+      final @Nullable HostSpec baselineWriter,
+      final boolean someRegionsInaccessible,
+      final List<Exception> exceptionList) {
+    this.submittedNodes.computeIfAbsent(hostSpec.getHost(),
+        (key) -> {
+          final @Nullable ExecutorService nodeExecutorServiceCopy = this.nodeExecutorService;
+          if (nodeExecutorServiceCopy != null) {
+            try {
+              nodeExecutorServiceCopy.submit(
+                  this.getNodeMonitoringWorker(hostSpec, baselineWriter, someRegionsInaccessible));
+            } catch (SQLException e) {
+              exceptionList.add(e);
+              return null;
+            }
+          }
+          return true;
+        });
+  }
+
   protected Runnable getNodeMonitoringWorker(
       final HostSpec hostSpec,
       final @Nullable HostSpec writerHostSpec,
@@ -721,7 +739,7 @@ public class ClusterTopologyMonitorImpl extends AbstractMonitor
         this.logUnclosedConnections);
   }
 
-  protected List<HostSpec> openAnyConnectionAndUpdateTopology() {
+  protected @Nullable List<HostSpec> openAnyConnectionAndUpdateTopology() {
     if (this.monitoringConnection.get() == null) {
 
       Connection conn;
@@ -751,19 +769,19 @@ public class ClusterTopologyMonitorImpl extends AbstractMonitor
             this.lastKnownWriterHostSpec = this.initialHostSpec;
             LOGGER.finest(() -> Messages.get(
                 "ClusterTopologyMonitorImpl.writerMonitoringConnection",
-                new Object[] {this.writerHostSpec.get().getHost()}));
+                new Object[] {this.initialHostSpec.getHost()}));
           } else {
-            final Pair<String, String> pair =
+            final @Nullable Pair<@Nullable String, @Nullable String> pair =
                 this.servicesContainer.getPluginService().getDialect().getHostId(conn);
             if (pair != null) {
-              HostSpec instanceTemplate = this.getInstanceTemplate(pair.getValue2(), conn);
-              HostSpec writerHost = this.topologyUtils.createHost(
+              final HostSpec instanceTemplate = this.getInstanceTemplate(pair.getValue2(), conn);
+              final HostSpec writerHost = this.topologyUtils.createHost(
                   pair.getValue1(), pair.getValue2(), true, 0, null, this.initialHostSpec, instanceTemplate);
               this.writerHostSpec.set(writerHost);
               this.lastKnownWriterHostSpec = writerHost;
               LOGGER.finest(() -> Messages.get(
                   "ClusterTopologyMonitorImpl.writerMonitoringConnection",
-                  new Object[] {this.writerHostSpec.get().getHost()}));
+                  new Object[] {writerHost.getHost()}));
             }
           }
         } catch (SQLException ex) {
@@ -790,7 +808,7 @@ public class ClusterTopologyMonitorImpl extends AbstractMonitor
   }
 
   // Note: even though the parameters are not used here, they may be used in subclasses overriding this method.
-  protected HostSpec getInstanceTemplate(String nodeId, Connection connection) throws SQLException {
+  protected HostSpec getInstanceTemplate(@Nullable String nodeId, Connection connection) throws SQLException {
     return this.instanceTemplate;
   }
 
@@ -828,7 +846,7 @@ public class ClusterTopologyMonitorImpl extends AbstractMonitor
     } while (!this.requestToUpdateTopology.get() && System.nanoTime() < end && !this.stop.get());
   }
 
-  protected @Nullable List<HostSpec> fetchTopologyAndUpdateCache(final Connection connection) {
+  protected @Nullable List<HostSpec> fetchTopologyAndUpdateCache(final @Nullable Connection connection) {
     if (connection == null) {
       return null;
     }
@@ -851,7 +869,7 @@ public class ClusterTopologyMonitorImpl extends AbstractMonitor
     return null;
   }
 
-  protected List<HostSpec> queryForTopology(Connection connection) throws SQLException {
+  protected @Nullable List<HostSpec> queryForTopology(Connection connection) throws SQLException {
     return this.topologyUtils.queryForTopology(connection, this.initialHostSpec, this.instanceTemplate);
   }
 
@@ -860,7 +878,8 @@ public class ClusterTopologyMonitorImpl extends AbstractMonitor
       return;
     }
     for (HostSpec host : hosts) {
-      host.setAvailability(this.readerTopologiesById.containsKey(host.getHostId())
+      final String hostId = host.getHostId();
+      host.setAvailability(hostId != null && this.readerTopologiesById.containsKey(hostId)
           ? HostAvailability.AVAILABLE
           : HostAvailability.NOT_AVAILABLE);
     }
@@ -908,6 +927,9 @@ public class ClusterTopologyMonitorImpl extends AbstractMonitor
     protected int connectionAttempts = 0;
     protected AtomicConnection connection;
 
+    // Publishing `this` to the AtomicConnection/LazyCleaner during construction is safe here: the cleaner only
+    // tracks the referent for reachability, it does not read the partially-initialized worker's state.
+    @SuppressWarnings({"argument", "assignment"})
     public NodeMonitoringWorker(
         final FullServicesContainer servicesContainer,
         final ClusterTopologyMonitorImpl monitor,
@@ -944,8 +966,8 @@ public class ClusterTopologyMonitorImpl extends AbstractMonitor
                 // It's a network issue that's expected during a cluster failover.
                 // We will try again on the next iteration.
                 TimeUnit.MILLISECONDS.sleep(100);
-                this.monitor.completedOneCycle.put(this.hostSpec.getHostId(), Boolean.TRUE);
-                this.monitor.readerTopologiesById.remove(this.hostSpec.getHostId());
+                this.markCycleCompleted();
+                this.removeReaderTopology();
                 continue;
               } else if (this.servicesContainer.getPluginService().isLoginException(
                     ex, this.servicesContainer.getPluginService().getTargetDriverDialect())) {
@@ -955,18 +977,19 @@ public class ClusterTopologyMonitorImpl extends AbstractMonitor
                 // It might be some transient error. Let's try again.
                 //  If the error repeats, we will try again after a longer delay.
                 TimeUnit.MILLISECONDS.sleep(this.calculateBackoffWithJitter(this.connectionAttempts++));
-                this.monitor.completedOneCycle.put(this.hostSpec.getHostId(), Boolean.TRUE);
-                this.monitor.readerTopologiesById.remove(this.hostSpec.getHostId());
+                this.markCycleCompleted();
+                this.removeReaderTopology();
                 continue;
               }
             }
           }
 
-          if (this.connection.get() != null) {
+          final Connection checkConn = this.connection.get();
+          if (checkConn != null) {
             boolean isWriter = false;
             try {
               // Use topology metadata to check on the currently connected instance
-              isWriter = this.monitor.topologyUtils.isWriterInstance(this.connection.get());
+              isWriter = this.monitor.topologyUtils.isWriterInstance(checkConn);
             } catch (SQLSyntaxErrorException ex) {
               LOGGER.severe(() -> Messages.get(
                   "NodeMonitoringThread.invalidWriterQuery",
@@ -979,14 +1002,16 @@ public class ClusterTopologyMonitorImpl extends AbstractMonitor
             if (isWriter) {
               try {
                 // Check if connected instance is read_only
-                if (this.servicesContainer.getPluginService().getHostRole(this.connection.get()) != HostRole.WRITER) {
+                final Connection roleConn = this.connection.get();
+                if (roleConn != null
+                    && this.servicesContainer.getPluginService().getHostRole(roleConn) != HostRole.WRITER) {
                   // The first connection after failover may be stale.
                   isWriter = false;
                 }
               } catch (SQLException e) {
                 // Invalid connection, retry.
-                this.monitor.completedOneCycle.put(this.hostSpec.getHostId(), Boolean.TRUE);
-                this.monitor.readerTopologiesById.remove(this.hostSpec.getHostId());
+                this.markCycleCompleted();
+                this.removeReaderTopology();
                 continue;
               }
             }
@@ -1021,7 +1046,7 @@ public class ClusterTopologyMonitorImpl extends AbstractMonitor
             }
           }
 
-          this.monitor.completedOneCycle.put(this.hostSpec.getHostId(), Boolean.TRUE);
+          this.markCycleCompleted();
           TimeUnit.MILLISECONDS.sleep(100);
         }
       } catch (InterruptedException ex) {
@@ -1030,8 +1055,8 @@ public class ClusterTopologyMonitorImpl extends AbstractMonitor
         LOGGER.log(Level.SEVERE, ex, () -> Messages.get("NodeMonitoringThread.unhandledException"));
         throw ex;
       } finally {
-        this.monitor.completedOneCycle.put(this.hostSpec.getHostId(), Boolean.TRUE);
-        this.monitor.readerTopologiesById.remove(this.hostSpec.getHostId());
+        this.markCycleCompleted();
+        this.removeReaderTopology();
 
         // Hand off any live connection to the main loop via a fresh AtomicConnection owned by the monitor.
         // We can't share `this.connection` directly: when this worker is cleaned up, the underlying connection
@@ -1058,7 +1083,25 @@ public class ClusterTopologyMonitorImpl extends AbstractMonitor
       }
     }
 
-    private void readerThreadFetchTopology(final Connection connection, final @Nullable HostSpec writerHostSpec) {
+    // The bookkeeping maps are keyed by host id. A monitored topology host always has a non-null host id
+    // (a null id could not be stored in the ConcurrentHashMap anyway); the guard keeps the checker satisfied
+    // and turns the impossible null case into a no-op instead of a NullPointerException.
+    private void markCycleCompleted() {
+      final String hostId = this.hostSpec.getHostId();
+      if (hostId != null) {
+        this.monitor.completedOneCycle.put(hostId, Boolean.TRUE);
+      }
+    }
+
+    private void removeReaderTopology() {
+      final String hostId = this.hostSpec.getHostId();
+      if (hostId != null) {
+        this.monitor.readerTopologiesById.remove(hostId);
+      }
+    }
+
+    private void readerThreadFetchTopology(
+        final @Nullable Connection connection, final @Nullable HostSpec writerHostSpec) {
       if (connection == null) {
         return;
       }
@@ -1075,7 +1118,10 @@ public class ClusterTopologyMonitorImpl extends AbstractMonitor
 
       // Share this topology so that the main monitoring thread can adjust the node monitoring threads.
       this.monitor.nodeThreadsLatestTopology.set(hosts);
-      this.monitor.readerTopologiesById.put(this.hostSpec.getHostId(), hosts);
+      final String readerHostId = this.hostSpec.getHostId();
+      if (readerHostId != null) {
+        this.monitor.readerTopologiesById.put(readerHostId, hosts);
+      }
 
       if (this.writerChanged) {
         this.monitor.updateHostsAvailability(hosts);
@@ -1129,7 +1175,12 @@ public class ClusterTopologyMonitorImpl extends AbstractMonitor
     return STABLE_TOPOLOGIES_DURATION_NANO;
   }
 
+  // Checker Framework: snapshot values are intentionally nullable, but the
+  // StateSnapshotProvider contract types them as Pair<String, Object> (non-null Object).
+  // Fixing this properly means widening that interface to Pair<String, @Nullable Object>
+  // across all ~25 implementers - out of scope for this change. Suppress locally.
   @Override
+  @SuppressWarnings("type.arguments.not.inferred")
   public List<Pair<String, Object>> getSnapshotState() {
     List<Pair<String, Object>> state = new ArrayList<>();
     state.add(Pair.create("monitoringConnection",

--- a/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/GdbMonitoringConnectionHandler.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/GdbMonitoringConnectionHandler.java
@@ -58,7 +58,7 @@ public class GdbMonitoringConnectionHandler
   }
 
   protected final RdsUtils rdsUtils = new RdsUtils();
-  protected final AtomicReference<HostSpec> writerHostSpec;
+  protected final AtomicReference<@Nullable HostSpec> writerHostSpec;
 
   public GdbMonitoringConnectionHandler(
       final AtomicConnection monitoringConnection,
@@ -66,7 +66,7 @@ public class GdbMonitoringConnectionHandler
       final TopologyUtils topologyUtils,
       final Properties properties,
       final Properties monitoringProperties,
-      final AtomicReference<HostSpec> writerHostSpec) {
+      final AtomicReference<@Nullable HostSpec> writerHostSpec) {
     this(monitoringConnection, pluginService, topologyUtils, properties, monitoringProperties, writerHostSpec, null);
   }
 
@@ -76,7 +76,7 @@ public class GdbMonitoringConnectionHandler
       final TopologyUtils topologyUtils,
       final Properties properties,
       final Properties monitoringProperties,
-      final AtomicReference<HostSpec> writerHostSpec,
+      final AtomicReference<@Nullable HostSpec> writerHostSpec,
       final @Nullable Runnable upgradeReadyNotifier) {
     super(
         monitoringConnection,
@@ -98,7 +98,7 @@ public class GdbMonitoringConnectionHandler
   public @Nullable HostSpec acceptConnections(
       Map<HostSpec, AtomicConnection> connections,
       @Nullable HostSpec writerHostSpecOverride,
-      List<HostSpec> topology) {
+      @Nullable List<HostSpec> topology) {
     if (connections == null || connections.isEmpty()) {
       return null;
     }
@@ -129,7 +129,12 @@ public class GdbMonitoringConnectionHandler
       return null;
     }
 
-    final AtomicConnection bestAtomic = connections.get(bestHost);
+    final @Nullable AtomicConnection bestAtomic = connections.get(bestHost);
+    if (bestAtomic == null) {
+      // bestHost was selected from connections' keys above; a null here could only arise from concurrent
+      // removal, in which case there is no connection to adopt.
+      return null;
+    }
     final Connection bestConn = bestAtomic.get();
     bestAtomic.set(null, false);
     this.monitoringConnection.set(bestConn);
@@ -157,7 +162,12 @@ public class GdbMonitoringConnectionHandler
     return "gatmu";
   }
 
+  // Checker Framework: snapshot values are intentionally nullable, but the
+  // StateSnapshotProvider contract types them as Pair<String, Object> (non-null Object).
+  // Fixing this properly means widening that interface to Pair<String, @Nullable Object>
+  // across all ~25 implementers - out of scope for this change. Suppress locally.
   @Override
+  @SuppressWarnings("type.arguments.not.inferred")
   protected @Nullable List<Pair<String, Object>> getAdditionalSnapshotState() {
     final List<Pair<String, Object>> extra = new ArrayList<>();
     extra.add(Pair.create("primaryRegion", getPrimaryRegion()));

--- a/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/GlobalAuroraHostListProvider.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/GlobalAuroraHostListProvider.java
@@ -21,6 +21,7 @@ import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import software.amazon.jdbc.AwsWrapperProperty;
 import software.amazon.jdbc.HostSpec;
 import software.amazon.jdbc.PropertyDefinition;
@@ -84,7 +85,7 @@ public class GlobalAuroraHostListProvider extends RdsHostListProvider {
   }
 
   @Override
-  public List<HostSpec> getCurrentTopology(Connection conn, HostSpec initialHostSpec) throws SQLException {
+  public @Nullable List<HostSpec> getCurrentTopology(Connection conn, HostSpec initialHostSpec) throws SQLException {
     init();
     return this.topologyUtils.queryForTopology(conn, initialHostSpec, this.instanceTemplatesByRegion);
   }

--- a/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/GlobalAuroraTopologyMonitor.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/GlobalAuroraTopologyMonitor.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import software.amazon.jdbc.HostSpec;
 import software.amazon.jdbc.util.AccessibleRegions;
 import software.amazon.jdbc.util.FullServicesContainer;
@@ -43,7 +44,7 @@ public class GlobalAuroraTopologyMonitor extends ClusterTopologyMonitorImpl {
 
   protected final Map<String, HostSpec> instanceTemplatesByRegion;
   protected final GlobalAuroraTopologyUtils topologyUtils;
-  protected final Set<String> accessibleRegions;
+  protected final @Nullable Set<String> accessibleRegions;
   protected final RdsUtils rdsUtils = new RdsUtils();
 
   public GlobalAuroraTopologyMonitor(
@@ -72,10 +73,10 @@ public class GlobalAuroraTopologyMonitor extends ClusterTopologyMonitorImpl {
   }
 
   @Override
-  protected HostSpec getInstanceTemplate(String instanceId, Connection connection) throws SQLException {
+  protected HostSpec getInstanceTemplate(@Nullable String instanceId, Connection connection) throws SQLException {
     String region = this.topologyUtils.getRegion(instanceId, connection);
     if (!StringUtils.isNullOrEmpty(region)) {
-      final HostSpec instanceTemplate = this.instanceTemplatesByRegion.get(region);
+      final @Nullable HostSpec instanceTemplate = this.instanceTemplatesByRegion.get(region);
       if (instanceTemplate == null) {
         throw new SQLException(
             Messages.get("GlobalAuroraTopologyMonitor.cannotFindRegionTemplate", new Object[] {region}));
@@ -88,12 +89,12 @@ public class GlobalAuroraTopologyMonitor extends ClusterTopologyMonitorImpl {
   }
 
   @Override
-  protected List<HostSpec> queryForTopology(Connection connection) throws SQLException {
+  protected @Nullable List<HostSpec> queryForTopology(Connection connection) throws SQLException {
     return this.topologyUtils.queryForTopology(connection, this.initialHostSpec, this.instanceTemplatesByRegion);
   }
 
   @Override
-  protected List<HostSpec> openAnyConnectionAndUpdateTopology() {
+  protected @Nullable List<HostSpec> openAnyConnectionAndUpdateTopology() {
     if (this.accessibleRegions != null) {
       final String region = this.rdsUtils.getRdsRegion(this.initialHostSpec.getHost());
       if (region != null && !this.accessibleRegions.contains(region.toLowerCase(Locale.ROOT))) {
@@ -107,13 +108,14 @@ public class GlobalAuroraTopologyMonitor extends ClusterTopologyMonitorImpl {
 
   @Override
   protected List<HostSpec> filterHostsForNodeMonitoring(final List<HostSpec> hosts) {
-    if (this.accessibleRegions == null) {
+    final Set<String> regions = this.accessibleRegions;
+    if (regions == null) {
       return hosts;
     }
     return hosts.stream()
         .filter(host -> {
           final String region = this.rdsUtils.getRdsRegion(host.getHost());
-          return region != null && this.accessibleRegions.contains(region.toLowerCase(Locale.ROOT));
+          return region != null && regions.contains(region.toLowerCase(Locale.ROOT));
         })
         .collect(Collectors.toList());
   }

--- a/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/GlobalAuroraTopologyUtils.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/GlobalAuroraTopologyUtils.java
@@ -113,7 +113,8 @@ public class GlobalAuroraTopologyUtils extends AuroraTopologyUtils {
     // Calculate weight based on node lag in time and CPU utilization.
     final long weight = Math.round(nodeLag) * 100L;
 
-    final HostSpec instanceTemplate = instanceTemplatesByRegion.get(awsRegion);
+    final HostSpec instanceTemplate =
+        awsRegion == null ? null : instanceTemplatesByRegion.get(awsRegion);
     if (instanceTemplate == null) {
       throw new SQLException(Messages.get(
           "GlobalAuroraTopologyMonitor.cannotFindRegionTemplate", new Object[] {awsRegion}));
@@ -124,7 +125,7 @@ public class GlobalAuroraTopologyUtils extends AuroraTopologyUtils {
         Timestamp.from(Instant.now()), initialHostSpec, instanceTemplate);
   }
 
-  public @Nullable String getRegion(String instanceId, Connection conn) throws SQLException {
+  public @Nullable String getRegion(@Nullable String instanceId, Connection conn) throws SQLException {
     try (final PreparedStatement stmt = conn.prepareStatement(this.dialect.getRegionByInstanceIdQuery())) {
       stmt.setString(1, instanceId);
       try (final ResultSet rs = stmt.executeQuery()) {
@@ -138,7 +139,8 @@ public class GlobalAuroraTopologyUtils extends AuroraTopologyUtils {
     return null;
   }
 
-  public Map<String, HostSpec> parseInstanceTemplates(String instanceTemplatesString, Consumer<String> hostValidator)
+  public Map<String, HostSpec> parseInstanceTemplates(
+      @Nullable String instanceTemplatesString, Consumer<String> hostValidator)
       throws SQLException {
     if (StringUtils.isNullOrEmpty(instanceTemplatesString)) {
       throw new SQLException(Messages.get("GlobalAuroraTopologyUtils.globalClusterInstanceHostPatternsRequired"));

--- a/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/HostListProvider.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/HostListProvider.java
@@ -20,6 +20,7 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.concurrent.TimeoutException;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import software.amazon.jdbc.HostSpec;
 
 public interface HostListProvider {
@@ -34,7 +35,7 @@ public interface HostListProvider {
    * @return the topology information for the connected database.
    * @throws SQLException if an error occurs while attempting to acquire the database topology information.
    */
-  List<HostSpec> getCurrentTopology(Connection conn, HostSpec initialHostSpec) throws SQLException;
+  @Nullable List<HostSpec> getCurrentTopology(Connection conn, HostSpec initialHostSpec) throws SQLException;
 
   List<HostSpec> refresh() throws SQLException;
 
@@ -47,7 +48,7 @@ public interface HostListProvider {
    * @throws SQLException     if there's errors updating topology
    * @throws TimeoutException if topology update takes longer time than expected
    */
-  List<HostSpec> forceRefresh() throws SQLException, TimeoutException;
+  @Nullable List<HostSpec> forceRefresh() throws SQLException, TimeoutException;
 
   /**
    * Force a host list provider to update its topology information. Results will be returned when the topology is
@@ -63,7 +64,7 @@ public interface HostListProvider {
    * @throws SQLException     if there's errors updating topology
    * @throws TimeoutException if the timeout is hit
    */
-  List<HostSpec> forceRefresh(final boolean verifyTopology, final long timeoutMs)
+  @Nullable List<HostSpec> forceRefresh(final boolean verifyTopology, final long timeoutMs)
       throws SQLException, TimeoutException;
 
   String getClusterId() throws UnsupportedOperationException, SQLException;

--- a/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/MonitoringConnectionHandler.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/MonitoringConnectionHandler.java
@@ -61,7 +61,7 @@ public interface MonitoringConnectionHandler extends StateSnapshotProvider {
   @Nullable HostSpec acceptConnections(
       Map<HostSpec, AtomicConnection> connections,
       @Nullable HostSpec writerHostSpec,
-      List<HostSpec> topology);
+      @Nullable List<HostSpec> topology);
 
   /**
    * Non-blocking attempt to upgrade the monitoring connection to a higher-priority node.

--- a/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/MultiAzTopologyUtils.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/MultiAzTopologyUtils.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.logging.Logger;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import software.amazon.jdbc.HostSpec;
@@ -95,7 +96,7 @@ public class MultiAzTopologyUtils extends TopologyUtils {
     // The writer ID is only returned when connected to a reader, so if the query does not return a value, it
     // means we are connected to a writer
     try {
-      Pair<String, String> pair = this.dialect.getHostId(connection);
+      final @Nullable Pair<@Nullable String, @Nullable String> pair = this.dialect.getHostId(connection);
       if (pair != null) {
         return pair.getValue1();
       }
@@ -112,10 +113,13 @@ public class MultiAzTopologyUtils extends TopologyUtils {
       final HostSpec instanceTemplate,
       final @Nullable String writerId) throws SQLException {
 
-    String endpoint = rs.getString("endpoint"); // "instance-name.XYZ.us-west-2.rds.amazonaws.com"
-    String instanceName = endpoint.substring(0, endpoint.indexOf(".")); // "instance-name"
-    String hostId = rs.getString("id"); // "1034958454"
-    final boolean isWriter = hostId.equals(writerId);
+    final String endpoint = rs.getString("endpoint"); // "instance-name.XYZ.us-west-2.rds.amazonaws.com"
+    if (endpoint == null) {
+      throw new SQLException(Messages.get("MultiAzTopologyUtils.missingEndpoint"));
+    }
+    final String instanceName = endpoint.substring(0, endpoint.indexOf(".")); // "instance-name"
+    final String hostId = rs.getString("id"); // "1034958454"
+    final boolean isWriter = Objects.equals(hostId, writerId);
 
     return createHost(
         hostId, instanceName, isWriter, 0, Timestamp.from(Instant.now()), initialHostSpec, instanceTemplate);

--- a/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/RdsHostListProvider.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/RdsHostListProvider.java
@@ -141,7 +141,10 @@ public class RdsHostListProvider implements DynamicHostListProvider, CanReleaseR
     this.initialHostSpec = this.initialHostList.get(0);
     this.hostListProviderService.setInitialConnectionHostSpec(this.initialHostSpec);
 
-    this.clusterId = CLUSTER_ID.getString(this.properties);
+    final String configuredClusterId = CLUSTER_ID.getString(this.properties);
+    // CLUSTER_ID declares a non-null default ("1"), so getString never returns null here; the fallback
+    // matches that default and keeps clusterId non-null.
+    this.clusterId = configuredClusterId != null ? configuredClusterId : "1";
     HostSpecBuilder hostSpecBuilder = this.hostListProviderService.getHostSpecBuilder();
     String clusterInstancePattern = CLUSTER_INSTANCE_HOST_PATTERN.getString(this.properties);
     if (clusterInstancePattern != null) {
@@ -178,12 +181,12 @@ public class RdsHostListProvider implements DynamicHostListProvider, CanReleaseR
   }
 
   @Override
-  public List<HostSpec> getCurrentTopology(Connection conn, HostSpec initialHostSpec) throws SQLException {
+  public @Nullable List<HostSpec> getCurrentTopology(Connection conn, HostSpec initialHostSpec) throws SQLException {
     init();
     return this.topologyUtils.queryForTopology(conn, initialHostSpec, this.instanceTemplate);
   }
 
-  protected List<HostSpec> forceRefreshMonitor(boolean verifyTopology, long timeoutMs) throws SQLException {
+  protected @Nullable List<HostSpec> forceRefreshMonitor(boolean verifyTopology, long timeoutMs) throws SQLException {
     ClusterTopologyMonitor monitor = this.getOrCreateMonitor();
     try {
       return monitor.forceRefresh(verifyTopology, timeoutMs);
@@ -294,12 +297,12 @@ public class RdsHostListProvider implements DynamicHostListProvider, CanReleaseR
   }
 
   @Override
-  public List<HostSpec> forceRefresh() throws SQLException, TimeoutException {
+  public @Nullable List<HostSpec> forceRefresh() throws SQLException, TimeoutException {
     return this.forceRefresh(false, DEFAULT_TOPOLOGY_QUERY_TIMEOUT_MS);
   }
 
   @Override
-  public List<HostSpec> forceRefresh(final boolean verifyTopology, final long timeoutMs)
+  public @Nullable List<HostSpec> forceRefresh(final boolean verifyTopology, final long timeoutMs)
       throws SQLException, TimeoutException {
     init();
     if (!this.pluginService.isDialectConfirmed()) {

--- a/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/Topology.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/Topology.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import software.amazon.jdbc.HostSpec;
 import software.amazon.jdbc.util.Pair;
 import software.amazon.jdbc.util.StateSnapshotProvider;
@@ -41,7 +42,7 @@ public class Topology implements StateSnapshotProvider {
   }
 
   @Override
-  public boolean equals(Object obj) {
+  public boolean equals(final @Nullable Object obj) {
     if (this == obj) {
       return true;
     }
@@ -54,7 +55,12 @@ public class Topology implements StateSnapshotProvider {
     return Objects.equals(hosts, other.hosts);
   }
 
+  // Checker Framework: snapshot values are intentionally nullable, but the
+  // StateSnapshotProvider contract types them as Pair<String, Object> (non-null Object).
+  // Fixing this properly means widening that interface to Pair<String, @Nullable Object>
+  // across all ~25 implementers - out of scope for this change. Suppress locally.
   @Override
+  @SuppressWarnings("type.arguments.not.inferred")
   public List<Pair<String, Object>> getSnapshotState() {
     List<Pair<String, Object>> state = new ArrayList<>();
     for (HostSpec host : this.hosts) {

--- a/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/TopologyUtils.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/TopologyUtils.java
@@ -23,6 +23,7 @@ import java.sql.SQLException;
 import java.sql.SQLSyntaxErrorException;
 import java.sql.Statement;
 import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -156,11 +157,11 @@ public abstract class TopologyUtils {
    * @return a {@link HostSpec} representing the given information.
    */
   public HostSpec createHost(
-      String instanceId,
-      String instanceName,
+      final @Nullable String instanceId,
+      final @Nullable String instanceName,
       final boolean isWriter,
       final long weight,
-      final Timestamp lastUpdateTime,
+      final @Nullable Timestamp lastUpdateTime,
       final HostSpec initialHostSpec,
       final HostSpec instanceTemplate) {
     return createHost(instanceId, instanceName, isWriter, weight, null,
@@ -180,13 +181,13 @@ public abstract class TopologyUtils {
    * @return a {@link HostSpec} representing the given information.
    */
   public HostSpec createHost(
-      String instanceId,
-      String instanceName,
+      final @Nullable String instanceId,
+      @Nullable String instanceName,
       final boolean isWriter,
       final long weight,
-      final Float cpuPercent,
-      final Float lag,
-      final Timestamp lastUpdateTime,
+      final @Nullable Float cpuPercent,
+      final @Nullable Float lag,
+      final @Nullable Timestamp lastUpdateTime,
       final HostSpec initialHostSpec,
       final HostSpec instanceTemplate) {
     instanceName = instanceName == null ? "?" : instanceName;
@@ -194,6 +195,11 @@ public abstract class TopologyUtils {
     final int port = instanceTemplate.isPortSpecified()
         ? instanceTemplate.getPort()
         : (initialHostSpec == null ? HostSpec.NO_PORT : initialHostSpec.getPort());
+
+    // HostSpec.lastUpdateTime is non-null by contract; when a caller has no timestamp (null), fall back to
+    // "now" - the same fallback already used by callers that fail to read the timestamp from the result set.
+    final Timestamp resolvedLastUpdateTime =
+        lastUpdateTime == null ? Timestamp.from(Instant.now()) : lastUpdateTime;
 
     final HostSpec hostSpec = this.hostSpecBuilder
         .hostId(instanceId)
@@ -204,7 +210,7 @@ public abstract class TopologyUtils {
         .weight(weight)
         .cpuPercent(cpuPercent)
         .lagMs(lag)
-        .lastUpdateTime(lastUpdateTime)
+        .lastUpdateTime(resolvedLastUpdateTime)
         .build();
     return hostSpec;
   }

--- a/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/GenericTargetDriverDialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/GenericTargetDriverDialect.java
@@ -254,6 +254,11 @@ public class GenericTargetDriverDialect implements TargetDriverDialect {
     return ALLOWED_ON_CLOSED_METHODS;
   }
 
+  // The generic dialect cannot extract a driver-specific SQL state, so it always returns null.
+  // Callers guard the result (e.g. StringUtils.isNullOrEmpty), so the null return is safe; the
+  // TargetDriverDialect.getSQLState contract is kept non-null in this pilot scope to avoid
+  // cascading nullness findings into the in-scope exception handlers that consume it.
+  @SuppressWarnings("return")
   @Override
   public String getSQLState(Throwable throwable) {
     return null;
@@ -273,7 +278,7 @@ public class GenericTargetDriverDialect implements TargetDriverDialect {
   }
 
   @Override
-  public String getSQLQueryString(PreparedStatement ps) {
+  public @Nullable String getSQLQueryString(PreparedStatement ps) {
     throw new UnsupportedOperationException("Not implemented");
   }
 
@@ -289,7 +294,7 @@ public class GenericTargetDriverDialect implements TargetDriverDialect {
   }
 
   @Override
-  public byte[] getEncryptedBytes(@NonNull ResultSet rs, Object columnRef) throws SQLException {
+  public byte @Nullable [] getEncryptedBytes(@NonNull ResultSet rs, Object columnRef) throws SQLException {
     if (columnRef instanceof Integer) {
       return rs.getBytes((Integer) columnRef);
     }
@@ -304,7 +309,7 @@ public class GenericTargetDriverDialect implements TargetDriverDialect {
   }
 
   // Get the SQL query string from a PreparedStatement which comes after a dialect specific header
-  protected String findSQLQueryString(PreparedStatement ps, String queryHeader) {
+  protected @Nullable String findSQLQueryString(PreparedStatement ps, @Nullable String queryHeader) {
     String rawStatementStr = ps.toString();
     if (rawStatementStr == null) {
       return null;

--- a/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/MariadbDriverHelper.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/MariadbDriverHelper.java
@@ -42,6 +42,10 @@ public class MariadbDriverHelper {
   private static final String DS_CLASS_NAME = MariaDbDataSource.class.getName();
   private static final String DS_CP_CLASS_NAME = MariaDbPoolDataSource.class.getName();
 
+  // MariaDbDataSource/MariaDbPoolDataSource #setUser/#setPassword are declared with @NonNull
+  // parameters in the driver stubs, but they accept null (meaning "no value configured"). The
+  // wrapper USER/PASSWORD properties may legitimately be null here, so the arguments are safe.
+  @SuppressWarnings("argument")
   public void prepareDataSource(
       final @NonNull DataSource dataSource,
       final @NonNull String protocol,

--- a/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/MariadbTargetDriverDialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/MariadbTargetDriverDialect.java
@@ -25,6 +25,7 @@ import java.util.Properties;
 import java.util.Set;
 import javax.sql.DataSource;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import software.amazon.jdbc.HostSpec;
 import software.amazon.jdbc.JdbcMethod;
 import software.amazon.jdbc.PropertyDefinition;
@@ -169,7 +170,7 @@ public class MariadbTargetDriverDialect extends GenericTargetDriverDialect {
   }
 
   @Override
-  public String getSQLQueryString(PreparedStatement ps) {
+  public @Nullable String getSQLQueryString(PreparedStatement ps) {
     // For MariaDB, this gives something like "ClientPreparedStatement{sql:'select * from T where A=1', parameters:[]}"
     return this.findSQLQueryString(ps, PREPARED_STATEMENT_QUERY_HEADER);
   }

--- a/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/MysqlConnectorJDriverHelper.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/MysqlConnectorJDriverHelper.java
@@ -36,6 +36,10 @@ public class MysqlConnectorJDriverHelper {
   private static final Logger LOGGER =
       Logger.getLogger(MysqlConnectorJDriverHelper.class.getName());
 
+  // MysqlDataSource#setDatabaseName/#setUser/#setPassword are declared with @NonNull parameters in
+  // the driver stubs, but they accept null (meaning "no value configured"). The wrapper properties
+  // may legitimately be null here, so the possibly-null arguments are safe.
+  @SuppressWarnings("argument")
   public void prepareDataSource(
       final @NonNull DataSource dataSource,
       final @NonNull HostSpec hostSpec,
@@ -94,6 +98,11 @@ public class MysqlConnectorJDriverHelper {
     }
   }
 
+  // CJException#getSQLState may return null and no SQL state is available for non-CJExceptions, so
+  // this method can legitimately return null. Callers guard the result (e.g. StringUtils.isNullOrEmpty),
+  // and the return type is kept non-null here to match the TargetDriverDialect.getSQLState contract,
+  // which stays non-null in this pilot scope to avoid cascading findings into the exception handlers.
+  @SuppressWarnings("return")
   public String getSQLState(final Throwable throwable) {
     return throwable instanceof CJException ? ((CJException) throwable).getSQLState() : null;
   }

--- a/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/MysqlConnectorJTargetDriverDialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/MysqlConnectorJTargetDriverDialect.java
@@ -28,6 +28,7 @@ import java.util.Properties;
 import java.util.Set;
 import javax.sql.DataSource;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import software.amazon.jdbc.HostSpec;
 import software.amazon.jdbc.JdbcMethod;
 import software.amazon.jdbc.PropertyDefinition;
@@ -140,7 +141,7 @@ public class MysqlConnectorJTargetDriverDialect extends GenericTargetDriverDiale
   }
 
   @Override
-  public String getSQLQueryString(PreparedStatement ps) {
+  public @Nullable String getSQLQueryString(PreparedStatement ps) {
     // For MySQL, this gives something like "com.mysql.cj.jdbc.ClientPreparedStatement: select * from T where A=1"
     return this.findSQLQueryString(ps, PREPARED_STATEMENT_QUERY_HEADER);
   }

--- a/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/PgTargetDriverDialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/PgTargetDriverDialect.java
@@ -31,6 +31,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 import javax.sql.DataSource;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import software.amazon.jdbc.HostSpec;
 import software.amazon.jdbc.JdbcMethod;
 import software.amazon.jdbc.PluginService;
@@ -185,7 +186,7 @@ public class PgTargetDriverDialect extends GenericTargetDriverDialect {
   }
 
   @Override
-  public String getSQLQueryString(PreparedStatement ps) {
+  public @Nullable String getSQLQueryString(PreparedStatement ps) {
     // For PG, this gives the raw query string itself. i.e. "select * from T where A = 1".
     return this.findSQLQueryString(ps, null);
   }

--- a/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/TargetDriverDialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/TargetDriverDialect.java
@@ -69,7 +69,7 @@ public interface TargetDriverDialect {
   void abortConnection(final @NonNull Connection connectionToAbort, final @NonNull Executor abortExecutor)
       throws SQLException;
 
-  String getSQLQueryString(PreparedStatement ps);
+  @Nullable String getSQLQueryString(PreparedStatement ps);
 
   void registerDataType(final @NonNull Connection connection,  final @NonNull String typeName,
       final @NonNull String className)
@@ -78,7 +78,7 @@ public interface TargetDriverDialect {
   void setEncryptedParameter(final @NonNull PreparedStatement ps, int paramIndex, byte[] encrypted)
       throws SQLException;
 
-  byte[] getEncryptedBytes(final @NonNull ResultSet rs, Object columnRef) throws SQLException;
+  byte @Nullable [] getEncryptedBytes(final @NonNull ResultSet rs, Object columnRef) throws SQLException;
 
   /**
    * Allows each target driver dialect to perform last-minute adjustments to the wrapper's

--- a/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/TargetDriverDialectManager.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/TargetDriverDialectManager.java
@@ -121,6 +121,13 @@ public class TargetDriverDialectManager implements TargetDriverDialectProvider {
     }
 
     result = knownDialectsByCode.get(TargetDriverDialectCodes.GENERIC);
+    if (result == null) {
+      // GENERIC is always registered in knownDialectsByCode, so this never happens in practice;
+      // the guard preserves the non-null return contract of getDialect.
+      throw new SQLException(Messages.get(
+          "TargetDriverDialectManager.unknownDialectCode",
+          new Object[] {TargetDriverDialectCodes.GENERIC}));
+    }
     this.logDialect(TargetDriverDialectCodes.GENERIC, result);
     return result;
   }

--- a/wrapper/src/main/java/software/amazon/jdbc/util/HostIdCacheServiceImpl.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/HostIdCacheServiceImpl.java
@@ -88,7 +88,7 @@ public class HostIdCacheServiceImpl implements HostIdCacheService {
       return null;
     }
 
-    List<HostSpec> topology;
+    @Nullable List<HostSpec> topology;
     try {
       topology = pluginService.getAllHosts();
       if (topology == null) {

--- a/wrapper/src/main/resources/aws_advanced_jdbc_wrapper_messages.properties
+++ b/wrapper/src/main/resources/aws_advanced_jdbc_wrapper_messages.properties
@@ -447,6 +447,8 @@ TopologyUtils.errorProcessingQueryResults=An error occurred while processing the
 TopologyUtils.invalidQuery=An error occurred while attempting to obtain the topology because the topology query was invalid. Please ensure you are connecting to an Aurora or RDS cluster: ''{0}''
 TopologyUtils.unexpectedTopologyQueryColumnCount=The topology query returned a result with 0 columns. This may occur if the topology query is executed when the server is failing over.
 
+MultiAzTopologyUtils.missingEndpoint=The topology query returned a row with a missing endpoint value.
+
 MariadbDriverHelper.canNotRegister=Can''t register driver  org.mariadb.jdbc.Driver.
 
 AuroraInitialConnectionStrategyPlugin.incorrectRole=The Aurora Initial Connection Strategy Plugin connected to ''{0}'', but the connected instance did not have the requested ''{1}'' role. Retrying connection attempt...


### PR DESCRIPTION
## Summary

Continues the incremental, package-by-package adoption of the Checker Framework `NullnessChecker` (warn-only, scoped via `-AonlyDefs`). This covers parts 11-13.

## Scope change

Broadens the `-AonlyDefs` regex in `wrapper/build.gradle.kts` to bring these into scope:

- **Part 11**: the `targetdriverdialect` and `dialect` packages
- **Part 12**: the `hostlistprovider` package
- **Part 13**: the remaining top-level `software.amazon.jdbc` classes (matched via `[A-Z]\w*`, which covers root classes and their nested classes without pulling in the still-deferred `plugin` sub-package)

## Changes

Adds the nullness annotations required to reach **0 warnings** across the newly-scoped packages. Several shared contracts are now annotated `@Nullable` to reflect their real behavior, with callers adjusted accordingly:

- `HostSpec.getRole()` / `getHostId()` / `getCpuPercent()` / `getLagMs()`, `HostRole.verifyConnectionTypeFromValue`, `HostSelector.getHost(...)`, `HostSpecBuilder` optional fields.
- `ConnectionProvider.getHostSpecByStrategy(...)` (and its implementations); `Driver`'s custom-handler `AtomicReference` getters.
- `Dialect.getHostId` (type-argument alignment across all implementations), `getDialectUpdateCandidates`, `getHostAliasQuery`, `getServerVersionQuery`; `TargetDriverDialect` query/encryption helpers.
- `HostListProvider.getCurrentTopology` / `forceRefresh(...)` and `ClusterTopologyMonitor` / `MonitoringConnectionHandler` topology methods.

Common fixes: honest `@Nullable` on genuinely-nullable fields/returns/params, field-capture-into-local guards, `Objects.equals` for nullable comparisons, explicit `Pair.<...>create` type witnesses, `@Nullable` `AtomicReference` element types, and narrow, commented `@SuppressWarnings` only for JDK/library-stub asymmetries or provably-safe cases. One new externalized message key (`MultiAzTopologyUtils.missingEndpoint`) replaces a latent NPE on the topology-result error path.

## Verification

- Checker Framework run on a clean Gradle home: **0 real findings, 0 style findings, 0 crashes**.
- Full wrapper unit-test suite: **1185 passed, 0 failed, 80 skipped**.
- Refactors preserve control flow, logging frequency, exception types, and null/empty handling on the monitoring threads and hot loops (added guards are unreachable in practice, e.g. map-key null checks against `ConcurrentHashMap`).
