### PR TITLE
chore: update changelog and bump version to 4.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/#semantic-versioning-200).
 
-## [4.3.0] - 2026-07-21
+## [4.3.0] - 2026-07-23
 
 ### :magic_wand: Added
 - Added a Blue/Green pre-switchover readiness log message to provide better visibility into the switchover lifecycle ([PR #2032](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/2032), [documentation](https://github.com/aws/aws-advanced-jdbc-wrapper/blob/main/docs/using-the-jdbc-driver/using-plugins/UsingTheBlueGreenPlugin.md)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/#semantic-versioning-200).
 
+## [4.3.0] - 2026-07-21
+
+### :magic_wand: Added
+- Added a Blue/Green pre-switchover readiness log message to provide better visibility into the switchover lifecycle ([PR #2032](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/2032)).
+
+### :bug: Fixed
+- Fixed endpoint resolution to fail fast on unresolvable instance endpoints for non-RDS hosts instead of retrying ([PR #2036](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/2036)).
+- Fixed `DefaultConnectionPlugin` strategy selection to allow a null role (any host) ([PR #2033](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/2033)).
+
+### :crab: Changed
+- Improved the `CachedSQLXML` user experience ([PR #2034](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/2034)).
+- Documentation: improved the configuration assistant skill for issue [#2020](https://github.com/aws/aws-advanced-jdbc-wrapper/issues/2020) ([PR #2031](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/2031)).
+- Dependency updates, including Hibernate ORM 7.4.5.Final, Jackson (2.22.1 and 3.2.1), Kotlin stdlib 2.4.10, Vert.x 4.5.31, AWS X-Ray Recorder SDK 2.21.1, and various GitHub Actions bumps ([PR #2024](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/2024), [PR #2025](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/2025), [PR #2026](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/2026), [PR #2027](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/2027), [PR #2028](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/2028), [PR #2029](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/2029), [PR #2030](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/2030), [PR #2037](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/2037), [PR #2038](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/2038), [PR #2039](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/2039), [PR #2040](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/2040), [PR #2041](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/2041)).
+
 ## [4.2.0] - 2026-07-13
 
 ### :magic_wand: Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [4.3.0] - 2026-07-21
 
 ### :magic_wand: Added
-- Added a Blue/Green pre-switchover readiness log message to provide better visibility into the switchover lifecycle ([PR #2032](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/2032)).
+- Added a Blue/Green pre-switchover readiness log message to provide better visibility into the switchover lifecycle ([PR #2032](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/2032), [documentation](https://github.com/aws/aws-advanced-jdbc-wrapper/blob/main/docs/using-the-jdbc-driver/using-plugins/UsingTheBlueGreenPlugin.md)).
 
 ### :bug: Fixed
-- Fixed endpoint resolution to fail fast on unresolvable instance endpoints for non-RDS hosts instead of retrying ([PR #2036](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/2036)).
-- Fixed `DefaultConnectionPlugin` strategy selection to allow a null role (any host) ([PR #2033](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/2033)).
+- Fixed endpoint resolution to fail fast on unresolvable instance endpoints for non-RDS hosts instead of retrying ([PR #2036](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/2036), [documentation](https://github.com/aws/aws-advanced-jdbc-wrapper/blob/main/docs/using-the-jdbc-driver/using-plugins/UsingTheFailover2Plugin.md)).
+- Fixed `DefaultConnectionPlugin` strategy selection to allow a null role (any host) ([PR #2033](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/2033), [documentation](https://github.com/aws/aws-advanced-jdbc-wrapper/blob/main/docs/using-the-jdbc-driver/HostSelectionStrategies.md)).
 
 ### :crab: Changed
-- Improved the `CachedSQLXML` user experience ([PR #2034](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/2034)).
-- Documentation: improved the configuration assistant skill for issue [#2020](https://github.com/aws/aws-advanced-jdbc-wrapper/issues/2020) ([PR #2031](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/2031)).
+- Improved the `CachedSQLXML` user experience ([PR #2034](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/2034), [documentation](https://github.com/aws/aws-advanced-jdbc-wrapper/blob/main/docs/using-the-jdbc-driver/using-plugins/UsingTheRemoteQueryCachePlugin.md#xml-columns)).
+- Documentation: improved the configuration assistant skill for issue [#2020](https://github.com/aws/aws-advanced-jdbc-wrapper/issues/2020) ([PR #2031](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/2031), [documentation](https://github.com/aws/aws-advanced-jdbc-wrapper/blob/main/docs/JDBC-WRAPPER-CONFIGURATION-ASSISTANT.md)).
 - Dependency updates, including Hibernate ORM 7.4.5.Final, Jackson (2.22.1 and 3.2.1), Kotlin stdlib 2.4.10, Vert.x 4.5.31, AWS X-Ray Recorder SDK 2.21.1, and various GitHub Actions bumps ([PR #2024](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/2024), [PR #2025](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/2025), [PR #2026](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/2026), [PR #2027](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/2027), [PR #2028](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/2028), [PR #2029](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/2029), [PR #2030](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/2030), [PR #2037](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/2037), [PR #2038](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/2038), [PR #2039](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/2039), [PR #2040](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/2040), [PR #2041](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/2041)).
 
 ## [4.2.0] - 2026-07-13

--- a/Maintenance.md
+++ b/Maintenance.md
@@ -49,6 +49,7 @@
 | May 13, 2026       | [Release 4.0.1](https://github.com/aws/aws-advanced-jdbc-wrapper/releases/tag/4.0.1) |
 | June 17, 2026      | [Release 4.1.0](https://github.com/aws/aws-advanced-jdbc-wrapper/releases/tag/4.1.0) |
 | July 13, 2026      | [Release 4.2.0](https://github.com/aws/aws-advanced-jdbc-wrapper/releases/tag/4.2.0) |
+| July 21, 2026      | [Release 4.3.0](https://github.com/aws/aws-advanced-jdbc-wrapper/releases/tag/4.3.0) |
 
 `aws-advanced-jdbc-wrapper` [follows semver](https://semver.org/#semantic-versioning-200) which means we will only
 release breaking changes in major versions. Generally speaking patches will be released to fix existing problems without
@@ -104,4 +105,4 @@ from the updated source after the PRs are merged.
 | 1             | 1.0.2                | Maintenance | Oct 5, 2022     | Apr 28, 2023             | Apr 28, 2024           | 
 | 2             | 2.6.8                | Maintenance | Apr 28, 2023    | Dec 18, 2025             | Dec 31, 2026           | 
 | 3             | 3.3.0                | Maintenance | Dec 18, 2025    | May 6, 2026              | May 6, 2027            | 
-| 4             | 4.2.0                | Current     | May 6, 2026     | N/A                      | N/A                    | 
+| 4             | 4.3.0                | Current     | May 6, 2026     | N/A                      | N/A                    | 

--- a/Maintenance.md
+++ b/Maintenance.md
@@ -49,7 +49,7 @@
 | May 13, 2026       | [Release 4.0.1](https://github.com/aws/aws-advanced-jdbc-wrapper/releases/tag/4.0.1) |
 | June 17, 2026      | [Release 4.1.0](https://github.com/aws/aws-advanced-jdbc-wrapper/releases/tag/4.1.0) |
 | July 13, 2026      | [Release 4.2.0](https://github.com/aws/aws-advanced-jdbc-wrapper/releases/tag/4.2.0) |
-| July 21, 2026      | [Release 4.3.0](https://github.com/aws/aws-advanced-jdbc-wrapper/releases/tag/4.3.0) |
+| July 23, 2026      | [Release 4.3.0](https://github.com/aws/aws-advanced-jdbc-wrapper/releases/tag/4.3.0) |
 
 `aws-advanced-jdbc-wrapper` [follows semver](https://semver.org/#semantic-versioning-200) which means we will only
 release breaking changes in major versions. Generally speaking patches will be released to fix existing problems without

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -7,5 +7,5 @@ The benchmarks do not measure the performance of target JDBC drivers nor the per
 ## Usage
 1. Build the benchmarks with the following command `../gradlew jmhJar`.
     1. the JAR file will be outputted to `build/libs`
-2. Run the benchmarks with the following command `java -jar build/libs/benchmarks-4.2.0-jmh.jar`.
+2. Run the benchmarks with the following command `java -jar build/libs/benchmarks-4.3.0-jmh.jar`.
     1. you may have to update the command based on the exact version of the produced JAR file

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -16,7 +16,7 @@ If you are using the AWS Advanced JDBC Wrapper as part of a Gradle project, incl
 
 ```gradle
 dependencies {
-    implementation group: 'software.amazon.jdbc', name: 'aws-advanced-jdbc-wrapper', version: '4.2.0'
+    implementation group: 'software.amazon.jdbc', name: 'aws-advanced-jdbc-wrapper', version: '4.3.0'
     implementation group: 'org.postgresql', name: 'postgresql', version: '42.7.8'
 }
 ```
@@ -30,16 +30,16 @@ You can use pre-compiled packages that can be downloaded directly from [GitHub R
 For example, the following command uses wget to download the wrapper:
 
 ```bash
-wget https://github.com/aws/aws-advanced-jdbc-wrapper/releases/download/4.2.0/aws-advanced-jdbc-wrapper-4.2.0.jar
+wget https://github.com/aws/aws-advanced-jdbc-wrapper/releases/download/4.3.0/aws-advanced-jdbc-wrapper-4.3.0.jar
 ```
 
 Then, the following command adds the AWS Advanced JDBC Wrapper to the CLASSPATH:
 
 ```bash
-export CLASSPATH=$CLASSPATH:/home/userx/libs/aws-advanced-jdbc-wrapper-4.2.0.jar
+export CLASSPATH=$CLASSPATH:/home/userx/libs/aws-advanced-jdbc-wrapper-4.3.0.jar
 ```
 
-> **Note**: There is also a JAR suffixed with `-bundle-federated-auth`. It is an Uber JAR that contains the AWS Advanced JDBC Wrapper as well as all the dependencies needed to run the Federated Authentication Plugin. **Our general recommendation is to use the `aws-advanced-jdbc-wrapper-4.2.0.jar` for use cases unrelated to complex Federated Authentication environments**. To learn more, please check out the [Federated Authentication Plugin](./using-the-jdbc-driver/using-plugins/UsingTheFederatedAuthPlugin.md#bundled-uber-jar). 
+> **Note**: There is also a JAR suffixed with `-bundle-federated-auth`. It is an Uber JAR that contains the AWS Advanced JDBC Wrapper as well as all the dependencies needed to run the Federated Authentication Plugin. **Our general recommendation is to use the `aws-advanced-jdbc-wrapper-4.3.0.jar` for use cases unrelated to complex Federated Authentication environments**. To learn more, please check out the [Federated Authentication Plugin](./using-the-jdbc-driver/using-plugins/UsingTheFederatedAuthPlugin.md#bundled-uber-jar). 
 
 ### As a Maven Dependency
 
@@ -50,7 +50,7 @@ You can use [Maven's dependency management](https://central.sonatype.com/artifac
     <dependency>
         <groupId>software.amazon.jdbc</groupId>
         <artifactId>aws-advanced-jdbc-wrapper</artifactId>
-        <version>4.2.0</version>
+        <version>4.3.0</version>
     </dependency>
 </dependencies>
 ```
@@ -61,7 +61,7 @@ You can use [Gradle's dependency management](https://central.sonatype.com/artifa
 
 ```gradle
 dependencies {
-    implementation group: 'software.amazon.jdbc', name: 'aws-advanced-jdbc-wrapper', version: '4.2.0'
+    implementation group: 'software.amazon.jdbc', name: 'aws-advanced-jdbc-wrapper', version: '4.3.0'
 }
 ```
 
@@ -69,7 +69,7 @@ To add a Gradle dependency in a Kotlin syntax, use the following configuration:
 
 ```kotlin
 dependencies {
-    implementation("software.amazon.jdbc:aws-advanced-jdbc-wrapper:4.2.0")
+    implementation("software.amazon.jdbc:aws-advanced-jdbc-wrapper:4.3.0")
 }
 ```
 

--- a/docs/using-the-jdbc-driver/UsingTheJdbcDriver.md
+++ b/docs/using-the-jdbc-driver/UsingTheJdbcDriver.md
@@ -342,7 +342,7 @@ To use a snapshot build in your project, check the following examples. More info
   <dependency>
     <groupId>software.amazon.jdbc</groupId>
     <artifactId>aws-advanced-jdbc-wrapper</artifactId>
-    <version>4.2.1-SNAPSHOT</version>
+    <version>4.3.1-SNAPSHOT</version>
   </dependency>
 </dependencies>
 
@@ -364,7 +364,7 @@ To use a snapshot build in your project, check the following examples. More info
 #### As a Gradle dependency
 ```gradle
 dependencies {
-    implementation("software.amazon.jdbc:aws-advanced-jdbc-wrapper:4.2.1-SNAPSHOT")
+    implementation("software.amazon.jdbc:aws-advanced-jdbc-wrapper:4.3.1-SNAPSHOT")
 }
 
 repositories {

--- a/docs/using-the-jdbc-driver/using-plugins/UsingTheFederatedAuthPlugin.md
+++ b/docs/using-the-jdbc-driver/using-plugins/UsingTheFederatedAuthPlugin.md
@@ -46,7 +46,7 @@ This JAR is a drop-in ready solution and is **recommended for customers who do n
 As this plugin has a number of transitive dependencies, the goal of this JAR is to eliminate the need to manually source all the dependencies and avoid potential issues with managing them. 
 In that spirit, the dependencies in this JAR are shaded with the prefix `shaded` to avoid potential package conflicts with pre-existing packages in your environment.
 
-It is important to note that the Uber JAR is bundled with the AWS Java RDS SDK and is larger (**15 MB**) than our `aws-advanced-jdbc-wrapper-4.2.0.jar`. So please take that into account when deciding if this solution is for you.
+It is important to note that the Uber JAR is bundled with the AWS Java RDS SDK and is larger (**15 MB**) than our `aws-advanced-jdbc-wrapper-4.3.0.jar`. So please take that into account when deciding if this solution is for you.
 
 If you would like to download and install the bundled Uber JAR, follow these [instructions](../../GettingStarted.md#direct-download-and-installation).
 

--- a/examples/SpringBootHikariExample/README.md
+++ b/examples/SpringBootHikariExample/README.md
@@ -4,7 +4,7 @@ In this tutorial, you will set up a Spring Boot application using Hikari and the
 
 > Note: this tutorial was written using the following technologies:
 >    - Spring Boot 2.7.0
->    - AWS Advanced JDBC Wrapper 4.2.0
+>    - AWS Advanced JDBC Wrapper 4.3.0
 >    - Postgresql 42.5.4
 >    - Java 8
 

--- a/examples/SpringHibernateBalancedReaderOneDataSourceExample/README.md
+++ b/examples/SpringHibernateBalancedReaderOneDataSourceExample/README.md
@@ -5,7 +5,7 @@ In this tutorial, you will set up a Spring Boot and Hibernate application with t
 > Note: this tutorial was written using the following technologies:
 >    - Spring Boot 3.4.4
 >    - Hibernate 6.x (via Spring Boot)
->    - AWS Advanced JDBC Wrapper 4.2.0
+>    - AWS Advanced JDBC Wrapper 4.3.0
 >    - Postgresql 42.7.10
 >    - Gradle 8
 >    - Java 17

--- a/examples/SpringHibernateBalancedReaderTwoDataSourceExample/README.md
+++ b/examples/SpringHibernateBalancedReaderTwoDataSourceExample/README.md
@@ -5,7 +5,7 @@ In this tutorial, you will set up a Spring Boot and Hibernate application with t
 > Note: this tutorial was written using the following technologies:
 >    - Spring Boot 3.4.4
 >    - Hibernate 6.x (via Spring Boot)
->    - AWS Advanced JDBC Wrapper 4.2.0
+>    - AWS Advanced JDBC Wrapper 4.3.0
 >    - Postgresql 42.7.10
 >    - Gradle 8
 >    - Java 17

--- a/examples/SpringHibernateExample/README.md
+++ b/examples/SpringHibernateExample/README.md
@@ -5,7 +5,7 @@ In this tutorial, you will set up a Spring Boot and Hibernate application with t
 > Note: this tutorial was written using the following technologies:
 >    - Spring Boot 3.4.4
 >    - Hibernate 6.x (via Spring Boot)
->    - AWS Advanced JDBC Wrapper 4.2.0
+>    - AWS Advanced JDBC Wrapper 4.3.0
 >    - Postgresql 42.7.10
 >    - Gradle 8
 >    - Java 17

--- a/examples/SpringTxFailoverExample/README.md
+++ b/examples/SpringTxFailoverExample/README.md
@@ -4,7 +4,7 @@ In this tutorial, you will set up a Spring Boot application using the AWS Advanc
 
 > Note: this tutorial was written using the following technologies:
 >    - Spring Boot 2.7.0
->    - AWS Advanced JDBC Wrapper 4.2.0
+>    - AWS Advanced JDBC Wrapper 4.3.0
 >    - Postgresql 42.5.4
 >    - Java 8
 

--- a/examples/SpringWildflyExample/README.md
+++ b/examples/SpringWildflyExample/README.md
@@ -5,7 +5,7 @@ In this tutorial, you will set up a Wildfly and Spring Boot application with the
 > Note: this tutorial was written using the following technologies:
 >    - Spring Boot 2.7.1
 >    - Wildfly 26.1.1 Final
->    - AWS Advanced JDBC Wrapper 4.2.0
+>    - AWS Advanced JDBC Wrapper 4.3.0
 >    - Postgresql 42.5.4
 >    - Gradle 7
 >    - Java 11

--- a/examples/SpringWildflyExample/wildfly/modules/software/amazon/jdbc/main/module.xml
+++ b/examples/SpringWildflyExample/wildfly/modules/software/amazon/jdbc/main/module.xml
@@ -19,7 +19,7 @@
 <module xmlns="urn:jboss:module:1.1" name="software.amazon.jdbc">
 
   <resources>
-    <resource-root path="aws-advanced-jdbc-wrapper-4.2.0.jar"/>
+    <resource-root path="aws-advanced-jdbc-wrapper-4.3.0.jar"/>
     <resource-root path="postgresql-42.5.4.jar"/>
   </resources>
 </module>

--- a/examples/VertxExample/README.md
+++ b/examples/VertxExample/README.md
@@ -3,7 +3,7 @@
 In this tutorial, you will set up a Vert.x application with the AWS Advanced JDBC Wrapper, and use the driver to execute some simple database operations on an Aurora PostgreSQL database.
 
 > Note: this tutorial was written using the following technologies:
->    - AWS Advanced JDBC Wrapper 4.2.0
+>    - AWS Advanced JDBC Wrapper 4.3.0
 >    - PostgreSQL 42.5.4
 >    - Java 8
 >    - Vert.x 4.4.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@
 #    limitations under the License.
 
 aws-advanced-jdbc-wrapper.version.major=4
-aws-advanced-jdbc-wrapper.version.minor=2
+aws-advanced-jdbc-wrapper.version.minor=3
 aws-advanced-jdbc-wrapper.version.subminor=0
 snapshot=false
 nexus.publish=true


### PR DESCRIPTION
## Summary

Release preparation for **4.3.0**. Bumps the version from 4.2.0 to 4.3.0 and updates the changelog and documentation.


## Changes

- Bump version to 4.3.0 in `gradle.properties`.
- Update `CHANGELOG.md` with the `4.3.0` section (PRs #2024-#2041). Each feature entry links to the corresponding documentation after its PR/issue link.
- Update version references in docs and examples (`GettingStarted.md`, `UsingTheFederatedAuthPlugin.md`, `benchmarks/README.md`, example READMEs, Wildfly `module.xml`).
- Bump snapshot examples in `UsingTheJdbcDriver.md` to `4.3.1-SNAPSHOT`.
- Update `Maintenance.md` release-history table and the "Current" major-version support row.

Historical "Since" version columns and "fixed in 4.2.0" annotations were intentionally left unchanged.

## Changelog highlights

### Added
- Blue/Green pre-switchover readiness log ([#2032](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/2032), [documentation](https://github.com/aws/aws-advanced-jdbc-wrapper/blob/main/docs/using-the-jdbc-driver/using-plugins/UsingTheBlueGreenPlugin.md)).

### Fixed
- Fail fast on unresolvable instance endpoints for non-RDS hosts ([#2036](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/2036), [documentation](https://github.com/aws/aws-advanced-jdbc-wrapper/blob/main/docs/using-the-jdbc-driver/using-plugins/UsingTheFailover2Plugin.md)).
- Allow null role (any host) in `DefaultConnectionPlugin` strategy selection ([#2033](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/2033), [documentation](https://github.com/aws/aws-advanced-jdbc-wrapper/blob/main/docs/using-the-jdbc-driver/HostSelectionStrategies.md)).

### Changed
- Improved `CachedSQLXML` user experience ([#2034](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/2034), [documentation](https://github.com/aws/aws-advanced-jdbc-wrapper/blob/main/docs/using-the-jdbc-driver/using-plugins/UsingTheRemoteQueryCachePlugin.md#xml-columns)).
- Configuration assistant skill docs ([#2031](https://github.com/aws/aws-advanced-jdbc-wrapper/pull/2031), [documentation](https://github.com/aws/aws-advanced-jdbc-wrapper/blob/main/docs/JDBC-WRAPPER-CONFIGURATION-ASSISTANT.md)).
- Dependency updates (Hibernate 7.4.5.Final, Jackson 2.22.1/3.2.1, Kotlin stdlib 2.4.10, Vert.x 4.5.31, AWS X-Ray 2.21.1, and GitHub Actions bumps).

