### PR TITLE
fix: custom endpoint monitor throttling backoff being bypassed

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/customendpoint/CustomEndpointMonitorImpl.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/customendpoint/CustomEndpointMonitorImpl.java
@@ -137,6 +137,10 @@ public class CustomEndpointMonitorImpl extends AbstractMonitor implements Custom
                       builder.dbClusterEndpointIdentifier(this.endpointIdentifier).filters(customEndpointFilter));
 
           this.hasConnectionIssue.set(false);
+          // A fetch attempt has completed, so any pending refresh request has now been serviced. Clearing this here
+          // (rather than only when the info changes) prevents a still-set flag from turning the subsequent
+          // interruptible sleep into a busy loop of RDS API calls.
+          this.refreshRequired.set(false);
 
           List<DBClusterEndpoint> endpoints = endpointsResponse.dbClusterEndpoints();
           if (endpoints.size() != 1) {
@@ -152,7 +156,7 @@ public class CustomEndpointMonitorImpl extends AbstractMonitor implements Custom
                     }
                 ));
 
-            this.sleep(this.refreshRateNano);
+            this.sleepIgnoringRefreshRequests(this.refreshRateNano);
             continue;
           }
 
@@ -203,13 +207,15 @@ public class CustomEndpointMonitorImpl extends AbstractMonitor implements Custom
 
           if (ex.isThrottlingException()) {
             slowdownRefreshRate();
-            this.sleep(this.refreshRateNano);
+            // The backoff sleep must not be shortened by connection-driven refresh requests, otherwise the monitor
+            // would keep hammering the RDS API and never actually back off while it is being throttled.
+            this.sleepIgnoringRefreshRequests(this.refreshRateNano);
           } else if (ex.statusCode() == HttpStatusCode.UNAUTHORIZED || ex.statusCode() == HttpStatusCode.FORBIDDEN) {
             // User has no permissions to get custom endpoint details.
             // Reduce the refresh rate.
-            this.sleep(UNAUTHORIZED_SLEEP_NANO);
+            this.sleepIgnoringRefreshRequests(UNAUTHORIZED_SLEEP_NANO);
           } else {
-            this.sleep(this.refreshRateNano);
+            this.sleepIgnoringRefreshRequests(this.refreshRateNano);
           }
         } catch (SdkClientException ex) {
           LOGGER.log(Level.SEVERE,
@@ -222,7 +228,7 @@ public class CustomEndpointMonitorImpl extends AbstractMonitor implements Custom
             this.refreshRequired.set(false);
             this.hasConnectionIssue.set(true);
           }
-          this.sleep(this.refreshRateNano);
+          this.sleepIgnoringRefreshRequests(this.refreshRateNano);
         } catch (Exception e) {
           // If the exception is not an InterruptedException, log it and continue monitoring.
           LOGGER.log(Level.SEVERE,
@@ -230,7 +236,7 @@ public class CustomEndpointMonitorImpl extends AbstractMonitor implements Custom
                   "CustomEndpointMonitorImpl.exception",
                   new Object[] {this.customEndpointHostSpec.getUrl()}), e);
 
