### PR TITLE
fix: propagate configuration profile to eagerly-created topology monitor (#2020)

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/util/ServiceUtility.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/ServiceUtility.java
@@ -79,6 +79,14 @@ public class ServiceUtility {
     servicesContainer.setPluginService(pluginService);
     servicesContainer.setPluginManagerService(pluginService);
 
+    // Set the configuration profile on the container before creating the host list provider and refreshing the host
+    // list. When a dialect is supplied via the configuration profile, isDialectConfirmed() is true immediately, so
+    // refreshHostList() below can eagerly create and cache the topology monitor. The monitor's minimal service
+    // container inherits its plugin list from this container's configuration profile; if the profile is not yet set
+    // at that point, the monitor silently falls back to the default plugin list (dropping profile-only plugins such
+    // as iam) and its connections fail authentication once the cached IAM token expires.
+    servicesContainer.setConfigurationProfile(configurationProfile);
+
     pluginManager.initPlugins(servicesContainer, configurationProfile);
     final HostListProviderSupplier supplier = pluginService.getDialect().getHostListProviderSupplier();
     if (supplier != null) {
@@ -91,7 +99,6 @@ public class ServiceUtility {
     // if it doesn't exist. Plugins may require this information even before connecting.
     pluginService.refreshHostList();
 
-    servicesContainer.setConfigurationProfile(configurationProfile);
     return servicesContainer;
   }
 

--- a/wrapper/src/test/java/integration/container/tests/AwsIamIntegrationTest.java
+++ b/wrapper/src/test/java/integration/container/tests/AwsIamIntegrationTest.java
@@ -19,6 +19,8 @@ package integration.container.tests;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import integration.DatabaseEngine;
+import integration.DatabaseEngineDeployment;
 import integration.DriverHelper;
 import integration.TestEnvironmentFeatures;
 import integration.container.ConnectionStringHelper;
@@ -27,6 +29,7 @@ import integration.container.TestDriverProvider;
 import integration.container.TestEnvironment;
 import integration.container.condition.DisableOnTestDriver;
 import integration.container.condition.DisableOnTestFeature;
+import integration.container.condition.EnableOnDatabaseEngineDeployment;
 import integration.container.condition.EnableOnTestFeature;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -34,7 +37,9 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.Properties;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -48,15 +53,23 @@ import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.rds.RdsUtilities;
 import software.amazon.awssdk.services.rds.TestDefaultRdsUtilities;
+import software.amazon.jdbc.ConnectionPluginFactory;
 import software.amazon.jdbc.HostSpec;
 import software.amazon.jdbc.HostSpecBuilder;
+import software.amazon.jdbc.PluginService;
 import software.amazon.jdbc.PropertyDefinition;
 import software.amazon.jdbc.authentication.AwsCredentialsManager;
+import software.amazon.jdbc.dialect.DialectCodes;
+import software.amazon.jdbc.dialect.DialectManager;
 import software.amazon.jdbc.ds.AwsWrapperDataSource;
 import software.amazon.jdbc.hostavailability.HostAvailabilityStrategy;
+import software.amazon.jdbc.plugin.AuroraConnectionTrackerPluginFactory;
 import software.amazon.jdbc.plugin.iam.IamAuthConnectionPlugin;
+import software.amazon.jdbc.plugin.iam.IamAuthConnectionPluginFactory;
 import software.amazon.jdbc.plugin.iam.LightRdsUtility;
 import software.amazon.jdbc.plugin.iam.RegularRdsUtility;
+import software.amazon.jdbc.profile.ConfigurationProfileBuilder;
+import software.amazon.jdbc.profile.DriverConfigurationProfiles;
 
 @TestMethodOrder(MethodOrderer.MethodName.class)
 @ExtendWith(TestDriverProvider.class)
@@ -255,6 +268,88 @@ public class AwsIamIntegrationTest {
 
     try (final Connection conn = ds.getConnection()) {
       assertTrue(conn.isValid(10));
+    }
+  }
+
+  /**
+   * Regression test for <a href="https://github.com/aws/aws-advanced-jdbc-wrapper/issues/2020">issue #2020</a>
+   * (reopening <a href="https://github.com/aws/aws-advanced-jdbc-wrapper/issues/1800">issue #1800</a>).
+   *
+   * <p>When the plugin list is configured via a class-based {@link ConfigurationProfileBuilder#withPluginFactories}
+   * profile rather than the {@code wrapperPlugins} string, the cluster topology monitor must inherit the profile's
+   * plugins — including the IAM authentication plugin. Otherwise the monitor falls back to the default plugin list
+   * (which does not contain {@code iam}) and its own connections to cluster instances cannot authenticate against an
+   * IAM-only database, so topology monitoring silently dies.
+   *
+   * <p>A dialect is supplied explicitly ({@code wrapperDialect}) so the dialect is confirmed immediately. This causes
+   * the topology monitor to be created eagerly during connection setup — the exact timing that previously dropped the
+   * configuration profile in {@code ServiceUtility.createStandardServiceContainer}. It mirrors Global Aurora (GDB)
+   * deployments, whose dialect is confirmed up front and where this bug was reported.
+   *
+   * <p>The database is connected to with IAM only (no password). Forcing a verified topology refresh drives the
+   * monitor into panic mode, where it opens its own connections to cluster instances using its plugin chain. That can
+   * only succeed if the monitor inherited the profile's IAM plugin.
+   */
+  @TestTemplate
+  @DisableOnTestDriver(TestDriver.MARIADB)
+  @EnableOnDatabaseEngineDeployment(DatabaseEngineDeployment.AURORA)
+  void test_AwsIam_TopologyMonitorInheritsProfilePlugins() throws SQLException {
+    final DatabaseEngine engine = TestEnvironment.getCurrent().getInfo().getRequest().getDatabaseEngine();
+    final String auroraDialectCode =
+        engine == DatabaseEngine.MYSQL ? DialectCodes.AURORA_MYSQL : DialectCodes.AURORA_PG;
+
+    final String profileName = "issue2020IamTopologyProfile";
+    // Configure the plugins programmatically (class factories), NOT via the wrapperPlugins string. The list
+    // intentionally omits initialConnection so the initial connection succeeds regardless of topology state,
+    // isolating the assertion to the topology monitor's own connections.
+    ConfigurationProfileBuilder.get()
+        .withName(profileName)
+        .withPluginFactories(Arrays.<Class<? extends ConnectionPluginFactory>>asList(
+            IamAuthConnectionPluginFactory.class,
+            AuroraConnectionTrackerPluginFactory.class,
+            software.amazon.jdbc.plugin.failover2.FailoverConnectionPluginFactory.class))
+        .buildAndSet();
+
+    try {
+      final Properties props = ConnectionStringHelper.getDefaultProperties();
+      // Class-based profile only: ensure no wrapperPlugins string is present so that, if the monitor were to fall
+      // back to the string/default plugin path (the bug), it would not pick up iam.
+      props.remove(PropertyDefinition.PLUGINS.name);
+      props.setProperty(PropertyDefinition.PROFILE_NAME.name, profileName);
+      // Confirm the dialect up front so the topology monitor is created during connection setup (as with GDB).
+      props.setProperty(DialectManager.DIALECT.name, auroraDialectCode);
+      props.setProperty(
+          IamAuthConnectionPlugin.IAM_REGION.name,
+          TestEnvironment.getCurrent().getInfo().getRegion());
+      props.setProperty(
+          PropertyDefinition.USER.name, TestEnvironment.getCurrent().getInfo().getIamUsername());
+      // IAM-only authentication: no password. The topology monitor can only connect if it has the iam plugin.
+      props.setProperty(PropertyDefinition.PASSWORD.name, "");
+      props.setProperty(PropertyDefinition.TCP_KEEP_ALIVE.name, "false");
+
+      try (final Connection conn =
+          DriverManager.getConnection(ConnectionStringHelper.getWrapperClusterEndpointUrl(), props)) {
+        assertTrue(conn.isValid(10));
+
+        final PluginService pluginService = conn.unwrap(PluginService.class);
+
+        // Force a verified topology refresh. This drives the cluster topology monitor into panic mode, where it opens
+        // fresh connections to cluster instances through its own plugin chain. On an IAM-only database with no
+        // password this only succeeds if the monitor inherited the profile's IAM plugin. With the bug, the monitor
+        // uses the default plugin list (no iam), cannot authenticate, and the refresh times out and returns false.
+        final boolean refreshed = pluginService.forceRefreshHostList(true, TimeUnit.SECONDS.toMillis(60));
+
+        assertTrue(
+            refreshed,
+            "The cluster topology monitor failed to refresh topology on an IAM-only database. This indicates the "
+                + "monitor did not inherit the IAM plugin from the class-based ConfigurationProfile and fell back to "
+                + "the default plugin list.");
+        assertTrue(
+            pluginService.getAllHosts().size() >= 1,
+            "Expected the topology monitor to have discovered at least one cluster host.");
+      }
+    } finally {
+      DriverConfigurationProfiles.remove(profileName);
     }
   }
 

--- a/wrapper/src/test/java/software/amazon/jdbc/util/ServiceUtilityTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/util/ServiceUtilityTest.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.jdbc.util;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.junit.jupiter.api.Test;
+import software.amazon.jdbc.ConnectionProvider;
+import software.amazon.jdbc.HostSpec;
+import software.amazon.jdbc.dialect.HostListProviderSupplier;
+import software.amazon.jdbc.dialect.PgDialect;
+import software.amazon.jdbc.hostlistprovider.HostListProvider;
+import software.amazon.jdbc.profile.ConfigurationProfile;
+import software.amazon.jdbc.profile.ConfigurationProfileBuilder;
+import software.amazon.jdbc.targetdriverdialect.TargetDriverDialect;
+import software.amazon.jdbc.util.events.EventPublisher;
+import software.amazon.jdbc.util.monitoring.MonitorService;
+import software.amazon.jdbc.util.storage.StorageService;
+import software.amazon.jdbc.util.telemetry.DefaultTelemetryFactory;
+import software.amazon.jdbc.util.telemetry.TelemetryFactory;
+
+class ServiceUtilityTest {
+
+  /**
+   * Regression test for <a href="https://github.com/aws/aws-advanced-jdbc-wrapper/issues/2020">issue #2020</a>.
+   *
+   * <p>When a dialect is supplied via the {@link ConfigurationProfile}, {@code PluginServiceImpl} marks the dialect as
+   * confirmed immediately. As a result, the {@code refreshHostList()} call inside
+   * {@link ServiceUtility#createStandardServiceContainer} can eagerly create and cache the cluster topology monitor.
+   * The monitor's minimal service container inherits its plugin list from this container's configuration profile via
+   * {@code FullServicesContainer#getConfigurationProfile()}. If the profile has not yet been set on the container at
+   * that point, the monitor silently falls back to the default plugin list (dropping profile-only plugins such as
+   * {@code iam}) and its connections fail authentication once the cached IAM token expires.
+   *
+   * <p>This test verifies that the configuration profile is already available on the services container by the time
+   * the host list provider is refreshed. A custom dialect supplies a host list provider that records the container's
+   * configuration profile from within {@code refresh()} — the exact point at which the real
+   * {@code RdsHostListProvider} would create the topology monitor.
+   */
+  @Test
+  void createStandardServiceContainer_setsConfigurationProfileBeforeHostListRefresh() throws SQLException {
+    final AtomicReference<@Nullable ConfigurationProfile> profileSeenAtRefresh = new AtomicReference<>();
+    final AtomicBoolean refreshCalled = new AtomicBoolean(false);
+
+    final ProfileCapturingDialect dialect = new ProfileCapturingDialect(profileSeenAtRefresh, refreshCalled);
+
+    // Supplying a dialect through the profile makes isDialectConfirmed() true immediately, which allows the host list
+    // to be refreshed (and the topology monitor to be created) during container construction. An empty plugin-factory
+    // list keeps plugin instantiation minimal while still exercising the profile-based (non-string) plugin path.
+    final ConfigurationProfile profile = ConfigurationProfileBuilder.get()
+        .withName("issue-2020-test-profile")
+        .withPluginFactories(Collections.emptyList())
+        .withDialect(dialect)
+        .build();
+
+    final Properties props = new Properties();
+    final TelemetryFactory telemetryFactory = new DefaultTelemetryFactory(props);
+
+    final FullServicesContainer container = ServiceUtility.getInstance().createStandardServiceContainer(
+        mock(StorageService.class),
+        mock(MonitorService.class),
+        mock(EventPublisher.class),
+        mock(ConnectionProvider.class),
+        null,
+        telemetryFactory,
+        "jdbc:postgresql://test-host:5432/db",
+        "jdbc:postgresql://",
+        mock(TargetDriverDialect.class),
+        props,
+        profile);
+
+    assertTrue(refreshCalled.get(),
+        "The host list provider should be refreshed during container creation.");
+    assertSame(profile, profileSeenAtRefresh.get(),
+        "The configuration profile must be set on the services container before the host list is refreshed, "
+            + "otherwise an eagerly-created topology monitor would miss profile-only plugins such as iam.");
+    assertSame(profile, container.getConfigurationProfile());
+  }
+
+  /**
+   * A PostgreSQL dialect whose host list provider records the configuration profile visible on the services container
+   * at the moment the host list is refreshed.
+   */
+  static class ProfileCapturingDialect extends PgDialect {
+    private final AtomicReference<@Nullable ConfigurationProfile> profileSeenAtRefresh;
+    private final AtomicBoolean refreshCalled;
+
+    ProfileCapturingDialect(
+        final AtomicReference<@Nullable ConfigurationProfile> profileSeenAtRefresh,
+        final AtomicBoolean refreshCalled) {
+      this.profileSeenAtRefresh = profileSeenAtRefresh;
+      this.refreshCalled = refreshCalled;
+    }
+
+    @Override
+    public HostListProviderSupplier getHostListProviderSupplier() {
+      return (properties, initialUrl, servicesContainer) ->
+          new ProfileCapturingHostListProvider(servicesContainer, this.profileSeenAtRefresh, this.refreshCalled);
+    }
+  }
+
+  static class ProfileCapturingHostListProvider implements HostListProvider {
+    private final FullServicesContainer servicesContainer;
+    private final AtomicReference<@Nullable ConfigurationProfile> profileSeenAtRefresh;
+    private final AtomicBoolean refreshCalled;
+
+    ProfileCapturingHostListProvider(
+        final FullServicesContainer servicesContainer,
+        final AtomicReference<@Nullable ConfigurationProfile> profileSeenAtRefresh,
+        final AtomicBoolean refreshCalled) {
+      this.servicesContainer = servicesContainer;
+      this.profileSeenAtRefresh = profileSeenAtRefresh;
+      this.refreshCalled = refreshCalled;
+    }
+
+    private void capture() {
+      this.refreshCalled.set(true);
+      this.profileSeenAtRefresh.set(this.servicesContainer.getConfigurationProfile());
+    }
+
+    @Override
+    public @Nullable List<HostSpec> getCurrentTopology(final Connection conn, final HostSpec initialHostSpec) {
+      return null;
+    }
+
+    @Override
+    public List<HostSpec> refresh() {
+      capture();
+      return new ArrayList<>();
+    }
+
+    @Override
+    public @Nullable List<HostSpec> forceRefresh() {
+      capture();
+      return new ArrayList<>();
+    }
+
+    @Override
+    public @Nullable List<HostSpec> forceRefresh(final boolean verifyTopology, final long timeoutMs) {
+      capture();
+      return new ArrayList<>();
+    }
+
+    @Override
+    public String getClusterId() {
+      return "issue-2020-test-cluster";
+    }
+
+    @Override
+    public void stopMonitor() {
+      // no-op
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Fixes [#2020](https://github.com/aws/aws-advanced-jdbc-wrapper/issues/2020) (a reopening of [#1800](https://github.com/aws/aws-advanced-jdbc-wrapper/issues/1800)).

When the plugin list is configured through a class-based `ConfigurationProfile` (`ConfigurationProfileBuilder.withPluginFactories(...)`) rather than the `wrapperPlugins` string, the cluster topology monitor could still lose the profile-configured plugins (notably `iam`). Its background connections then authenticate without IAM and fail once the cached IAM token expires (~15 min), e.g.:

```
PSQLException: The server requested password-based authentication, but no password was provided by plugin null.
```

## Root cause

PR #1802 and PR #1919 wired the configuration profile through the monitor's minimal service container, so in the common case the monitor inherits the profile correctly. The remaining gap is an ordering problem in `ServiceUtility.createStandardServiceContainer`:

- `PluginServiceImpl` marks the dialect as **confirmed immediately** when a dialect is supplied via the profile (or `wrapperDialect`), and Global Aurora (GDB) deployments are confirmed up front automatically.
- With a confirmed dialect, `pluginService.refreshHostList()` inside `createStandardServiceContainer` **eagerly creates and caches** the `ClusterTopologyMonitorImpl`.
- That happened **before** `servicesContainer.setConfigurationProfile(configurationProfile)` was called, so the monitor's minimal container read a `null` profile and fell back to `DEFAULT_PLUGINS` (`initialConnection,auroraConnectionTracker,failover2,efm2`) - no `iam`.

This matches the reporter's observation that adding `iam` to the `wrapperPlugins` string works around it: the string path (PATH B) is only reached when the profile is missing.

## Fix

Set the configuration profile on the services container **before** creating the host list provider and refreshing the host list, so any eagerly-created topology monitor inherits it. This is a semantics-preserving move of a field setter to an earlier point in the same method; the container's final state is unchanged.

## Tests

- `ServiceUtilityTest` (unit): drives the real `createStandardServiceContainer` with a profile-supplied dialect and a host list provider that records the container's configuration profile at `refresh()` time (the exact point the monitor would be created). Verified it fails without the fix (`expected: <profile> but was: <null>`) and passes with it.
- `AwsIamIntegrationTest#test_AwsIam_TopologyMonitorInheritsProfilePlugins` (integration): configures plugins via `withPluginFactories` (iam, auroraConnectionTracker, failover2), confirms the dialect up front, connects IAM-only (no password) to an Aurora cluster, then forces a verified topology refresh. This drives the monitor to open its own connections through its plugin chain, which only succeeds if it inherited the `iam` plugin. Gated with `@EnableOnTestFeature(IAM)` + `@EnableOnDatabaseEngineDeployment(AURORA)` + `@DisableOnTestDriver(MARIADB)`.

