### PR TITLE
chore: update changelog and bump version to 4.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,28 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/#semantic-versioning-200).
 
+## [4.2.0] - 2026-07-13
+
+### :magic_wand: Added
+- Added automatic read/write splitting driven by SQL parsing via the new `autoReadWriteSplitting` and `sqlParser` plugins, which route statements to a reader or writer based on the parsed SQL ([PR #1995](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/1995)).
+- Added query-level load balancing for the `autoReadWriteSplitting` plugin so read traffic can be distributed across readers on a per-query basis ([PR #2009](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/2009)).
+- Added the `awsSecretsManager2` plugin, which uses a stale-while-revalidate caching strategy to serve credentials from cache while refreshing them in the background ([PR #1985](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/1985)).
+- Added `lowestLoadByCpu` and `lowestLoadByLag` host selection strategy variants that default to CPU-dominant and lag-dominant weighting respectively ([PR #1997](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/1997)).
+
+### :bug: Fixed
+- Fixed the configuration profile not being propagated to eagerly-created topology monitors, which could leave those monitors without profile-configured plugins ([Issue #2020](https://github.com/aws/aws-advanced-jdbc-wrapper/issues/2020), [PR #2021](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/2021)).
+- Fixed the custom endpoint monitor's throttling backoff being bypassed ([PR #2014](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/2014)).
+- Fixed an NPE caused by a check-then-act race in `ImportantEventService#removeExpiredEvents` ([PR #1987](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/1987)).
+
+### :crab: Changed
+- Adopted the Checker Framework `NullnessChecker` across the codebase to improve null-safety ([PR #1981](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/1981), [PR #1998](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/1998), [PR #1999](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/1999), [PR #2007](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/2007), [PR #2008](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/2008), [PR #2010](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/2010), [PR #2015](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/2015), [PR #2018](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/2018)).
+- Dependency updates, including PostgreSQL JDBC driver 42.7.13, Hibernate ORM 7.4.4.Final, Jackson (2.22.0 and 3.2.0), Kotlin 2.4.0, c3p0 0.14.1, Gradle Shadow plugin 8.3.11, and various GitHub Actions bumps ([PR #2012](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/2012), [PR #2006](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/2006), [PR #2013](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/2013), [PR #2005](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/2005), [PR #2000](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/2000), [PR #1991](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/1991), [PR #1988](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/1988), [PR #1994](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/1994), [PR #1990](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/1990), [PR #2001](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/2001), [PR #2003](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/2003), [PR #2004](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/2004), [PR #2002](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/2002), [PR #1993](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/1993), [PR #1992](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/1992)).
+- Documentation: 
+  - clarified internal and external connection pool stacking guidance ([PR #2019](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/2019)) 
+  - documented the MariaDB driver Aurora pipelining caveat ([PR #1984](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/1984)) 
+  - clarified setting wrapper properties via JDBC URL parameters ([PR #1983](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/1983)) 
+  - added examples for specifying driver properties ([PR #1982](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/1982)).
+
 ## [4.1.0] - 2026-06-17
 
 ### :magic_wand: Added

--- a/Maintenance.md
+++ b/Maintenance.md
@@ -48,6 +48,7 @@
 | May 6, 2026        | [Release 4.0.0](https://github.com/aws/aws-advanced-jdbc-wrapper/releases/tag/4.0.0) |
 | May 13, 2026       | [Release 4.0.1](https://github.com/aws/aws-advanced-jdbc-wrapper/releases/tag/4.0.1) |
 | June 17, 2026      | [Release 4.1.0](https://github.com/aws/aws-advanced-jdbc-wrapper/releases/tag/4.1.0) |
+| July 13, 2026      | [Release 4.2.0](https://github.com/aws/aws-advanced-jdbc-wrapper/releases/tag/4.2.0) |
 
 `aws-advanced-jdbc-wrapper` [follows semver](https://semver.org/#semantic-versioning-200) which means we will only
 release breaking changes in major versions. Generally speaking patches will be released to fix existing problems without
@@ -103,4 +104,4 @@ from the updated source after the PRs are merged.
 | 1             | 1.0.2                | Maintenance | Oct 5, 2022     | Apr 28, 2023             | Apr 28, 2024           | 
 | 2             | 2.6.8                | Maintenance | Apr 28, 2023    | Dec 18, 2025             | Dec 31, 2026           | 
 | 3             | 3.3.0                | Maintenance | Dec 18, 2025    | May 6, 2026              | May 6, 2027            | 
-| 4             | 4.1.0                | Current     | May 6, 2026     | N/A                      | N/A                    | 
+| 4             | 4.2.0                | Current     | May 6, 2026     | N/A                      | N/A                    | 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -7,5 +7,5 @@ The benchmarks do not measure the performance of target JDBC drivers nor the per
 ## Usage
 1. Build the benchmarks with the following command `../gradlew jmhJar`.
     1. the JAR file will be outputted to `build/libs`
-2. Run the benchmarks with the following command `java -jar build/libs/benchmarks-4.1.0-jmh.jar`.
+2. Run the benchmarks with the following command `java -jar build/libs/benchmarks-4.2.0-jmh.jar`.
     1. you may have to update the command based on the exact version of the produced JAR file

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -16,7 +16,7 @@ If you are using the AWS Advanced JDBC Wrapper as part of a Gradle project, incl
 
 ```gradle
 dependencies {
-    implementation group: 'software.amazon.jdbc', name: 'aws-advanced-jdbc-wrapper', version: '4.1.0'
+    implementation group: 'software.amazon.jdbc', name: 'aws-advanced-jdbc-wrapper', version: '4.2.0'
     implementation group: 'org.postgresql', name: 'postgresql', version: '42.7.8'
 }
 ```
@@ -30,16 +30,16 @@ You can use pre-compiled packages that can be downloaded directly from [GitHub R
 For example, the following command uses wget to download the wrapper:
 
 ```bash
-wget https://github.com/aws/aws-advanced-jdbc-wrapper/releases/download/4.1.0/aws-advanced-jdbc-wrapper-4.1.0.jar
+wget https://github.com/aws/aws-advanced-jdbc-wrapper/releases/download/4.2.0/aws-advanced-jdbc-wrapper-4.2.0.jar
 ```
 
 Then, the following command adds the AWS Advanced JDBC Wrapper to the CLASSPATH:
 
 ```bash
-export CLASSPATH=$CLASSPATH:/home/userx/libs/aws-advanced-jdbc-wrapper-4.1.0.jar
+export CLASSPATH=$CLASSPATH:/home/userx/libs/aws-advanced-jdbc-wrapper-4.2.0.jar
 ```
 
-> **Note**: There is also a JAR suffixed with `-bundle-federated-auth`. It is an Uber JAR that contains the AWS Advanced JDBC Wrapper as well as all the dependencies needed to run the Federated Authentication Plugin. **Our general recommendation is to use the `aws-advanced-jdbc-wrapper-4.1.0.jar` for use cases unrelated to complex Federated Authentication environments**. To learn more, please check out the [Federated Authentication Plugin](./using-the-jdbc-driver/using-plugins/UsingTheFederatedAuthPlugin.md#bundled-uber-jar). 
+> **Note**: There is also a JAR suffixed with `-bundle-federated-auth`. It is an Uber JAR that contains the AWS Advanced JDBC Wrapper as well as all the dependencies needed to run the Federated Authentication Plugin. **Our general recommendation is to use the `aws-advanced-jdbc-wrapper-4.2.0.jar` for use cases unrelated to complex Federated Authentication environments**. To learn more, please check out the [Federated Authentication Plugin](./using-the-jdbc-driver/using-plugins/UsingTheFederatedAuthPlugin.md#bundled-uber-jar). 
 
 ### As a Maven Dependency
 
@@ -50,7 +50,7 @@ You can use [Maven's dependency management](https://central.sonatype.com/artifac
     <dependency>
         <groupId>software.amazon.jdbc</groupId>
         <artifactId>aws-advanced-jdbc-wrapper</artifactId>
-        <version>4.1.0</version>
+        <version>4.2.0</version>
     </dependency>
 </dependencies>
 ```
@@ -61,7 +61,7 @@ You can use [Gradle's dependency management](https://central.sonatype.com/artifa
 
 ```gradle
 dependencies {
-    implementation group: 'software.amazon.jdbc', name: 'aws-advanced-jdbc-wrapper', version: '4.1.0'
+    implementation group: 'software.amazon.jdbc', name: 'aws-advanced-jdbc-wrapper', version: '4.2.0'
 }
 ```
 
@@ -69,7 +69,7 @@ To add a Gradle dependency in a Kotlin syntax, use the following configuration:
 
 ```kotlin
 dependencies {
-    implementation("software.amazon.jdbc:aws-advanced-jdbc-wrapper:4.1.0")
+    implementation("software.amazon.jdbc:aws-advanced-jdbc-wrapper:4.2.0")
 }
 ```
 

--- a/docs/using-the-jdbc-driver/UsingTheJdbcDriver.md
+++ b/docs/using-the-jdbc-driver/UsingTheJdbcDriver.md
@@ -342,7 +342,7 @@ To use a snapshot build in your project, check the following examples. More info
   <dependency>
     <groupId>software.amazon.jdbc</groupId>
     <artifactId>aws-advanced-jdbc-wrapper</artifactId>
-    <version>4.1.1-SNAPSHOT</version>
+    <version>4.2.1-SNAPSHOT</version>
   </dependency>
 </dependencies>
 
@@ -364,7 +364,7 @@ To use a snapshot build in your project, check the following examples. More info
 #### As a Gradle dependency
 ```gradle
 dependencies {
-    implementation("software.amazon.jdbc:aws-advanced-jdbc-wrapper:4.1.1-SNAPSHOT")
+    implementation("software.amazon.jdbc:aws-advanced-jdbc-wrapper:4.2.1-SNAPSHOT")
 }
 
 repositories {

--- a/docs/using-the-jdbc-driver/using-plugins/UsingTheFederatedAuthPlugin.md
+++ b/docs/using-the-jdbc-driver/using-plugins/UsingTheFederatedAuthPlugin.md
@@ -46,7 +46,7 @@ This JAR is a drop-in ready solution and is **recommended for customers who do n
 As this plugin has a number of transitive dependencies, the goal of this JAR is to eliminate the need to manually source all the dependencies and avoid potential issues with managing them. 
 In that spirit, the dependencies in this JAR are shaded with the prefix `shaded` to avoid potential package conflicts with pre-existing packages in your environment.
 
-It is important to note that the Uber JAR is bundled with the AWS Java RDS SDK and is larger (**15 MB**) than our `aws-advanced-jdbc-wrapper-4.1.0.jar`. So please take that into account when deciding if this solution is for you.
+It is important to note that the Uber JAR is bundled with the AWS Java RDS SDK and is larger (**15 MB**) than our `aws-advanced-jdbc-wrapper-4.2.0.jar`. So please take that into account when deciding if this solution is for you.
 
 If you would like to download and install the bundled Uber JAR, follow these [instructions](../../GettingStarted.md#direct-download-and-installation).
 

--- a/examples/SpringBootHikariExample/README.md
+++ b/examples/SpringBootHikariExample/README.md
@@ -4,7 +4,7 @@ In this tutorial, you will set up a Spring Boot application using Hikari and the
 
 > Note: this tutorial was written using the following technologies:
 >    - Spring Boot 2.7.0
->    - AWS Advanced JDBC Wrapper 4.1.0
+>    - AWS Advanced JDBC Wrapper 4.2.0
 >    - Postgresql 42.5.4
 >    - Java 8
 

--- a/examples/SpringHibernateBalancedReaderOneDataSourceExample/README.md
+++ b/examples/SpringHibernateBalancedReaderOneDataSourceExample/README.md
@@ -5,7 +5,7 @@ In this tutorial, you will set up a Spring Boot and Hibernate application with t
 > Note: this tutorial was written using the following technologies:
 >    - Spring Boot 3.4.4
 >    - Hibernate 6.x (via Spring Boot)
->    - AWS Advanced JDBC Wrapper 4.1.0
+>    - AWS Advanced JDBC Wrapper 4.2.0
 >    - Postgresql 42.7.10
 >    - Gradle 8
 >    - Java 17

--- a/examples/SpringHibernateBalancedReaderTwoDataSourceExample/README.md
+++ b/examples/SpringHibernateBalancedReaderTwoDataSourceExample/README.md
@@ -5,7 +5,7 @@ In this tutorial, you will set up a Spring Boot and Hibernate application with t
 > Note: this tutorial was written using the following technologies:
 >    - Spring Boot 3.4.4
 >    - Hibernate 6.x (via Spring Boot)
->    - AWS Advanced JDBC Wrapper 4.1.0
+>    - AWS Advanced JDBC Wrapper 4.2.0
 >    - Postgresql 42.7.10
 >    - Gradle 8
 >    - Java 17

--- a/examples/SpringHibernateExample/README.md
+++ b/examples/SpringHibernateExample/README.md
@@ -5,7 +5,7 @@ In this tutorial, you will set up a Spring Boot and Hibernate application with t
 > Note: this tutorial was written using the following technologies:
 >    - Spring Boot 3.4.4
 >    - Hibernate 6.x (via Spring Boot)
->    - AWS Advanced JDBC Wrapper 4.1.0
+>    - AWS Advanced JDBC Wrapper 4.2.0
 >    - Postgresql 42.7.10
 >    - Gradle 8
 >    - Java 17

--- a/examples/SpringTxFailoverExample/README.md
+++ b/examples/SpringTxFailoverExample/README.md
@@ -4,7 +4,7 @@ In this tutorial, you will set up a Spring Boot application using the AWS Advanc
 
 > Note: this tutorial was written using the following technologies:
 >    - Spring Boot 2.7.0
->    - AWS Advanced JDBC Wrapper 4.1.0
+>    - AWS Advanced JDBC Wrapper 4.2.0
 >    - Postgresql 42.5.4
 >    - Java 8
 

--- a/examples/SpringWildflyExample/README.md
+++ b/examples/SpringWildflyExample/README.md
@@ -5,7 +5,7 @@ In this tutorial, you will set up a Wildfly and Spring Boot application with the
 > Note: this tutorial was written using the following technologies:
 >    - Spring Boot 2.7.1
 >    - Wildfly 26.1.1 Final
->    - AWS Advanced JDBC Wrapper 4.1.0
+>    - AWS Advanced JDBC Wrapper 4.2.0
 >    - Postgresql 42.5.4
 >    - Gradle 7
 >    - Java 11

--- a/examples/SpringWildflyExample/wildfly/modules/software/amazon/jdbc/main/module.xml
+++ b/examples/SpringWildflyExample/wildfly/modules/software/amazon/jdbc/main/module.xml
@@ -19,7 +19,7 @@
 <module xmlns="urn:jboss:module:1.1" name="software.amazon.jdbc">
 
   <resources>
-    <resource-root path="aws-advanced-jdbc-wrapper-4.1.0.jar"/>
+    <resource-root path="aws-advanced-jdbc-wrapper-4.2.0.jar"/>
     <resource-root path="postgresql-42.5.4.jar"/>
   </resources>
 </module>

--- a/examples/VertxExample/README.md
+++ b/examples/VertxExample/README.md
@@ -3,7 +3,7 @@
 In this tutorial, you will set up a Vert.x application with the AWS Advanced JDBC Wrapper, and use the driver to execute some simple database operations on an Aurora PostgreSQL database.
 
 > Note: this tutorial was written using the following technologies:
->    - AWS Advanced JDBC Wrapper 4.1.0
+>    - AWS Advanced JDBC Wrapper 4.2.0
 >    - PostgreSQL 42.5.4
 >    - Java 8
 >    - Vert.x 4.4.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@
 #    limitations under the License.
 
 aws-advanced-jdbc-wrapper.version.major=4
-aws-advanced-jdbc-wrapper.version.minor=1
+aws-advanced-jdbc-wrapper.version.minor=2
 aws-advanced-jdbc-wrapper.version.subminor=0
 snapshot=false
 nexus.publish=true


### PR DESCRIPTION
## Summary

Release preparation for **4.2.0**. This branch contains only release plumbing (version bump + changelog); no functional code changes.

**Do not merge until the release is validated** (draft release tested, AWS approval obtained, Sonatype staging verified). Merge via **squash** at the end of the release process.

## Changes
- Bumped version `4.1.0` ? `4.2.0` in `gradle.properties`.
- Added the `[4.2.0]` section to `CHANGELOG.md` (Added / Fixed / Changed).
- Updated version references in docs and examples (`GettingStarted.md`, `UsingTheJdbcDriver.md` incl. snapshot refs ? `4.2.1-SNAPSHOT`, `UsingTheFederatedAuthPlugin.md`, `benchmarks/README.md`, all example READMEs, and the Wildfly `module.xml`).
- Updated `Maintenance.md`: added the 4.2.0 release-history row and moved the "Current" latest-minor to 4.2.0.

## Highlights in this release
- **Added:** SQL-parsing-driven automatic read/write splitting (`autoReadWriteSplitting` + `sqlParser` plugins) with query-level load balancing; `awsSecretsManager2` plugin (stale-while-revalidate); `lowestLoadByCpu` / `lowestLoadByLag` host selection strategies.
- **Fixed:** configuration profile not propagated to eagerly-created topology monitors; custom endpoint monitor throttling backoff bypass; NPE race in `ImportantEventService#removeExpiredEvents`.
- **Changed:** Checker Framework `NullnessChecker` adoption across the codebase; dependency updates (PostgreSQL 42.7.13, Hibernate 7.4.4.Final, Jackson, Kotlin 2.4.0, c3p0, Shadow, GitHub Actions); documentation improvements.

## Testing
- Built locally: `:aws-advanced-jdbc-wrapper:jar` and `:shadowJar` succeed and produce `aws-advanced-jdbc-wrapper-4.2.0.jar` and `aws-advanced-jdbc-wrapper-4.2.0-bundle-federated-auth.jar`.
- Relying on CI for the full check suite.