-          this.sleep(this.refreshRateNano);
+          this.sleepIgnoringRefreshRequests(this.refreshRateNano);
         }
       }
     } catch (InterruptedException e) {
@@ -275,6 +281,29 @@ public class CustomEndpointMonitorImpl extends AbstractMonitor implements Custom
       synchronized (this.refreshRequired) {
         this.refreshRequired.wait(waitDurationMs);
       }
+    }
+  }
+
+  /**
+   * Sleeps for the given duration without being woken early by connection-driven refresh requests (see
+   * {@link #refreshRequired}). This is used on the error/backoff paths so that the throttling backoff, and other
+   * error delays, cannot be bypassed by incoming connections. If it could, the monitor would keep issuing RDS API
+   * calls as fast as connections arrive, defeating the built-in rate limiting and sustaining the throttling. The
+   * sleep still returns promptly when the monitor is stopped or the thread is interrupted.
+   *
+   * @param durationNano the time to sleep, in nanoseconds.
+   * @throws InterruptedException if the thread is interrupted while sleeping.
+   */
+  protected void sleepIgnoringRefreshRequests(long durationNano) throws InterruptedException {
+    long endNano = System.nanoTime() + durationNano;
+    while (!this.stop.get()) {
+      long remainingNano = endNano - System.nanoTime();
+      if (remainingNano <= 0) {
+        break;
+      }
+      // Poll the stop flag at least every 500ms so shutdown stays responsive, but never wake for refreshRequired.
+      long sleepMs = Math.min(500, Math.max(1, TimeUnit.NANOSECONDS.toMillis(remainingNano)));
+      TimeUnit.MILLISECONDS.sleep(sleepMs);
     }
   }
 

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/customendpoint/CustomEndpointMonitorImplTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/customendpoint/CustomEndpointMonitorImplTest.java
@@ -18,6 +18,7 @@ package software.amazon.jdbc.plugin.customendpoint;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
@@ -31,6 +32,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -40,10 +43,12 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.rds.model.DBClusterEndpoint;
 import software.amazon.awssdk.services.rds.model.DescribeDbClusterEndpointsResponse;
+import software.amazon.awssdk.services.rds.model.RdsException;
 import software.amazon.jdbc.AllowedAndBlockedHosts;
 import software.amazon.jdbc.HostSpec;
 import software.amazon.jdbc.HostSpecBuilder;
