### PR TITLE
chore: checker-framework: adopt NullnessChecker for top-level plugin classes (part 14)

### DIFF
--- a/wrapper/build.gradle.kts
+++ b/wrapper/build.gradle.kts
@@ -324,10 +324,14 @@ if (project.hasProperty("enableCheckerFramework")) {
         // (parts 8-10) the whole util package plus the exceptions, cleanup, authentication,
         // hostavailability, osgi, profile, states and ds packages,
         // (part 11) the targetdriverdialect and dialect packages,
-        // (part 12) the hostlistprovider package, and
-        // (part 13) the remaining top-level software.amazon.jdbc classes.
+        // (part 12) the hostlistprovider package,
+        // (part 13) the remaining top-level software.amazon.jdbc classes, and
+        // (part 14) the top-level classes of the plugin package (the plugin sub-package
+        // families remain out of scope for follow-on parts).
         // No end-anchor: matching an outer class also covers its nested classes (and, for
-        // "pkg\.\w+", the classes of nested sub-packages such as util.telemetry.*).
+        // "pkg\.\w+", the classes of nested sub-packages such as util.telemetry.*). The
+        // "plugin\.[A-Z]\w*" entry matches only classes directly in the plugin package
+        // (upper-case class names), not its lower-case sub-packages (efm, cache, ...).
         extraJavacArgs = listOf(
             "-AonlyDefs=^software\\.amazon\\.jdbc\\.(ConnectionPluginManager|PluginServiceImpl"
                 + "|wrapper\\.\\w+"
@@ -337,6 +341,7 @@ if (project.hasProperty("enableCheckerFramework")) {
                 + "|states\\.\\w+|ds\\.\\w+"
                 + "|targetdriverdialect\\.\\w+|dialect\\.\\w+"
                 + "|hostlistprovider\\.\\w+"
+                + "|plugin\\.[A-Z]\\w*"
                 + "|[A-Z]\\w*)",
             // Warning mode: report issues but do not fail the build.
             "-Awarns",

--- a/wrapper/src/main/java/software/amazon/jdbc/ConnectionPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/ConnectionPlugin.java
@@ -132,10 +132,11 @@ public interface ConnectionPlugin extends StateSnapshotProvider {
    * @throws UnsupportedOperationException if this {@link ConnectionPlugin} does not support the
    *                                       requested strategy
    */
-  HostSpec getHostSpecByStrategy(final @Nullable HostRole role, final String strategy)
+  @Nullable HostSpec getHostSpecByStrategy(final @Nullable HostRole role, final String strategy)
       throws SQLException, UnsupportedOperationException;
 
-  HostSpec getHostSpecByStrategy(final List<HostSpec> hosts, final @Nullable HostRole role, final String strategy)
+  @Nullable HostSpec getHostSpecByStrategy(
+      final List<HostSpec> hosts, final @Nullable HostRole role, final String strategy)
       throws SQLException, UnsupportedOperationException;
 
   void initHostProvider(

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/AbstractConnectionPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/AbstractConnectionPlugin.java
@@ -44,7 +44,7 @@ public abstract class AbstractConnectionPlugin implements ConnectionPlugin {
       final Object methodInvokeOn,
       final String methodName,
       final JdbcCallable<T, E> jdbcMethodFunc,
-      final Object[] jdbcMethodArgs)
+      final @Nullable Object[] jdbcMethodArgs)
       throws E {
 
     return jdbcMethodFunc.call();
@@ -111,7 +111,7 @@ public abstract class AbstractConnectionPlugin implements ConnectionPlugin {
   public void notifyNodeListChanged(final Map<String, EnumSet<NodeChangeOptions>> changes) {}
 
   @Override
-  public List<Pair<String, Object>> getSnapshotState() {
+  public @Nullable List<Pair<String, Object>> getSnapshotState() {
     return null;
   }
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/AuroraConnectionTrackerPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/AuroraConnectionTrackerPlugin.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Logger;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import software.amazon.jdbc.HostSpec;
 import software.amazon.jdbc.JdbcCallable;
 import software.amazon.jdbc.JdbcMethod;
@@ -51,7 +52,7 @@ public class AuroraConnectionTrackerPlugin extends AbstractConnectionPlugin {
   private final PluginService pluginService;
   private final RdsUtils rdsHelper;
   private final OpenedConnectionTracker tracker;
-  private HostSpec currentWriter = null;
+  private @Nullable HostSpec currentWriter = null;
   private boolean needUpdateCurrentWriter = false;
 
   AuroraConnectionTrackerPlugin(final PluginService pluginService, final Properties props) {
@@ -88,9 +89,8 @@ public class AuroraConnectionTrackerPlugin extends AbstractConnectionPlugin {
     final Connection conn = connectFunc.call();
 
     if (conn != null && !Boolean.TRUE.equals(this.pluginService.isPooledConnection())) {
-      HostSpec connectionHostSpec = this.pluginService.getRoutedHostSpec() == null
-          ? hostSpec
-          : this.pluginService.getRoutedHostSpec();
+      final HostSpec routedHostSpec = this.pluginService.getRoutedHostSpec();
+      HostSpec connectionHostSpec = routedHostSpec == null ? hostSpec : routedHostSpec;
       final RdsUrlType type = this.rdsHelper.identifyRdsType(connectionHostSpec.getHost());
       if (type.isRdsCluster() || type == RdsUrlType.OTHER || type == RdsUrlType.IP_ADDRESS) {
         final HostSpec identifiedHostSpec = this.pluginService.identifyConnection(conn, connectionHostSpec);
@@ -109,7 +109,7 @@ public class AuroraConnectionTrackerPlugin extends AbstractConnectionPlugin {
   @Override
   public <T, E extends Exception> T execute(final Class<T> resultClass, final Class<E> exceptionClass,
       final Object methodInvokeOn, final String methodName, final JdbcCallable<T, E> jdbcMethodFunc,
-      final Object[] jdbcMethodArgs) throws E {
+      final @Nullable Object[] jdbcMethodArgs) throws E {
 
     final HostSpec currentHostSpec = this.pluginService.getCurrentHostSpec();
     this.rememberWriter();
@@ -173,12 +173,13 @@ public class AuroraConnectionTrackerPlugin extends AbstractConnectionPlugin {
       return;
     }
 
-    if (this.currentWriter == null) {
+    final HostSpec previousWriter = this.currentWriter;
+    if (previousWriter == null) {
       this.currentWriter = hostSpecAfterFailover;
       this.needUpdateCurrentWriter = false;
-    } else if (!this.currentWriter.getHostAndPort().equals(hostSpecAfterFailover.getHostAndPort())) {
+    } else if (!previousWriter.getHostAndPort().equals(hostSpecAfterFailover.getHostAndPort())) {
       // the writer's changed
-      tracker.invalidateAllConnections(this.currentWriter);
+      tracker.invalidateAllConnections(previousWriter);
       tracker.logOpenedConnections();
       this.currentWriter = hostSpecAfterFailover;
       this.needUpdateCurrentWriter = false;

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/AuroraInitialConnectionStrategyPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/AuroraInitialConnectionStrategyPlugin.java
@@ -225,6 +225,11 @@ public class AuroraInitialConnectionStrategyPlugin extends AbstractConnectionPlu
               originalConnectHost, urlType, substitutionStrategy, props, connectFunc, candidateConnHolder);
 
           final Connection candidateConn = candidateConnHolder.get();
+          if (candidateConn == null) {
+            // openCandidateConnection always stores a connection on success; if none is present the
+            // attempt did not yield a usable connection, so retry until the timeout is reached.
+            continue;
+          }
 
           if (roleToVerify == null) {
             // No verification required.
@@ -575,7 +580,7 @@ public class AuroraInitialConnectionStrategyPlugin extends AbstractConnectionPlu
     }
   }
 
-  protected HostSpec getCandidateHost(
+  protected @Nullable HostSpec getCandidateHost(
       final @NonNull HostSpec originalConnectHost,
       final @NonNull RdsUrlType urlType,
       final @NonNull InstanceSubstitutionStrategy substitutionStrategy)
@@ -590,8 +595,10 @@ public class AuroraInitialConnectionStrategyPlugin extends AbstractConnectionPlu
       return Utils.getWriter(availableHosts);
     }
 
-    HostRole targetRole = InstanceSubstitutionStrategy.toTargetRole(substitutionStrategy);
-    if (!this.pluginService.acceptsStrategy(targetRole, this.selectionStrategyPropValue)) {
+    final HostRole targetRole = InstanceSubstitutionStrategy.toTargetRole(substitutionStrategy);
+    final String selectionStrategy = this.selectionStrategyPropValue;
+    if (targetRole == null || selectionStrategy == null
+        || !this.pluginService.acceptsStrategy(targetRole, selectionStrategy)) {
       throw new UnsupportedOperationException(
           Messages.get(
               "AuroraInitialConnectionStrategyPlugin.unsupportedStrategy",
@@ -611,9 +618,9 @@ public class AuroraInitialConnectionStrategyPlugin extends AbstractConnectionPlu
         final List<HostSpec> hostsInRegion = availableHosts.stream()
             .filter(x -> awsRegion.equalsIgnoreCase(this.rdsUtils.getRdsRegion(x.getHost())))
             .collect(Collectors.toList());
-        return this.pluginService.getHostSpecByStrategy(hostsInRegion, targetRole, this.selectionStrategyPropValue);
+        return this.pluginService.getHostSpecByStrategy(hostsInRegion, targetRole, selectionStrategy);
       } else {
-        return this.pluginService.getHostSpecByStrategy(availableHosts, targetRole, this.selectionStrategyPropValue);
+        return this.pluginService.getHostSpecByStrategy(availableHosts, targetRole, selectionStrategy);
       }
     } catch (SQLException ex) {
       // Unable to find candidate host.

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/AwsSecretsManagerConnectionPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/AwsSecretsManagerConnectionPlugin.java
@@ -36,6 +36,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
@@ -110,14 +111,14 @@ public class AwsSecretsManagerConnectionPlugin extends AbstractConnectionPlugin 
   private final BiFunction<HostSpec, Region, SecretsManagerClient>
       secretsManagerClientFunc;
   private final Function<String, GetSecretValueRequest> getSecretValueRequestFunc;
-  protected Secret secret;
+  protected @Nullable Secret secret;
   private final String secretUsername;
   private final String secretPassword;
   protected final long secretExpirationTime;
   protected final PluginService pluginService;
   protected final FullServicesContainer servicesContainer;
 
-  protected final TelemetryCounter fetchCredentialsCounter;
+  protected final @Nullable TelemetryCounter fetchCredentialsCounter;
 
   static {
     PropertyDefinition.registerPluginProperties(AwsSecretsManagerConnectionPlugin.class);
@@ -154,6 +155,9 @@ public class AwsSecretsManagerConnectionPlugin extends AbstractConnectionPlugin 
     );
   }
 
+  // resolveSecretExpirationTime is an overridable instance method invoked here during construction;
+  // it only reads its argument and does not touch not-yet-initialized state, so the call is safe.
+  @SuppressWarnings("method.invocation")
   AwsSecretsManagerConnectionPlugin(
       final FullServicesContainer servicesContainer,
       final Properties props,
@@ -195,7 +199,10 @@ public class AwsSecretsManagerConnectionPlugin extends AbstractConnectionPlugin 
     if (region == null) {
       final Matcher matcher = SECRETS_ARN_PATTERN.matcher(secretId);
       if (matcher.matches()) {
-        region = regionUtils.getRegionFromRegionString(matcher.group("region"));
+        final String regionFromArn = matcher.group("region");
+        if (regionFromArn != null) {
+          region = regionUtils.getRegionFromRegionString(regionFromArn);
+        }
       }
     }
 
@@ -206,8 +213,14 @@ public class AwsSecretsManagerConnectionPlugin extends AbstractConnectionPlugin 
               new Object[] {REGION_PROPERTY.name}));
     }
 
-    this.secretUsername = AwsSecretsManagerConnectionPlugin.SECRETS_MANAGER_SECRET_USERNAME_PROPERTY.getString(props);
-    this.secretPassword = AwsSecretsManagerConnectionPlugin.SECRETS_MANAGER_SECRET_PASSWORD_PROPERTY.getString(props);
+    // Both properties are declared with non-null default values ("username"/"password"), so getString
+    // never returns null; the fallback keeps the fields non-null to satisfy the checker.
+    final String configuredSecretUsername =
+        AwsSecretsManagerConnectionPlugin.SECRETS_MANAGER_SECRET_USERNAME_PROPERTY.getString(props);
+    this.secretUsername = configuredSecretUsername != null ? configuredSecretUsername : "username";
+    final String configuredSecretPassword =
+        AwsSecretsManagerConnectionPlugin.SECRETS_MANAGER_SECRET_PASSWORD_PROPERTY.getString(props);
+    this.secretPassword = configuredSecretPassword != null ? configuredSecretPassword : "password";
     this.secretExpirationTime = resolveSecretExpirationTime(
         AwsSecretsManagerConnectionPlugin.SECRETS_MANAGER_EXPIRATION_SEC_PROPERTY.getInteger(props));
     this.secretKey = Pair.create(secretId, region.id());
@@ -368,15 +381,16 @@ public class AwsSecretsManagerConnectionPlugin extends AbstractConnectionPlugin 
           Messages.get("AwsSecretsManagerConnectionPlugin.endpointOverrideInvalidConnection",
               new Object[] {exception.getMessage()}), exception);
     } catch (Exception exception) {
-      if (exception.getCause() != null && exception.getCause() instanceof URISyntaxException) {
+      final Throwable cause = exception.getCause();
+      if (cause != null && cause instanceof URISyntaxException) {
         LOGGER.log(
             Level.WARNING,
             exception,
             () -> Messages.get(
                 "AwsSecretsManagerConnectionPlugin.endpointOverrideMisconfigured",
-                new Object[] {exception.getCause().getMessage()}));
+                new Object[] {cause.getMessage()}));
         throw new RuntimeException(Messages.get("AwsSecretsManagerConnectionPlugin.endpointOverrideMisconfigured",
-            new Object[] {exception.getCause().getMessage()}));
+            new Object[] {cause.getMessage()}));
       }
       LOGGER.log(
           Level.WARNING,
@@ -432,9 +446,10 @@ public class AwsSecretsManagerConnectionPlugin extends AbstractConnectionPlugin 
    * @param properties Properties to store credentials.
    */
   private void applySecretToProperties(final Properties properties) {
-    if (this.secret != null) {
-      PropertyDefinition.USER.set(properties, secret.getUsername());
-      PropertyDefinition.PASSWORD.set(properties, secret.getPassword());
+    final Secret currentSecret = this.secret;
+    if (currentSecret != null) {
+      PropertyDefinition.USER.set(properties, currentSecret.getUsername());
+      PropertyDefinition.PASSWORD.set(properties, currentSecret.getPassword());
     }
   }
 

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/DefaultConnectionPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/DefaultConnectionPlugin.java
@@ -117,7 +117,7 @@ public final class DefaultConnectionPlugin implements ConnectionPlugin {
       final Object methodInvokeOn,
       final String methodName,
       final JdbcCallable<T, E> jdbcMethodFunc,
-      final Object[] jdbcMethodArgs)
+      final @Nullable Object[] jdbcMethodArgs)
       throws E {
 
     LOGGER.finest(
@@ -244,7 +244,7 @@ public final class DefaultConnectionPlugin implements ConnectionPlugin {
 
   @Override
   public boolean acceptsStrategy(@Nullable HostRole role, String strategy) {
-    if (HostRole.UNKNOWN.equals(role)) {
+    if (role == null || HostRole.UNKNOWN.equals(role)) {
       // Users must request either a writer or a reader role.
       return false;
     }
@@ -253,7 +253,7 @@ public final class DefaultConnectionPlugin implements ConnectionPlugin {
   }
 
   @Override
-  public HostSpec getHostSpecByStrategy(@Nullable HostRole role, String strategy)
+  public @Nullable HostSpec getHostSpecByStrategy(@Nullable HostRole role, String strategy)
       throws SQLException {
     List<HostSpec> hosts = this.pluginService.getHosts();
 
@@ -261,10 +261,10 @@ public final class DefaultConnectionPlugin implements ConnectionPlugin {
   }
 
   @Override
-  public HostSpec getHostSpecByStrategy(
+  public @Nullable HostSpec getHostSpecByStrategy(
       final List<HostSpec> hosts, final @Nullable HostRole role, final String strategy)
       throws SQLException {
-    if (HostRole.UNKNOWN.equals(role)) {
+    if (role == null || HostRole.UNKNOWN.equals(role)) {
       // Users must request either a writer or a reader role.
       return null;
     }
@@ -317,7 +317,7 @@ public final class DefaultConnectionPlugin implements ConnectionPlugin {
   }
 
   @Override
-  public List<Pair<String, Object>> getSnapshotState() {
+  public @Nullable List<Pair<String, Object>> getSnapshotState() {
     return null;
   }
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/DriverMetaDataConnectionPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/DriverMetaDataConnectionPlugin.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Properties;
 import java.util.Set;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import software.amazon.jdbc.AwsWrapperProperty;
 import software.amazon.jdbc.JdbcCallable;
 import software.amazon.jdbc.JdbcMethod;
@@ -47,10 +48,13 @@ public class DriverMetaDataConnectionPlugin extends AbstractConnectionPlugin {
         Collections.singletonList(JdbcMethod.DATABASEMETADATA_GETDRIVERNAME.methodName));
   }
 
+  // WRAPPER_DRIVER_NAME is declared with a non-null default value, so getString (and therefore the
+  // cast) never yields null here; the interface's execute contract is a non-null result.
+  @SuppressWarnings("return")
   @Override
   public <T, E extends Exception> T execute(Class<T> resultClass, Class<E> exceptionClass,
       Object methodInvokeOn, String methodName, JdbcCallable<T, E> jdbcMethodFunc,
-      Object[] jdbcMethodArgs) throws E {
+      @Nullable Object[] jdbcMethodArgs) throws E {
     return resultClass.cast(WRAPPER_DRIVER_NAME.getString(this.properties));
   }
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/ExecutionTimeConnectionPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/ExecutionTimeConnectionPlugin.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.logging.Logger;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import software.amazon.jdbc.JdbcCallable;
 import software.amazon.jdbc.util.Messages;
 
@@ -44,7 +45,7 @@ public class ExecutionTimeConnectionPlugin extends AbstractConnectionPlugin {
       final Object methodInvokeOn,
       final String methodName,
       final JdbcCallable<T, E> jdbcMethodFunc,
-      final Object[] jdbcMethodArgs)
+      final @Nullable Object[] jdbcMethodArgs)
       throws E {
 
     final long startTime = System.nanoTime();

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/LogQueryConnectionPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/LogQueryConnectionPlugin.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.logging.Logger;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import software.amazon.jdbc.AwsWrapperProperty;
 import software.amazon.jdbc.JdbcCallable;
 import software.amazon.jdbc.JdbcMethod;
@@ -124,7 +125,7 @@ public class LogQueryConnectionPlugin extends AbstractConnectionPlugin {
       final Object methodInvokeOn,
       final String methodName,
       final JdbcCallable<T, E> jdbcMethodFunc,
-      final Object[] jdbcMethodArgs)
+      final @Nullable Object[] jdbcMethodArgs)
       throws E {
 
     final String sql = getQuery(methodInvokeOn, methodName, jdbcMethodArgs);
@@ -139,7 +140,8 @@ public class LogQueryConnectionPlugin extends AbstractConnectionPlugin {
     return jdbcMethodFunc.call();
   }
 
-  protected <T> String getQuery(final Object methodInvokeOn, final String methodName, final Object[] jdbcMethodArgs) {
+  protected <T> @Nullable String getQuery(
+      final Object methodInvokeOn, final String methodName, final @Nullable Object[] jdbcMethodArgs) {
 
     // Get query from method argument
     if (methodWithQueryArg.contains(methodName)

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/OpenedConnectionTracker.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/OpenedConnectionTracker.java
@@ -29,6 +29,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import software.amazon.jdbc.HostSpec;
 import software.amazon.jdbc.PluginService;
 import software.amazon.jdbc.util.ExecutorFactory;
@@ -96,7 +97,8 @@ public class OpenedConnectionTracker {
     this.pluginService = pluginService;
   }
 
-  public TrackedConnectionList.Node populateOpenedConnectionQueue(final HostSpec hostSpec, final Connection conn) {
+  public TrackedConnectionList.@Nullable Node populateOpenedConnectionQueue(
+      final HostSpec hostSpec, final Connection conn) {
     if (hostSpec == null || conn == null) {
       return null;
     }
@@ -132,7 +134,7 @@ public class OpenedConnectionTracker {
     invalidateAllConnections(hostSpec.getHostAndPort(), hostSpec.getHost(), hostSpec.getHostId());
   }
 
-  public void invalidateAllConnections(final String... keys) {
+  public void invalidateAllConnections(final @Nullable String... keys) {
     TelemetryFactory telemetryFactory = this.pluginService.getTelemetryFactory();
     TelemetryContext telemetryContext = telemetryFactory.openTelemetryContext(
         TELEMETRY_INVALIDATE_CONNECTIONS, TelemetryTraceLevel.NESTED);
@@ -196,7 +198,7 @@ public class OpenedConnectionTracker {
     }
   }
 
-  private TrackedConnectionList.Node trackConnection(
+  private TrackedConnectionList.@Nullable Node trackConnection(
       final String instanceEndpoint, final Connection connection) {
     if (connection == null) {
       return null;
@@ -209,12 +211,14 @@ public class OpenedConnectionTracker {
     return connectionList.add(connection);
   }
 
-  private void invalidateConnections(final TrackedConnectionList connectionList) {
+  private void invalidateConnections(final @Nullable TrackedConnectionList connectionList) {
     if (connectionList == null || connectionList.isEmpty()) {
       return;
     }
+    // connectionList is non-null past the guard; capture it so the refinement holds inside the lambda.
+    final TrackedConnectionList list = connectionList;
     getOrCreateInvalidateExecutor().submit(() -> {
-      final List<Connection> connections = connectionList.drainAll();
+      final List<Connection> connections = list.drainAll();
       for (final Connection conn : connections) {
         try {
           conn.abort(abortConnectionExecutor);
@@ -241,7 +245,7 @@ public class OpenedConnectionTracker {
     });
   }
 
-  private void logConnectionList(final String host, final TrackedConnectionList list) {
+  private void logConnectionList(final String host, final @Nullable TrackedConnectionList list) {
     if (list == null || list.isEmpty()) {
       return;
     }

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/TrackedConnectionList.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/TrackedConnectionList.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Predicate;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * A thread-safe doubly-linked list for tracking opened connections.
@@ -31,8 +32,8 @@ import java.util.function.Predicate;
 public class TrackedConnectionList {
 
   private final ReentrantLock lock = new ReentrantLock();
-  private Node head;
-  private Node tail;
+  private @Nullable Node head;
+  private @Nullable Node tail;
   private int size;
 
   /**
@@ -41,8 +42,8 @@ public class TrackedConnectionList {
   public static class Node {
     final WeakReference<Connection> connectionRef;
     final TrackedConnectionList ownerList;
-    Node prev;
-    Node next;
+    @Nullable Node prev;
+    @Nullable Node next;
     boolean removed;
 
     Node(final WeakReference<Connection> connectionRef, final TrackedConnectionList ownerList) {

--- a/wrapper/src/main/java/software/amazon/jdbc/util/SqlMethodAnalyzer.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/SqlMethodAnalyzer.java
@@ -62,7 +62,7 @@ public class SqlMethodAnalyzer {
       )));
 
   public boolean doesOpenTransaction(final Connection conn, final String methodName,
-      final Object[] args) {
+      final @Nullable Object[] args) {
     if (!(EXECUTE_SQL_METHOD_NAMES.contains(methodName) && args != null && args.length >= 1)) {
       return false;
     }
@@ -109,7 +109,7 @@ public class SqlMethodAnalyzer {
   }
 
   public boolean doesCloseTransaction(final Connection conn, final String methodName,
-      final Object[] args) {
+      final @Nullable Object[] args) {
     if (CLOSE_TRANSACTION_METHOD_NAMES.contains(methodName)) {
       return true;
     }
@@ -145,7 +145,7 @@ public class SqlMethodAnalyzer {
         || statement.startsWith("ABORT");
   }
 
-  public boolean isStatementSettingAutoCommit(final String methodName, final Object[] args) {
+  public boolean isStatementSettingAutoCommit(final String methodName, final @Nullable Object[] args) {
     if (args == null || args.length < 1) {
       return false;
     }
@@ -159,7 +159,7 @@ public class SqlMethodAnalyzer {
   }
 
   public boolean doesSwitchAutoCommitFalseTrue(final Connection conn, final String methodName,
-      final Object[] jdbcMethodArgs) {
+      final @Nullable Object[] jdbcMethodArgs) {
     final boolean isStatementSettingAutoCommit = isStatementSettingAutoCommit(
         methodName, jdbcMethodArgs);
     if (!isStatementSettingAutoCommit && !JdbcMethod.CONNECTION_SETAUTOCOMMIT.methodName.equals(methodName)) {
@@ -183,7 +183,7 @@ public class SqlMethodAnalyzer {
     return !oldAutoCommitVal && Boolean.TRUE.equals(newAutoCommitVal);
   }
 
-  public @Nullable Boolean getAutoCommitValueFromSqlStatement(final Object[] args) {
+  public @Nullable Boolean getAutoCommitValueFromSqlStatement(final @Nullable Object[] args) {
     if (args == null || args.length < 1) {
       return null;
     }


### PR DESCRIPTION
## Summary

Continues the incremental, package-by-package adoption of the Checker Framework `NullnessChecker` (warn-only, scoped via `-AonlyDefs`). This is **part 14**, the first increment into the large `plugin` package.

## Scope change

Broadens the `-AonlyDefs` regex in `wrapper/build.gradle.kts` to include the **top-level classes of the `plugin` package** (matched via `plugin\.[A-Z]\w*`, which covers classes directly in `software.amazon.jdbc.plugin` and their nested classes, but **not** the lower-case sub-package families such as `efm`, `cache`, `failover`, `bluegreen`, `encryption`, ...). Those families remain out of scope for follow-on parts.

## Changes

Adds the nullness annotations/guards required to reach **0 warnings** across the top-level plugin classes:

- Aligns the `execute(...)` overrides' `jdbcMethodArgs` parameter to the `ConnectionPlugin` interface's existing `@Nullable Object[]` contract (`AbstractConnectionPlugin`, `DefaultConnectionPlugin`, `AuroraConnectionTrackerPlugin`, `DriverMetaDataConnectionPlugin`, `ExecutionTimeConnectionPlugin`, `LogQueryConnectionPlugin`).
- `ConnectionPlugin.getHostSpecByStrategy(...)` → `@Nullable HostSpec` to reflect real behavior; the only in-scope caller (`ConnectionPluginManager`) already null-checks and throws, so its own non-null contract is preserved.
- `SqlMethodAnalyzer` nullable-array params annotated `@Nullable Object[]` (methods already handle null/empty arrays and null elements).
- Honest `@Nullable` on genuinely-nullable fields (`TrackedConnectionList` linked-list nodes, `AuroraConnectionTrackerPlugin.currentWriter`, `AwsSecretsManagerConnectionPlugin.secret`), field-capture-into-local guards to preserve narrowing across calls/lambdas, `Throwable.getCause()` / `Matcher.group(...)` null-guards, and narrow, commented `@SuppressWarnings` only for JDK/library-stub asymmetries.

No new user-facing strings were added.

## Verification

- Checker Framework run on a clean Gradle home: **0 real findings, 0 style findings, 0 crashes**.
- Full wrapper unit-test suite: **1194 passed, 0 failed, 80 skipped**.
- Refactors preserve control flow, logging frequency, exception types, and null/empty handling; added guards are unreachable in practice and mirror the adjacent semantics where they would fire.