@@ -149,5 +154,98 @@ public class CustomEndpointMonitorImplTest {
     // Wait for monitor to close
     TimeUnit.MILLISECONDS.sleep(refreshRateMs);
     verify(mockRdsClient, atLeastOnce()).close();
+  }
+
+  /**
+   * Reproduces the production issue where RDS {@code DescribeDBClusterEndpoints} calls keep getting throttled even
+   * though the monitor has exponential-backoff logic that is supposed to slow the call rate down.
+   *
+   * <p>When the RDS API throttles the monitor, no custom endpoint info is ever cached. As a result, every incoming
+   * connection calls {@link CustomEndpointMonitorImpl#requestCustomEndpointInfoUpdate()} /
+   * {@link CustomEndpointMonitorImpl#hasCustomEndpointInfo()}, both of which set {@code refreshRequired = true}. That
+   * flag is never cleared on the throttling path, and {@link CustomEndpointMonitorImpl#sleep(long)} returns
+   * immediately whenever {@code refreshRequired} is {@code true}. Consequently the backoff sleep is bypassed and the
+   * monitor spins, issuing RDS API calls as fast as it can instead of honoring the growing refresh rate.
+   *
+   * <p>This test starts a background "connection storm" that continuously requests custom endpoint info while the
+   * RDS API always throttles, then asserts that the number of RDS API calls over a fixed window stays small (i.e.
+   * the backoff is actually honored). It fails against the current (buggy) implementation and should pass once the
+   * throttling backoff can no longer be short-circuited by connection-driven refresh requests.
+   */
+  @Test
+  public void testThrottlingBackoffBypassedByConnectionStorm() throws InterruptedException {
+    // Ensure no leftover cached info from other tests so hasCustomEndpointInfo() reflects the throttled state.
+    CustomEndpointMonitorImpl.customEndpointInfoCache.clear();
+
+    final int refreshRateMs = 50;
+    final int backoffFactor = 2;
+    final int maxRefreshRateMs = 2000;
+
+    // The RDS API always responds with a throttling exception.
+    final RdsException throttlingException = (RdsException) RdsException.builder()
+        .awsErrorDetails(AwsErrorDetails.builder().errorCode("ThrottlingException").build())
+        .statusCode(400)
+        .message("Rate exceeded")
+        .build();
+
+    final AtomicInteger describeCallCount = new AtomicInteger(0);
+    when(mockRdsClient.describeDBClusterEndpoints(any(Consumer.class))).thenAnswer(invocation -> {
+      int count = describeCallCount.incrementAndGet();
+      // Safety valve: if the backoff is bypassed the monitor spins. Slow the runaway loop once it is clearly
+      // established so the test does not exhaust resources while still far exceeding the expected call count.
+      if (count > 2000) {
+        TimeUnit.MILLISECONDS.sleep(5);
+      }
+      throw throttlingException;
+    });
+
+    final CustomEndpointMonitorImpl monitor = new CustomEndpointMonitorImpl(
+        mockStorageService,
+        mockTelemetryFactory,
+        host,
+        endpointId,
+        Region.US_EAST_1,
+        TimeUnit.MILLISECONDS.toNanos(refreshRateMs),
+        backoffFactor,
+        TimeUnit.MILLISECONDS.toNanos(maxRefreshRateMs),
+        mockRdsClientFunc);
+
+    // Simulate a connection storm: connections continuously ask the monitor for custom endpoint info while it is
+    // unable to provide any (because it is being throttled). Each request sets refreshRequired = true.
+    final AtomicBoolean stormActive = new AtomicBoolean(true);
+    final Thread stormThread = new Thread(() -> {
+      while (stormActive.get()) {
+        monitor.requestCustomEndpointInfoUpdate();
+        try {
+          TimeUnit.MILLISECONDS.sleep(1);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          return;
+        }
+      }
+    });
+
+    monitor.start();
+    stormThread.start();
+
+    // Measure how many RDS API calls the monitor issues during the window.
+    final long measurementWindowMs = 1000;
+    TimeUnit.MILLISECONDS.sleep(measurementWindowMs);
+
+    stormActive.set(false);
+    stormThread.join(TimeUnit.SECONDS.toMillis(5));
+    monitor.stop();
+
+    final int calls = describeCallCount.get();
+
+    // With the backoff honored (50 -> 100 -> 200 -> 400 -> 800 -> ... capped at 2000ms), the monitor makes only a
+    // handful of calls (~4) during a 1s window. If connection-driven refresh requests bypass the backoff, the
+    // monitor spins and issues far more calls.
+    final int maxExpectedCalls = 10;
+    assertTrue(
+        calls <= maxExpectedCalls,
+        "Expected throttling backoff to limit RDS DescribeDBClusterEndpoints calls to at most " + maxExpectedCalls
+            + " during the " + measurementWindowMs + "ms window, but the monitor made " + calls + " calls. "
+            + "The backoff is being bypassed by connection-driven refresh requests (refreshRequired).");
   }
 }


### PR DESCRIPTION
## Summary

The custom endpoint monitor's exponential backoff had no effect while the RDS API was throttling it, so the monitor kept hammering `DescribeDBClusterEndpoints` and sustained the throttling.

Root cause: on the error/backoff paths, `sleep()` returned immediately whenever `refreshRequired` was set. That flag was pinned `true` by every incoming connection requesting endpoint info (which never became available while throttled) and was never cleared on the throttle path, so `slowdownRefreshRate()` had no observable effect. Under a connection storm the monitor spun and issued RDS calls as fast as they returned.

## Changes

- Add `sleepIgnoringRefreshRequests()` and use it on all error/backoff paths (throttling, unauthorized, SDK client, generic, unexpected endpoint count) so connection-driven refresh requests can no longer short-circuit the backoff. It still polls the stop flag and honors interruption for responsive shutdown.
- Clear `refreshRequired` after each completed fetch so a stuck flag cannot turn the healthy-path sleep into a busy loop.
- Healthy-path sleeps stay interruptible, preserving fast on-demand refresh in normal operation.

## Testing

- Added `testThrottlingBackoffBypassedByConnectionStorm`, which reproduces the storm (585 RDS calls/s before the fix) and asserts the backoff is honored after it.
- `CustomEndpointMonitorImplTest` and `CustomEndpointPluginTest` pass; `checkstyleMain` is clean.
- Full wrapper unit suite and integration tests were not run.