### PR TITLE
feat: add XA distributed transaction support (AwsWrapperXADataSource)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,6 @@
 * text=auto
 gradlew text eol=lf
+# Shell scripts must always use LF so they run inside Linux containers (a CRLF shebang
+# produces "/bin/bash^M: bad interpreter"). This matters for scripts copied verbatim into
+# containers by the integration-test harness (e.g. src/test/config/*.sh).
+*.sh text eol=lf

--- a/docs/Documentation.md
+++ b/docs/Documentation.md
@@ -3,6 +3,7 @@
 - [Getting Started](./GettingStarted.md)
 - [Using the AWS Advanced JDBC Wrapper](./using-the-jdbc-driver/UsingTheJdbcDriver.md)
   - [Data Sources](./using-the-jdbc-driver/DataSource.md)
+    - [XA DataSource (distributed / two-phase commit transactions)](./using-the-jdbc-driver/UsingXADataSource.md)
   - [Aurora Global Databases](./using-the-jdbc-driver/GlobalDatabases.md)
   - [Logging](./using-the-jdbc-driver/UsingTheJdbcDriver.md#logging)
   - [Telemetry](./using-the-jdbc-driver/Telemetry.md)

--- a/docs/JDBC-WRAPPER-CONFIGURATION-ASSISTANT.md
+++ b/docs/JDBC-WRAPPER-CONFIGURATION-ASSISTANT.md
@@ -46,8 +46,9 @@ Always lead with this:
 > e. **Auth integration** — IAM, Secrets Manager, federated (Okta/ADFS).
 > f. **Multi-region / Aurora Global Database** — cross-region replicas, planned switchover.
 > g. **Blue/Green Deployment** — survive RDS Blue/Green switchover.
-> h. **Troubleshooting** — diagnose a specific error message or behavior.
-> i. **Just answer a parameter / plugin question** — quick reference.
+> h. **Distributed / XA transactions** — participate in JTA two-phase commit (WildFly/Narayana, Atomikos).
+> i. **Troubleshooting** — diagnose a specific error message or behavior.
+> j. **Just answer a parameter / plugin question** — quick reference.
 
 Then branch to the relevant interview track in §2.
 
@@ -169,7 +170,21 @@ There are eight read/write splitting codes, and users routinely pick the wrong o
 3. **Multiple deployments at once?** (drives `bgdId`)
 4. **Open Liberty / Wildfly?** (need `identifyException` for failover SQL states — see §15)
 
-### 2.8 Track H — Troubleshooting
+### 2.8 Track H — Distributed / XA transactions
+
+1. **JTA transaction manager?** (WildFly/Narayana, Atomikos, Bitronix) — confirms the XA entry point
+   `AwsWrapperXADataSource` is what's needed, not `AwsWrapperDataSource`.
+2. **Engine + target XADataSource?** (PG `org.postgresql.xa.PGXADataSource`, MySQL
+   `com.mysql.cj.jdbc.MysqlXADataSource`, MariaDB `org.mariadb.jdbc.MariaDbDataSource`)
+3. **Auth?** (password / IAM / Secrets Manager — all act at connect time and work on the XA path)
+4. **Do you also need failover or read/write splitting?** If yes → recommend the **two-datasource**
+   pattern (XA datasource for writes + a normal datasource with `failover2`/read-write splitting for
+   reads); connection-switching plugins cannot run on the XA datasource.
+
+→ Branch to recipe §3.12. State the XA-path constraints up front (no switching plugins, no internal
+pool; PostgreSQL needs `max_prepared_transactions > 0`).
+
+### 2.9 Track I — Troubleshooting
 
 Walk through these in order until the cause is clear:
 
@@ -180,7 +195,7 @@ Walk through these in order until the cause is clear:
 5. **Logs available?** Enable `wrapperLoggerLevel=FINER` and look for `DialectManager Current dialect:` and the rearranged plugin order line. (See §16 for diagnostic workflow.)
 6. Check §18 for known anti-patterns.
 
-### 2.9 Track I — Quick parameter / plugin lookup
+### 2.10 Track J — Quick parameter / plugin lookup
 
 Skip the interview. Look up the parameter or plugin in §5–§9 and answer directly. If the term isn't in the document, say so.
 
@@ -461,6 +476,52 @@ props.setProperty("wrapperProfileName", "SF_F0"); // Spring Boot, internal pool,
 ```
 
 See §11 for the full preset list.
+
+### 3.12 Distributed (XA) transactions (WildFly / JTA)
+
+Use this when the application needs **XA / two-phase commit** transactions coordinated by a JTA
+transaction manager (WildFly/Narayana, Atomikos, Bitronix). The entry point is a dedicated
+`javax.sql.XADataSource`, **not** `AwsWrapperDataSource`:
+
+```xml
+<xa-datasource jndi-name="java:jboss/datasources/WriterXADS" pool-name="WriterXADS">
+    <driver>aws-advanced-jdbc-wrapper</driver>
+    <xa-datasource-class>software.amazon.jdbc.ds.AwsWrapperXADataSource</xa-datasource-class>
+    <!-- Target driver's XADataSource: PG org.postgresql.xa.PGXADataSource;
+         MySQL com.mysql.cj.jdbc.MysqlXADataSource; MariaDB org.mariadb.jdbc.MariaDbDataSource -->
+    <xa-datasource-property name="targetDataSourceClassName">org.postgresql.xa.PGXADataSource</xa-datasource-property>
+    <!-- Wrapper properties go in the jdbcUrl query string (XML-escape '&' as '&amp;').
+         Use CONNECT-TIME plugins only; wrapper params are stripped before reaching the target driver. -->
+    <xa-datasource-property name="jdbcUrl">jdbc:aws-wrapper:postgresql://my-cluster.cluster-XXX.us-east-1.rds.amazonaws.com:5432/mydb?wrapperDialect=aurora-pg&amp;wrapperPlugins=efm2</xa-datasource-property>
+    <security>
+        <user-name>myuser</user-name>
+        <password>mypassword</password>
+    </security>
+</xa-datasource>
+```
+
+**Non-negotiable constraints on the XA path (state these to the user):**
+- **No connection-switching plugins.** `readWriteSplitting` (any variant) and `failover`/`failover2`
+  must not be configured on the XA datasource — an XA branch is pinned to one physical session, so a
+  switch would run work outside the transaction. Read/write splitting is skipped during a branch, and
+  a failover attempt mid-branch **fails fast** (SQLSTATE `08007`); the transaction manager then rolls
+  the (unprepared) branch back. There is no transparent failover of an in-flight XA transaction — this
+  is inherent to XA, not a wrapper limitation.
+- **No wrapper internal connection pool** (`connectionPoolType`) and **no custom connection provider** —
+  both fail fast, because they pool/return plain connections with no `XAResource`. The transaction
+  manager / application server provides XA connection pooling.
+- **What the wrapper still adds at connect time:** IAM / Secrets Manager authentication, topology-aware
+  writer discovery, observability, and Blue/Green awareness. For IAM, use `wrapperPlugins=iam`, set
+  `iamRegion`, use the IAM DB user, and omit the password.
+- **PostgreSQL server prerequisite:** set `max_prepared_transactions > 0` (cluster parameter group for
+  Aurora) or `XAResource.prepare` fails. MySQL/InnoDB supports XA by default.
+
+**Recommended architecture — two datasources:** an `AwsWrapperXADataSource` for the write/2PC path
+(connect-time plugins only) **plus** a normal `AwsWrapperDataSource` with `failover2` + read/write
+splitting for the read path (§3.6 / §3.6b). The XA datasource gets what XA allows; the read datasource
+keeps the switching features.
+
+Full details, per-driver examples, and the IAM example: [`UsingXADataSource.md`](using-the-jdbc-driver/UsingXADataSource.md).
 
 ---
 

--- a/docs/using-the-jdbc-driver/DataSource.md
+++ b/docs/using-the-jdbc-driver/DataSource.md
@@ -1,6 +1,8 @@
 # Connecting with a DataSource
 You can use the `DriverManager` class or a datasource to establish a new connection when using the AWS Advanced JDBC Wrapper. The AWS Advanced JDBC Wrapper has a built-in datasource class named [AwsWrapperDataSource](../../wrapper/src/main/java/software/amazon/jdbc/ds/AwsWrapperDataSource.java) that allows the AWS Advanced JDBC Wrapper to work with various driver-specific datasources.
 
+> **Distributed (XA) transactions:** to participate in XA / two-phase commit transactions coordinated by a JTA transaction manager, use the `javax.sql.XADataSource` entry point instead. See [Using the AWS Advanced JDBC Wrapper as an XADataSource](./UsingXADataSource.md).
+
 ## Using the AwsWrapperDataSource
 
 To establish a connection with the AwsWrapperDataSource, you must:

--- a/docs/using-the-jdbc-driver/UsingXADataSource.md
+++ b/docs/using-the-jdbc-driver/UsingXADataSource.md
@@ -1,0 +1,170 @@
+# Using the AWS Advanced JDBC Wrapper as an XADataSource
+
+The AWS Advanced JDBC Wrapper can be used as a `javax.sql.XADataSource` so it can participate in
+distributed (XA / two-phase commit) transactions coordinated by a JTA transaction manager such as
+the one built into WildFly/JBoss (Narayana), or a standalone manager like Atomikos or Bitronix.
+
+The XA entry point is `software.amazon.jdbc.ds.AwsWrapperXADataSource`. It wraps a **target
+driver-specific `XADataSource`** (for example `org.postgresql.xa.PGXADataSource`,
+`com.mysql.cj.jdbc.MysqlXADataSource`, or `org.mariadb.jdbc.MariaDbDataSource` — MariaDB
+Connector/J uses a single unified class that also implements `XADataSource`) so the wrapper's
+plugin pipeline applies to the
+application-facing `java.sql.Connection`, while the XA control surface (`XAConnection` /
+`XAResource`) is delegated to the target driver.
+
+## Configuration
+
+`AwsWrapperXADataSource` exposes the same configuration surface as `AwsWrapperDataSource`, except
+that `targetDataSourceClassName` must name a `javax.sql.XADataSource` implementation.
+
+| Property                       | Description                                                                 |
+|--------------------------------|-----------------------------------------------------------------------------|
+| `targetDataSourceClassName`    | Fully-qualified class name of the target `XADataSource` (required). PostgreSQL: `org.postgresql.xa.PGXADataSource`. MySQL: `com.mysql.cj.jdbc.MysqlXADataSource`. MariaDB: `org.mariadb.jdbc.MariaDbDataSource` (a single unified class that also implements `XADataSource`). |
+| `jdbcUrl`                      | The JDBC URL to connect with (e.g. `jdbc:aws-wrapper:postgresql://host/db`). Wrapper properties may be supplied as query parameters here (e.g. `?wrapperPlugins=iam&wrapperDialect=aurora-pg`). |
+| `serverName` / `serverPort` / `database` | Used to build the URL when `jdbcUrl` is not set.                  |
+| `jdbcProtocol`                 | e.g. `jdbc:postgresql:` (required when `jdbcUrl` is not set).                |
+| `user` / `password`            | Credentials.                                                                |
+| `targetDataSourceProperties`   | Properties applied to the target `XADataSource` (see below).                |
+
+### Passing properties to the wrapper and the target XADataSource
+
+There are two ways to supply configuration, and you can use either or both:
+
+1. **`jdbcUrl` query string** — append parameters to the URL, for example
+   `jdbc:aws-wrapper:postgresql://host:5432/db?wrapperPlugins=iam&ssl=true`. Both **wrapper**
+   parameters (`wrapperPlugins`, `wrapperDialect`, `iamRegion`, …) and **target-driver** parameters
+   (`ssl`, `ApplicationName`, `socketTimeout`, …) can be mixed here. The wrapper consumes its own
+   parameters and **strips them from the URL before handing it to the target driver**, so the target
+   only ever sees target-driver parameters.
+2. **`targetDataSourceProperties`** — a `Properties` object whose entries are applied to the target
+   `XADataSource` via its bean setters. This mirrors how `AwsWrapperDataSource` configures a target
+   `DataSource`. Wrapper-specific keys placed here are also stripped before reaching the target.
+
+### WildFly `<xa-datasource-class>` example
+
+Wrapper properties (for example `wrapperPlugins` and `wrapperDialect`) are configured as query
+parameters on the `jdbcUrl`. In XML, separate them with `&amp;`. Only **connect-time** plugins are
+meaningful on the XA path — see [Benefits and limitations](#benefits-and-limitations-on-the-xa-path);
+do not configure connection-switching plugins such as `readWriteSplitting`, `failover`, or
+`failover2` on the XA datasource.
+
+```xml
+<datasource-class name="aws-wrapper-xa">
+    <driver>aws-advanced-jdbc-wrapper</driver>
+</datasource-class>
+
+<xa-datasource jndi-name="java:jboss/datasources/ExampleXADS" pool-name="ExampleXADS">
+    <driver>aws-advanced-jdbc-wrapper</driver>
+    <xa-datasource-class>software.amazon.jdbc.ds.AwsWrapperXADataSource</xa-datasource-class>
+    <xa-datasource-property name="targetDataSourceClassName">org.postgresql.xa.PGXADataSource</xa-datasource-property>
+    <!-- Wrapper properties are passed as jdbcUrl query parameters (XML-escape '&' as '&amp;').
+         Here: confirm the Aurora PostgreSQL dialect up front and enable the host-monitoring (efm2)
+         connect-time plugin. Add or remove connect-time plugins to taste. -->
+    <xa-datasource-property name="jdbcUrl">jdbc:aws-wrapper:postgresql://db.cluster-xyz.us-east-1.rds.amazonaws.com:5432/mydb?wrapperDialect=aurora-pg&amp;wrapperPlugins=efm2</xa-datasource-property>
+    <security>
+        <user-name>myuser</user-name>
+        <password>mypassword</password>
+    </security>
+</xa-datasource>
+```
+
+#### IAM authentication example
+
+IAM database authentication works on the XA path: the IAM plugin generates a short-lived token at
+connect time and the wrapper applies it to the target `XADataSource`. Enable the `iam` plugin, set
+the region, use the IAM database user, and omit the password.
+
+```xml
+<xa-datasource jndi-name="java:jboss/datasources/IamXADS" pool-name="IamXADS">
+    <driver>aws-advanced-jdbc-wrapper</driver>
+    <xa-datasource-class>software.amazon.jdbc.ds.AwsWrapperXADataSource</xa-datasource-class>
+    <xa-datasource-property name="targetDataSourceClassName">org.postgresql.xa.PGXADataSource</xa-datasource-property>
+    <xa-datasource-property name="jdbcUrl">jdbc:aws-wrapper:postgresql://db.cluster-xyz.us-east-1.rds.amazonaws.com:5432/mydb?wrapperPlugins=iam&amp;iamRegion=us-east-1</xa-datasource-property>
+    <security>
+        <!-- IAM database user; no password (the IAM plugin supplies a generated token). -->
+        <user-name>iam_user</user-name>
+    </security>
+</xa-datasource>
+```
+
+## Benefits and limitations on the XA path
+
+On the XA datasource the wrapper's value is **primarily connect-time** rather than switch-time: no
+connection-switching plugin may move an in-flight XA branch to a different session (the one runtime
+exception is Blue/Green Deployment, which pauses and resumes rather than switching mid-transaction).
+This is important to understand before adopting it.
+
+**What the wrapper provides on the XA path:**
+
+- **Authentication** — IAM authentication and AWS Secrets Manager / federated credentials work
+  unchanged (they act while establishing the connection).
+- **Topology-aware writer discovery** — connect to the current writer, handling cluster/custom
+  endpoints and stale DNS.
+- **Faster reconnection for the next transaction** — after an instance failover, when the
+  transaction manager's pool discards the broken `XAConnection` and requests a new one, the wrapper
+  routes it to the promoted writer via topology (faster than plain DNS).
+- **Observability** — enhanced logging, exception context, and telemetry.
+- **Blue/Green Deployment support** — not limited to connect time. The Blue/Green Deployment plugin
+  also acts at runtime: it can hold execution while a switchover is in progress and resume against
+  the promoted topology once the switchover completes.
+
+**What is NOT supported on the XA path:**
+
+- **Read/write splitting is not supported.** An XA transaction branch is pinned to one physical
+  database session and the `XAResource` is bound to it, so routing a statement to a different
+  (reader) session would run it outside the transaction. Read/write splitting therefore has no
+  valid use on the XA datasource, and it is skipped during an XA transaction (a warning is logged if
+  it is configured).
+- **Transparent failover of an in-flight XA transaction is not possible.** This is inherent to XA:
+  if the database session is lost mid-transaction, the branch cannot be moved to another node. The
+  wrapper fails fast (SQLSTATE `08007`) so the transaction manager rolls the branch back. Recovery
+  happens for the *next* transaction, not the current one.
+- **The wrapper's internal connection pool is not applicable.** XA connection pooling is provided
+  by the transaction manager / application server. Configuring the wrapper's internal connection
+  pool (or a custom connection provider) together with the XA datasource fails fast.
+
+If your only goal is transparent failover, note that the XA datasource offers little in that
+regard — again, an inherent property of XA rather than a wrapper limitation.
+
+## Recommended architecture: the two-datasource pattern
+
+For applications that need both distributed transactions and the wrapper's failover / read-write
+splitting features, use **two datasources**:
+
+- an `AwsWrapperXADataSource` (no connection-switching plugins, no internal pool) for the
+  **write / 2PC** path, and
+- a non-XA `AwsWrapperDataSource` with failover + read/write splitting (and internal pooling) for
+  the **read** path.
+
+The read path keeps the headline switching features; the write path gets what XA allows.
+
+```xml
+<!-- Write / XA path: connect-time plugins only (no connection-switching plugins). Wrapper
+     properties are jdbcUrl query parameters; XML-escape '&' as '&amp;'. -->
+<xa-datasource jndi-name="java:jboss/datasources/WriterXADS" pool-name="WriterXADS">
+    <driver>aws-advanced-jdbc-wrapper</driver>
+    <xa-datasource-class>software.amazon.jdbc.ds.AwsWrapperXADataSource</xa-datasource-class>
+    <xa-datasource-property name="targetDataSourceClassName">org.postgresql.xa.PGXADataSource</xa-datasource-property>
+    <xa-datasource-property name="jdbcUrl">jdbc:aws-wrapper:postgresql://cluster-endpoint:5432/mydb?wrapperDialect=aurora-pg&amp;wrapperPlugins=efm2</xa-datasource-property>
+</xa-datasource>
+
+<!-- Read path (non-XA, with failover + read/write splitting). Here connection-switching plugins
+     are appropriate because this datasource does not participate in XA transactions. -->
+<datasource jndi-name="java:jboss/datasources/ReaderDS" pool-name="ReaderDS">
+    <connection-url>jdbc:aws-wrapper:postgresql://reader-cluster-endpoint:5432/mydb?wrapperPlugins=readWriteSplitting,failover2,efm2</connection-url>
+    <driver>aws-advanced-jdbc-wrapper</driver>
+</datasource>
+```
+
+## Notes
+
+- **PostgreSQL server configuration:** PostgreSQL disables prepared (two-phase) transactions by
+  default (`max_prepared_transactions = 0`). To use XA / two-phase commit against PostgreSQL (or
+  Aurora PostgreSQL), set `max_prepared_transactions` to a value greater than 0 (in the RDS/Aurora
+  cluster parameter group for Aurora) and restart. Otherwise `XAResource.prepare` fails. MySQL/InnoDB
+  supports XA by default.
+- `AwsWrapperXADataSource` requires a target `XADataSource`; a plain `DataSource` class name is
+  rejected at `getXAConnection()` time.
+- Because each `XAConnection.getConnection()` returns a fresh logical connection over the same
+  physical session, the wrapper builds a fresh plugin pipeline per logical connection to keep plugin
+  state isolated between checkouts.

--- a/wrapper/build.gradle.kts
+++ b/wrapper/build.gradle.kts
@@ -131,6 +131,12 @@ dependencies {
     testImplementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.22.1")
     testImplementation("io.valkey:valkey-glide:2.3.0:$nativeClassifier") // Note: to run unit tests on ARM Mac, change native classifier to "osx-x86_64"
     testImplementation("com.github.jsqlparser:jsqlparser:4.9") // Required by sqlParser/autoReadWriteSplitting and kmsEncryption plugins
+    // XA transaction managers for XADataSource integration tests (both are exercised for compatibility).
+    testImplementation("org.jboss.narayana.jta:narayana-jta:5.11.4.Final") // 5.11.x is the last Java 8-compatible line
+    // Narayana declares jboss-logging as optional/provided; add it explicitly or jtaLogger fails to init.
+    testImplementation("org.jboss.logging:jboss-logging:3.4.3.Final")
+    testImplementation("com.atomikos:transactions-jta:5.0.9")
+    testImplementation("com.atomikos:transactions-jdbc:5.0.9")
 }
 
 repositories {

--- a/wrapper/src/main/java/software/amazon/jdbc/ConnectionInfo.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/ConnectionInfo.java
@@ -17,18 +17,36 @@
 package software.amazon.jdbc;
 
 import java.sql.Connection;
+import javax.sql.XAConnection;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class ConnectionInfo {
   private final Connection connection;
   private final boolean isPooled;
+  private final @Nullable XAConnection xaConnection;
 
   public ConnectionInfo(Connection connection, boolean isPooled) {
-    this.connection = connection;
-    this.isPooled = isPooled;
+    this(connection, isPooled, null);
   }
 
   public ConnectionInfo(Connection connection) {
-    this(connection, false);
+    this(connection, false, null);
+  }
+
+  /**
+   * Creates a {@link ConnectionInfo} that also carries the owning {@link XAConnection} for the XA
+   * datasource path. The {@code connection} is the logical connection obtained from
+   * {@code xaConnection.getConnection()}; {@code xaConnection} owns the physical session and the
+   * {@code XAResource}.
+   *
+   * @param connection   the (logical) physical connection handed to the wrapper.
+   * @param isPooled     whether the connection came from a pool.
+   * @param xaConnection the owning XA connection, or null on the non-XA path.
+   */
+  public ConnectionInfo(Connection connection, boolean isPooled, @Nullable XAConnection xaConnection) {
+    this.connection = connection;
+    this.isPooled = isPooled;
+    this.xaConnection = xaConnection;
   }
 
   public Connection getConnection() {
@@ -37,5 +55,15 @@ public class ConnectionInfo {
 
   public boolean isPooled() {
     return isPooled;
+  }
+
+  /**
+   * Returns the owning {@link XAConnection} when this info was produced on the XA datasource path,
+   * or null otherwise.
+   *
+   * @return the owning XA connection, or null.
+   */
+  public @Nullable XAConnection getXaConnection() {
+    return xaConnection;
   }
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/PartialPluginService.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/PartialPluginService.java
@@ -369,6 +369,18 @@ public class PartialPluginService implements PluginService, CanReleaseResources,
   }
 
   @Override
+  public boolean isXaTransactionActive() {
+    throw new UnsupportedOperationException(
+        Messages.get("PartialPluginService.unexpectedMethodCall", new Object[] {"isXaTransactionActive"}));
+  }
+
+  @Override
+  public void setXaTransactionActive(final boolean active) {
+    throw new UnsupportedOperationException(
+        Messages.get("PartialPluginService.unexpectedMethodCall", new Object[] {"setXaTransactionActive"}));
+  }
+
+  @Override
   public boolean isDialectConfirmed() {
     throw new UnsupportedOperationException(
         Messages.get("PartialPluginService.unexpectedMethodCall", new Object[] {"isDialectConfirmed"}));

--- a/wrapper/src/main/java/software/amazon/jdbc/PluginService.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/PluginService.java
@@ -163,6 +163,25 @@ public interface PluginService extends ExceptionHandler, Wrapper, StateSnapshotP
 
   boolean isInTransaction();
 
+  /**
+   * Indicates whether the current connection is enlisted in an active XA transaction branch (i.e.
+   * between {@code XAResource.start(xid)} and the terminal {@code commit}/{@code rollback}). This is
+   * tracked separately from {@link #isInTransaction()} because XA branches driven by a transaction
+   * manager run without the {@code BEGIN}/{@code COMMIT} SQL that the SQL heuristic observes.
+   *
+   * @return true if an XA transaction branch is currently active on the connection.
+   */
+  boolean isXaTransactionActive();
+
+  /**
+   * Marks whether the current connection is enlisted in an active XA transaction branch. Driven by
+   * the wrapper's {@code XAResourceWrapper} ({@code start} sets it; terminal {@code commit}/
+   * {@code rollback} clears it; {@code prepare} does not clear it).
+   *
+   * @param active true to mark the connection XA-active, false to clear.
+   */
+  void setXaTransactionActive(boolean active);
+
   boolean isDialectConfirmed();
 
   HostListProvider getHostListProvider();

--- a/wrapper/src/main/java/software/amazon/jdbc/PluginServiceImpl.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/PluginServiceImpl.java
@@ -58,6 +58,7 @@ import software.amazon.jdbc.util.Messages;
 import software.amazon.jdbc.util.Pair;
 import software.amazon.jdbc.util.PropertyUtils;
 import software.amazon.jdbc.util.ResourceLock;
+import software.amazon.jdbc.util.SqlState;
 import software.amazon.jdbc.util.Utils;
 import software.amazon.jdbc.util.storage.CacheMap;
 import software.amazon.jdbc.util.telemetry.TelemetryFactory;
@@ -83,6 +84,7 @@ public class PluginServiceImpl implements PluginService, CanReleaseResources,
   protected HostSpec initialConnectionHostSpec;
   protected @Nullable HostSpec routedHostSpec;
   private boolean isInTransaction;
+  private volatile boolean isXaTransactionActive;
   private boolean isDialectConfirmed;
   private final ExceptionManager exceptionManager;
   protected final @Nullable ExceptionHandler exceptionHandler;
@@ -294,6 +296,19 @@ public class PluginServiceImpl implements PluginService, CanReleaseResources,
       throws SQLException {
 
     try (ResourceLock ignored = connectionSwitchLock.obtain()) {
+
+      // Last line of defense for XA correctness: a physical connection enlisted in an active XA
+      // transaction branch must not be swapped out from under the transaction manager. Plugins are
+      // expected to skip (voluntary switches) or fail fast (failover) before reaching this point;
+      // this guard only catches a switch that slipped through. A HostSpec-only update (same
+      // connection object) and initial establishment (currentConnection == null) are allowed.
+      if (this.isXaTransactionActive
+          && this.currentConnection != null
+          && connection != this.currentConnection) {
+        throw new SQLException(
+            Messages.get("PluginServiceImpl.connectionSwitchDuringXaTransaction"),
+            SqlState.ACTIVE_SQL_TRANSACTION.getState());
+      }
 
       if (this.currentConnection == null) {
         // setting up an initial connection
@@ -524,6 +539,16 @@ public class PluginServiceImpl implements PluginService, CanReleaseResources,
   @Override
   public void setInTransaction(final boolean inTransaction) {
     this.isInTransaction = inTransaction;
+  }
+
+  @Override
+  public boolean isXaTransactionActive() {
+    return this.isXaTransactionActive;
+  }
+
+  @Override
+  public void setXaTransactionActive(final boolean active) {
+    this.isXaTransactionActive = active;
   }
 
   @Override
@@ -910,6 +935,7 @@ public class PluginServiceImpl implements PluginService, CanReleaseResources,
     state.add(Pair.create("currentHostSpec",
         this.currentHostSpec != null ? this.currentHostSpec.toString() : null));
     state.add(Pair.create("isInTransaction", this.isInTransaction));
+    state.add(Pair.create("isXaTransactionActive", this.isXaTransactionActive));
     state.add(Pair.create("dialect", this.dialect != null ? this.dialect.getClass().getName() : null));
     state.add(Pair.create("pooledConnection", this.pooledConnection));
     return state;

--- a/wrapper/src/main/java/software/amazon/jdbc/ds/AwsWrapperDataSource.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/ds/AwsWrapperDataSource.java
@@ -16,9 +16,6 @@
 
 package software.amazon.jdbc.ds;
 
-import static software.amazon.jdbc.util.ConnectionUrlBuilder.buildUrl;
-import static software.amazon.jdbc.util.ConnectionUrlParser.parsePropertiesFromUrl;
-
 import java.io.PrintWriter;
 import java.io.Serializable;
 import java.sql.Connection;
@@ -38,7 +35,6 @@ import software.amazon.jdbc.ConnectionProvider;
 import software.amazon.jdbc.DataSourceConnectionProvider;
 import software.amazon.jdbc.Driver;
 import software.amazon.jdbc.DriverConnectionProvider;
-import software.amazon.jdbc.HostSpec;
 import software.amazon.jdbc.PropertyDefinition;
 import software.amazon.jdbc.TargetDriverHelper;
 import software.amazon.jdbc.authentication.AwsCredentialsManager;
@@ -69,9 +65,6 @@ public class AwsWrapperDataSource implements DataSource, Referenceable, Serializ
   private static final Logger LOGGER = Logger.getLogger(AwsWrapperDataSource.class.getName());
 
   private static final String PROTOCOL_PREFIX = "jdbc:aws-wrapper:";
-
-  private static final String SERVER_NAME = "serverName";
-  private static final String SERVER_PORT = "serverPort";
 
   private final ConnectionUrlParser urlParser = new ConnectionUrlParser();
   private final StorageService storageService;
@@ -157,55 +150,17 @@ public class AwsWrapperDataSource implements DataSource, Referenceable, Serializ
         TelemetryTraceLevel.TOP_LEVEL);
 
     try {
-      // Identify the URL for connection.
-      if (!StringUtils.isNullOrEmpty(this.jdbcUrl)) {
-        finalUrl = this.jdbcUrl.replaceFirst(PROTOCOL_PREFIX, "jdbc:");
-
-        parsePropertiesFromUrl(this.jdbcUrl, props);
-        setDatabasePropertyFromUrl(props);
-
-        // Override credentials with the ones provided through the data source property.
-        setCredentialProperties(props);
-
-        // Override database with the one provided through the data source property.
-        if (!StringUtils.isNullOrEmpty(this.database)) {
-          PropertyDefinition.DATABASE.set(props, this.database);
-        }
-
-      } else {
-        final String serverName = !StringUtils.isNullOrEmpty(this.serverName)
-            ? this.serverName
-            : props.getProperty(SERVER_NAME);
-        final String serverPort = !StringUtils.isNullOrEmpty(this.serverPort)
-            ? this.serverPort
-            : props.getProperty(SERVER_PORT);
-        final String databaseName = !StringUtils.isNullOrEmpty(this.database)
-            ? this.database
-            : PropertyDefinition.DATABASE.getString(props);
-
-        if (StringUtils.isNullOrEmpty(serverName)) {
-          throw new SQLException(Messages.get("AwsWrapperDataSource.missingTarget"));
-        }
-        final String jdbcProtocol = this.jdbcProtocol;
-        if (StringUtils.isNullOrEmpty(jdbcProtocol)) {
-          throw new SQLException(Messages.get("AwsWrapperDataSource.missingJdbcProtocol"));
-        }
-
-        int port = HostSpec.NO_PORT;
-        if (!StringUtils.isNullOrEmpty(serverPort)) {
-          port = Integer.parseInt(serverPort);
-        }
-
-        finalUrl = buildUrl(jdbcProtocol, serverName, port, databaseName);
-
-        // Override credentials with the ones provided through the data source property.
-        setCredentialProperties(props);
-
-        // Override database with the one provided through the data source property.
-        if (!StringUtils.isNullOrEmpty(databaseName)) {
-          PropertyDefinition.DATABASE.set(props, databaseName);
-        }
-      }
+      // Identify the URL for connection (shared with AwsWrapperXADataSource).
+      finalUrl = DataSourceConfigHelper.resolveFinalUrl(
+          props,
+          PROTOCOL_PREFIX,
+          this.jdbcUrl,
+          this.serverName,
+          this.serverPort,
+          this.database,
+          this.jdbcProtocol,
+          this.user,
+          this.password);
 
       TargetDriverDialect targetDriverDialect = configurationProfile == null
           ? null
@@ -454,33 +409,11 @@ public class AwsWrapperDataSource implements DataSource, Referenceable, Serializ
     return reference;
   }
 
-  private void setCredentialProperties(final Properties props) {
-    // If username was provided as a get connection parameter.
-    if (!StringUtils.isNullOrEmpty(this.user)) {
-      PropertyDefinition.USER.set(props, this.user);
-    }
-
-    if (!StringUtils.isNullOrEmpty(this.password)) {
-      PropertyDefinition.PASSWORD.set(props, this.password);
-    }
-  }
-
   DataSource createTargetDataSource() throws SQLException {
     try {
       return WrapperUtils.createInstance(this.targetDataSourceClassName, DataSource.class);
     } catch (final InstantiationException instEx) {
       throw new SQLException(instEx.getMessage(), SqlState.UNKNOWN_STATE.getState(), instEx);
-    }
-  }
-
-  private void setDatabasePropertyFromUrl(final Properties props) {
-    final String url = this.jdbcUrl;
-    if (StringUtils.isNullOrEmpty(url)) {
-      return;
-    }
-    final String databaseName = ConnectionUrlParser.parseDatabaseFromUrl(url);
-    if (!StringUtils.isNullOrEmpty(databaseName)) {
-      PropertyDefinition.DATABASE.set(props, databaseName);
     }
   }
 

--- a/wrapper/src/main/java/software/amazon/jdbc/ds/AwsWrapperXADataSource.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/ds/AwsWrapperXADataSource.java
@@ -1,0 +1,467 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.jdbc.ds;
+
+import java.io.PrintWriter;
+import java.io.Serializable;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Properties;
+import java.util.Set;
+import java.util.logging.Logger;
+import javax.sql.XAConnection;
+import javax.sql.XADataSource;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import software.amazon.jdbc.Driver;
+import software.amazon.jdbc.PropertyDefinition;
+import software.amazon.jdbc.authentication.AwsCredentialsManager;
+import software.amazon.jdbc.ds.xa.XAConnectionWrapper;
+import software.amazon.jdbc.ds.xa.XADataSourceConnectionProvider;
+import software.amazon.jdbc.profile.ConfigurationProfile;
+import software.amazon.jdbc.profile.DriverConfigurationProfiles;
+import software.amazon.jdbc.targetdriverdialect.TargetDriverDialect;
+import software.amazon.jdbc.targetdriverdialect.TargetDriverDialectManager;
+import software.amazon.jdbc.util.ConnectionUrlParser;
+import software.amazon.jdbc.util.CoreServicesContainer;
+import software.amazon.jdbc.util.FullServicesContainer;
+import software.amazon.jdbc.util.Messages;
+import software.amazon.jdbc.util.PropertyUtils;
+import software.amazon.jdbc.util.ServiceUtility;
+import software.amazon.jdbc.util.SqlState;
+import software.amazon.jdbc.util.StringUtils;
+import software.amazon.jdbc.util.WrapperUtils;
+import software.amazon.jdbc.util.events.EventPublisher;
+import software.amazon.jdbc.util.monitoring.MonitorService;
+import software.amazon.jdbc.util.storage.StorageService;
+import software.amazon.jdbc.util.telemetry.DefaultTelemetryFactory;
+import software.amazon.jdbc.util.telemetry.TelemetryFactory;
+import software.amazon.jdbc.wrapper.ConnectionWrapper;
+
+/**
+ * An {@link XADataSource} entry point for the AWS Advanced JDBC Wrapper. It wraps a target
+ * driver-specific {@code XADataSource} (for example {@code org.postgresql.xa.PGXADataSource} or
+ * {@code com.mysql.cj.jdbc.MysqlXADataSource}) so the wrapper's plugin pipeline applies to the
+ * application-facing {@link java.sql.Connection}, while the XA control surface is delegated to the
+ * target's {@code XAResource}.
+ *
+ * <p>Connection-switching plugins (read/write splitting, failover) are not supported on the XA
+ * path; see the XA documentation for the recommended two-datasource pattern. The wrapper's internal
+ * connection pool is also not applicable to the XA path (the transaction manager / application
+ * server provides XA connection pooling).
+ */
+public class AwsWrapperXADataSource implements XADataSource, Serializable {
+
+  private static final long serialVersionUID = 1L;
+  private static final Logger LOGGER = Logger.getLogger(AwsWrapperXADataSource.class.getName());
+
+  private static final String PROTOCOL_PREFIX = "jdbc:aws-wrapper:";
+
+  private static final Set<String> RW_SPLITTING_PLUGIN_CODES = Collections.unmodifiableSet(
+      new HashSet<>(Arrays.asList(
+          "readWriteSplitting",
+          "autoReadWriteSplitting",
+          "srw",
+          "gdbReadWriteSplitting",
+          "autoGdbReadWriteSplitting",
+          "autoSrwReadWriteSplitting")));
+
+  private final transient ConnectionUrlParser urlParser = new ConnectionUrlParser();
+  private final transient StorageService storageService;
+  private final transient MonitorService monitorService;
+  private final transient EventPublisher eventPublisher;
+
+  static {
+    try {
+      if (!Driver.isRegistered()) {
+        Driver.register();
+      }
+    } catch (final SQLException e) {
+      throw new ExceptionInInitializerError(e);
+    }
+  }
+
+  protected transient @Nullable PrintWriter logWriter;
+  protected @Nullable String user;
+  protected @Nullable String password;
+  protected @Nullable String jdbcUrl;
+  protected @Nullable String targetDataSourceClassName;
+  protected @Nullable Properties targetDataSourceProperties;
+  protected @Nullable String jdbcProtocol;
+  protected @Nullable String serverName;
+  protected @Nullable String serverPort;
+  protected @Nullable String database;
+  private int loginTimeout = 0;
+
+  public AwsWrapperXADataSource() {
+    this(CoreServicesContainer.getInstance());
+  }
+
+  public AwsWrapperXADataSource(final CoreServicesContainer coreServicesContainer) {
+    this.storageService = coreServicesContainer.getStorageService();
+    this.monitorService = coreServicesContainer.getMonitorService();
+    this.eventPublisher = coreServicesContainer.getEventPublisher();
+  }
+
+  public void setTargetDataSourceClassName(final @Nullable String className) {
+    this.targetDataSourceClassName = className;
+  }
+
+  public @Nullable String getTargetDataSourceClassName() {
+    return this.targetDataSourceClassName;
+  }
+
+  public void setServerName(final @NonNull String serverName) {
+    this.serverName = serverName;
+  }
+
+  public @Nullable String getServerName() {
+    return this.serverName;
+  }
+
+  public void setServerPort(final @NonNull String serverPort) {
+    this.serverPort = serverPort;
+  }
+
+  public @Nullable String getServerPort() {
+    return this.serverPort;
+  }
+
+  public void setDatabase(final @NonNull String database) {
+    this.database = database;
+  }
+
+  public @Nullable String getDatabase() {
+    return this.database;
+  }
+
+  public void setJdbcUrl(final @Nullable String url) {
+    this.jdbcUrl = url;
+  }
+
+  public @Nullable String getJdbcUrl() {
+    return this.jdbcUrl;
+  }
+
+  public void setJdbcProtocol(final @NonNull String jdbcProtocol) {
+    this.jdbcProtocol = jdbcProtocol;
+  }
+
+  public @Nullable String getJdbcProtocol() {
+    return this.jdbcProtocol;
+  }
+
+  public void setTargetDataSourceProperties(final @Nullable Properties props) {
+    this.targetDataSourceProperties = props;
+  }
+
+  public @Nullable Properties getTargetDataSourceProperties() {
+    return this.targetDataSourceProperties;
+  }
+
+  public void setUser(final @Nullable String user) {
+    this.user = user;
+  }
+
+  public @Nullable String getUser() {
+    return this.user;
+  }
+
+  public void setPassword(final @Nullable String password) {
+    this.password = password;
+  }
+
+  public @Nullable String getPassword() {
+    return this.password;
+  }
+
+  @Override
+  public XAConnection getXAConnection() throws SQLException {
+    return getXAConnection(this.user, this.password);
+  }
+
+  @Override
+  public XAConnection getXAConnection(final @Nullable String username, final @Nullable String password)
+      throws SQLException {
+    this.user = username;
+    this.password = password;
+
+    // Reject the wrapper's internal connection pool on the XA path: those providers pool plain
+    // Connections and cannot expose an XAResource. XA connection pooling is provided by the
+    // transaction manager / application server.
+    final Properties rawProps = PropertyUtils.copyProperties(
+        this.targetDataSourceProperties != null ? this.targetDataSourceProperties : new Properties());
+    if (PropertyDefinition.CONNECTION_POOL_TYPE.getString(rawProps) != null) {
+      throw new SQLException(
+          Messages.get(
+              "AwsWrapperXADataSource.internalConnectionPoolNotSupportedWithXa",
+              new Object[] {PropertyDefinition.CONNECTION_POOL_TYPE.getString(rawProps)}),
+          SqlState.UNKNOWN_STATE.getState());
+    }
+
+    // A globally-set custom connection provider (e.g. an internal pooled provider) would be used by
+    // the connect pipeline instead of the XA provider, silently opening a non-XA connection. That is
+    // not compatible with the XA path, so reject it.
+    if (Driver.getCustomConnectionProvider() != null) {
+      throw new SQLException(
+          Messages.get("AwsWrapperXADataSource.customConnectionProviderNotSupportedWithXa"),
+          SqlState.UNKNOWN_STATE.getState());
+    }
+
+    final XADataSource targetXaDataSource = createTargetXADataSource();
+    final ResolvedConfig config = resolveConfig();
+    warnIfConnectionSwitchingPluginsConfigured(config.props);
+    configureTargetXaDataSource(targetXaDataSource, config);
+
+    // The provider re-applies a wrapper-parameter-free URL to the target at connect time, when the
+    // configured plugin classes are loaded and all wrapper property names are registered (so the
+    // URL cleaning is complete, unlike the best-effort cleaning done above at getXAConnection time).
+    final XADataSourceConnectionProvider provider =
+        new XADataSourceConnectionProvider(targetXaDataSource, config.finalUrl);
+
+    // Each getConnection() on the returned XAConnection builds a fresh logical connection with a
+    // fresh plugin pipeline over the same physical XA connection (Option B).
+    final XAConnectionWrapper.LogicalConnectionBuilder handleBuilder =
+        () -> buildLogicalConnection(provider, config);
+
+    return new XAConnectionWrapper(provider, handleBuilder);
+  }
+
+  /**
+   * Builds one logical connection: a {@link ConnectionWrapper} with a fresh plugin pipeline whose
+   * physical connection is obtained (and reused) from the shared {@link XADataSourceConnectionProvider}.
+   */
+  ConnectionWrapper buildLogicalConnection(
+      final XADataSourceConnectionProvider provider, final ResolvedConfig config) throws SQLException {
+
+    final TelemetryFactory telemetryFactory = new DefaultTelemetryFactory(config.props);
+    final String targetProtocol = this.urlParser.getProtocol(config.finalUrl);
+
+    final FullServicesContainer servicesContainer = ServiceUtility.getInstance().createStandardServiceContainer(
+        this.storageService,
+        this.monitorService,
+        this.eventPublisher,
+        provider,
+        null,
+        telemetryFactory,
+        config.finalUrl,
+        targetProtocol,
+        config.targetDriverDialect,
+        config.props,
+        config.configurationProfile);
+
+    return new ConnectionWrapper(
+        servicesContainer,
+        config.props,
+        config.finalUrl,
+        targetProtocol,
+        config.configurationProfile);
+  }
+
+  /**
+   * Read/write splitting (and other connection-switching plugins that route work to a different
+   * physical session) have no valid use on the XA datasource: the {@code XAResource} is pinned to
+   * one session, so routing a statement elsewhere would run it outside the transaction. Warn if such
+   * a plugin is configured, and point users to the two-datasource pattern.
+   */
+  void warnIfConnectionSwitchingPluginsConfigured(final Properties props) {
+    final String plugins = PropertyDefinition.PLUGINS.getString(props);
+    if (StringUtils.isNullOrEmpty(plugins)) {
+      return;
+    }
+    for (final String rawCode : plugins.split(",")) {
+      final String code = rawCode.trim();
+      if (RW_SPLITTING_PLUGIN_CODES.contains(code)) {
+        LOGGER.warning(() -> Messages.get(
+            "AwsWrapperXADataSource.readWriteSplittingNotSupportedWithXa", new Object[] {code}));
+      }
+    }
+  }
+
+  XADataSource createTargetXADataSource() throws SQLException {
+    if (StringUtils.isNullOrEmpty(this.targetDataSourceClassName)) {
+      throw new SQLException(
+          Messages.get("AwsWrapperXADataSource.missingTarget"), SqlState.UNKNOWN_STATE.getState());
+    }
+    final String className = this.targetDataSourceClassName;
+    final Class<?> loaded;
+    try {
+      loaded = Class.forName(className);
+    } catch (final ClassNotFoundException e) {
+      throw new SQLException(
+          Messages.get("AwsWrapperXADataSource.missingTarget"), SqlState.UNKNOWN_STATE.getState(), e);
+    }
+    if (!XADataSource.class.isAssignableFrom(loaded)) {
+      throw new SQLException(
+          Messages.get("AwsWrapperXADataSource.targetNotXaDataSource", new Object[] {className}),
+          SqlState.UNKNOWN_STATE.getState());
+    }
+    try {
+      return WrapperUtils.createInstance(className, XADataSource.class);
+    } catch (final InstantiationException instEx) {
+      throw new SQLException(instEx.getMessage(), SqlState.UNKNOWN_STATE.getState(), instEx);
+    }
+  }
+
+  /**
+   * Configures the target {@link XADataSource} via bean setters from
+   * {@code targetDataSourceProperties}, plus the resolved connection URL and user/password.
+   *
+   * <p>AWS Wrapper-specific properties are stripped before anything reaches the target: from the
+   * property map via {@link PropertyDefinition#removeAll(Properties)}, and from the URL query string
+   * via {@link DataSourceConfigHelper#removeWrapperPropertiesFromUrl(String)}. This prevents wrapper
+   * parameters (e.g. {@code wrapperPlugins}) from leaking into the target driver's URL, which some
+   * drivers reject as unknown parameters.
+   */
+  void configureTargetXaDataSource(final XADataSource xaDataSource, final ResolvedConfig config) {
+    final Properties targetProps = new Properties();
+
+    if (this.targetDataSourceProperties != null) {
+      targetProps.putAll(this.targetDataSourceProperties);
+    }
+
+    // A computed URL lets server/port/database flow to the target XADataSource that supports setUrl.
+    // Strip wrapper-specific query parameters so they are not passed to the target driver.
+    final String targetUrl = DataSourceConfigHelper.removeWrapperPropertiesFromUrl(config.finalUrl);
+    if (!StringUtils.isNullOrEmpty(targetUrl)) {
+      targetProps.put("url", targetUrl);
+    }
+    if (!StringUtils.isNullOrEmpty(this.user)) {
+      targetProps.put(PropertyDefinition.USER.name, this.user);
+    }
+    if (!StringUtils.isNullOrEmpty(this.password)) {
+      targetProps.put(PropertyDefinition.PASSWORD.name, this.password);
+    }
+
+    // "user"/"password" are AWS Wrapper property names but are also standard target-datasource bean
+    // setters, so capture their effective values and re-apply them after removeAll strips
+    // wrapper-specific keys.
+    final String effectiveUser = targetProps.getProperty(PropertyDefinition.USER.name);
+    final String effectivePassword = targetProps.getProperty(PropertyDefinition.PASSWORD.name);
+
+    // Remove AWS Wrapper-specific properties so only target-relevant properties are applied.
+    PropertyDefinition.removeAll(targetProps);
+
+    if (!StringUtils.isNullOrEmpty(effectiveUser)) {
+      targetProps.put(PropertyDefinition.USER.name, effectiveUser);
+    }
+    if (!StringUtils.isNullOrEmpty(effectivePassword)) {
+      targetProps.put(PropertyDefinition.PASSWORD.name, effectivePassword);
+    }
+
+    PropertyUtils.applyProperties(xaDataSource, targetProps);
+  }
+
+  /**
+   * Resolves the final target URL, effective properties, target driver dialect, and configuration
+   * profile from the configured server/port/database or JDBC URL. (Kept local to the XA datasource
+   * for now; a shared resolver with {@link AwsWrapperDataSource} is a later optimization.)
+   */
+  ResolvedConfig resolveConfig() throws SQLException {
+    final Properties props = PropertyUtils.copyProperties(
+        this.targetDataSourceProperties != null ? this.targetDataSourceProperties : new Properties());
+
+    final String profileName = PropertyDefinition.PROFILE_NAME.getString(props);
+    ConfigurationProfile configurationProfile = null;
+    if (!StringUtils.isNullOrEmpty(profileName)) {
+      configurationProfile = DriverConfigurationProfiles.getProfileConfiguration(profileName);
+      if (configurationProfile != null) {
+        PropertyUtils.addProperties(props, configurationProfile.getProperties());
+        if (configurationProfile.getAwsCredentialsProviderHandler() != null) {
+          AwsCredentialsManager.setCustomHandler(configurationProfile.getAwsCredentialsProviderHandler());
+        }
+      } else {
+        throw new SQLException(
+            Messages.get("AwsWrapperDataSource.configurationProfileNotFound", new Object[] {profileName}));
+      }
+    }
+
+    final String finalUrl = DataSourceConfigHelper.resolveFinalUrl(
+        props,
+        PROTOCOL_PREFIX,
+        this.jdbcUrl,
+        this.serverName,
+        this.serverPort,
+        this.database,
+        this.jdbcProtocol,
+        this.user,
+        this.password);
+
+    TargetDriverDialect targetDriverDialect = configurationProfile == null
+        ? null : configurationProfile.getTargetDriverDialect();
+    if (targetDriverDialect == null) {
+      final TargetDriverDialectManager manager = new TargetDriverDialectManager();
+      targetDriverDialect = manager.getDialect(this.targetDataSourceClassName, props);
+    }
+
+    return new ResolvedConfig(finalUrl, props, targetDriverDialect, configurationProfile);
+  }
+
+  /** Resolved configuration used to open the target XA connection and build logical handles. */
+  static final class ResolvedConfig {
+    final String finalUrl;
+    final Properties props;
+    final TargetDriverDialect targetDriverDialect;
+    final @Nullable ConfigurationProfile configurationProfile;
+
+    ResolvedConfig(
+        final String finalUrl,
+        final Properties props,
+        final TargetDriverDialect targetDriverDialect,
+        final @Nullable ConfigurationProfile configurationProfile) {
+      this.finalUrl = finalUrl;
+      this.props = props;
+      this.targetDriverDialect = targetDriverDialect;
+      this.configurationProfile = configurationProfile;
+    }
+  }
+
+  @Override
+  // The JDK stub declares a @NonNull return, but the log writer is unset (null) by default.
+  @SuppressWarnings("override.return")
+  public @Nullable PrintWriter getLogWriter() throws SQLException {
+    return this.logWriter;
+  }
+
+  @Override
+  public void setLogWriter(final PrintWriter out) throws SQLException {
+    this.logWriter = out;
+  }
+
+  @Override
+  public void setLoginTimeout(final int seconds) throws SQLException {
+    if (seconds < 0) {
+      throw new SQLException(Messages.get("AwsWrapperXADataSource.negativeLoginTimeout"));
+    }
+    this.loginTimeout = seconds;
+  }
+
+  @Override
+  public int getLoginTimeout() throws SQLException {
+    return this.loginTimeout;
+  }
+
+  @Override
+  // Returning null is existing behavior for this data source family.
+  @SuppressWarnings("return")
+  public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+    return null;
+  }
+}

--- a/wrapper/src/main/java/software/amazon/jdbc/ds/AwsWrapperXADataSource.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/ds/AwsWrapperXADataSource.java
@@ -206,8 +206,7 @@ public class AwsWrapperXADataSource implements XADataSource, Serializable {
     // Reject the wrapper's internal connection pool on the XA path: those providers pool plain
     // Connections and cannot expose an XAResource. XA connection pooling is provided by the
     // transaction manager / application server.
-    final Properties rawProps = PropertyUtils.copyProperties(
-        this.targetDataSourceProperties != null ? this.targetDataSourceProperties : new Properties());
+    final Properties rawProps = PropertyUtils.copyProperties(this.targetDataSourceProperties);
     if (PropertyDefinition.CONNECTION_POOL_TYPE.getString(rawProps) != null) {
       throw new SQLException(
           Messages.get(
@@ -375,8 +374,7 @@ public class AwsWrapperXADataSource implements XADataSource, Serializable {
    * for now; a shared resolver with {@link AwsWrapperDataSource} is a later optimization.)
    */
   ResolvedConfig resolveConfig() throws SQLException {
-    final Properties props = PropertyUtils.copyProperties(
-        this.targetDataSourceProperties != null ? this.targetDataSourceProperties : new Properties());
+    final Properties props = PropertyUtils.copyProperties(this.targetDataSourceProperties);
 
     final String profileName = PropertyDefinition.PROFILE_NAME.getString(props);
     ConfigurationProfile configurationProfile = null;

--- a/wrapper/src/main/java/software/amazon/jdbc/ds/DataSourceConfigHelper.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/ds/DataSourceConfigHelper.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.jdbc.ds;
+
+import java.sql.SQLException;
+import java.util.Properties;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import software.amazon.jdbc.HostSpec;
+import software.amazon.jdbc.PropertyDefinition;
+import software.amazon.jdbc.util.ConnectionUrlBuilder;
+import software.amazon.jdbc.util.ConnectionUrlParser;
+import software.amazon.jdbc.util.Messages;
+import software.amazon.jdbc.util.StringUtils;
+
+/**
+ * Shared configuration-resolution logic for the wrapper's data sources
+ * ({@link AwsWrapperDataSource} and {@link AwsWrapperXADataSource}). Resolves the final target JDBC
+ * URL from either a configured JDBC URL or the server/port/database properties, and applies database
+ * and credential overrides to {@code props}. The behavior mirrors the logic that previously lived
+ * inline in {@link AwsWrapperDataSource#getConnection} so both entry points resolve configuration
+ * identically.
+ */
+public final class DataSourceConfigHelper {
+
+  private static final String SERVER_NAME = "serverName";
+  private static final String SERVER_PORT = "serverPort";
+
+  private DataSourceConfigHelper() {
+  }
+
+  /**
+   * Resolves the final (non-wrapper) target URL and applies database/credential overrides to
+   * {@code props}.
+   *
+   * @param props          the connection properties to update in place.
+   * @param protocolPrefix the wrapper protocol prefix to strip from a configured JDBC URL
+   *                       (e.g. {@code jdbc:aws-wrapper:}).
+   * @param jdbcUrl        the configured JDBC URL, or null.
+   * @param serverName     the configured server name, or null.
+   * @param serverPort     the configured server port, or null.
+   * @param database       the configured database name, or null.
+   * @param jdbcProtocol   the configured JDBC protocol (required when {@code jdbcUrl} is not set).
+   * @param user           the user to apply, or null.
+   * @param password       the password to apply, or null.
+   * @return the resolved final target URL.
+   * @throws SQLException if neither a URL nor a server name is provided, or the protocol is missing.
+   */
+  public static String resolveFinalUrl(
+      final Properties props,
+      final String protocolPrefix,
+      final @Nullable String jdbcUrl,
+      final @Nullable String serverName,
+      final @Nullable String serverPort,
+      final @Nullable String database,
+      final @Nullable String jdbcProtocol,
+      final @Nullable String user,
+      final @Nullable String password) throws SQLException {
+
+    final String finalUrl;
+    if (!StringUtils.isNullOrEmpty(jdbcUrl)) {
+      finalUrl = jdbcUrl.replaceFirst(protocolPrefix, "jdbc:");
+
+      ConnectionUrlParser.parsePropertiesFromUrl(jdbcUrl, props);
+      setDatabasePropertyFromUrl(props, jdbcUrl);
+
+      // Override credentials with the ones provided through the data source property.
+      setCredentialProperties(props, user, password);
+
+      // Override database with the one provided through the data source property.
+      if (!StringUtils.isNullOrEmpty(database)) {
+        PropertyDefinition.DATABASE.set(props, database);
+      }
+
+    } else {
+      final String effectiveServerName = !StringUtils.isNullOrEmpty(serverName)
+          ? serverName
+          : props.getProperty(SERVER_NAME);
+      final String effectiveServerPort = !StringUtils.isNullOrEmpty(serverPort)
+          ? serverPort
+          : props.getProperty(SERVER_PORT);
+      final String databaseName = !StringUtils.isNullOrEmpty(database)
+          ? database
+          : PropertyDefinition.DATABASE.getString(props);
+
+      if (StringUtils.isNullOrEmpty(effectiveServerName)) {
+        throw new SQLException(Messages.get("AwsWrapperDataSource.missingTarget"));
+      }
+      if (StringUtils.isNullOrEmpty(jdbcProtocol)) {
+        throw new SQLException(Messages.get("AwsWrapperDataSource.missingJdbcProtocol"));
+      }
+
+      int port = HostSpec.NO_PORT;
+      if (!StringUtils.isNullOrEmpty(effectiveServerPort)) {
+        port = Integer.parseInt(effectiveServerPort);
+      }
+
+      finalUrl = ConnectionUrlBuilder.buildUrl(jdbcProtocol, effectiveServerName, port, databaseName);
+
+      // Override credentials with the ones provided through the data source property.
+      setCredentialProperties(props, user, password);
+
+      // Override database with the one provided through the data source property.
+      if (!StringUtils.isNullOrEmpty(databaseName)) {
+        PropertyDefinition.DATABASE.set(props, databaseName);
+      }
+    }
+
+    return finalUrl;
+  }
+
+  /**
+   * Returns {@code url} with any AWS Wrapper-specific query parameters removed, keeping only
+   * target-driver parameters. This prevents wrapper parameters (e.g. {@code wrapperPlugins},
+   * {@code wrapperDialect}, plugin-specific properties) from leaking into the URL handed to the
+   * target driver, which some drivers reject as unknown parameters. Recognition uses the same
+   * registry as {@link PropertyDefinition#removeAll(Properties)} (named and prefix-registered
+   * wrapper properties), so it is only complete once the relevant plugin classes have been loaded.
+   *
+   * @param url the URL to sanitize (may be null or have no query string).
+   * @return the URL with wrapper query parameters removed.
+   */
+  public static @Nullable String removeWrapperPropertiesFromUrl(final @Nullable String url) {
+    if (StringUtils.isNullOrEmpty(url)) {
+      return url;
+    }
+    final int queryStart = url.indexOf('?');
+    if (queryStart < 0) {
+      return url;
+    }
+    final String base = url.substring(0, queryStart);
+    final String query = url.substring(queryStart + 1);
+    if (StringUtils.isNullOrEmpty(query)) {
+      return base;
+    }
+
+    // Collect the parameter names, then let PropertyDefinition.removeAll decide which are AWS
+    // Wrapper properties; whatever it leaves behind are the target-driver parameters to keep.
+    final Properties names = new Properties();
+    for (final String token : query.split("&")) {
+      if (StringUtils.isNullOrEmpty(token)) {
+        continue;
+      }
+      final int eq = token.indexOf('=');
+      names.setProperty(eq < 0 ? token : token.substring(0, eq), "");
+    }
+    PropertyDefinition.removeAll(names);
+
+    final StringBuilder kept = new StringBuilder();
+    for (final String token : query.split("&")) {
+      if (StringUtils.isNullOrEmpty(token)) {
+        continue;
+      }
+      final int eq = token.indexOf('=');
+      final String name = eq < 0 ? token : token.substring(0, eq);
+      if (!names.containsKey(name)) {
+        continue; // recognized AWS Wrapper parameter; drop it from the target URL
+      }
+      if (kept.length() > 0) {
+        kept.append('&');
+      }
+      kept.append(token); // preserve the original (encoded) token
+    }
+    return kept.length() == 0 ? base : base + "?" + kept.toString();
+  }
+
+  private static void setDatabasePropertyFromUrl(final Properties props, final @Nullable String jdbcUrl) {
+    if (StringUtils.isNullOrEmpty(jdbcUrl)) {
+      return;
+    }
+    final String databaseName = ConnectionUrlParser.parseDatabaseFromUrl(jdbcUrl);
+    if (!StringUtils.isNullOrEmpty(databaseName)) {
+      PropertyDefinition.DATABASE.set(props, databaseName);
+    }
+  }
+
+  private static void setCredentialProperties(
+      final Properties props, final @Nullable String user, final @Nullable String password) {
+    if (!StringUtils.isNullOrEmpty(user)) {
+      PropertyDefinition.USER.set(props, user);
+    }
+    if (!StringUtils.isNullOrEmpty(password)) {
+      PropertyDefinition.PASSWORD.set(props, password);
+    }
+  }
+}

--- a/wrapper/src/main/java/software/amazon/jdbc/ds/DataSourceConfigHelper.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/ds/DataSourceConfigHelper.java
@@ -77,14 +77,6 @@ public final class DataSourceConfigHelper {
       ConnectionUrlParser.parsePropertiesFromUrl(jdbcUrl, props);
       setDatabasePropertyFromUrl(props, jdbcUrl);
 
-      // Override credentials with the ones provided through the data source property.
-      setCredentialProperties(props, user, password);
-
-      // Override database with the one provided through the data source property.
-      if (!StringUtils.isNullOrEmpty(database)) {
-        PropertyDefinition.DATABASE.set(props, database);
-      }
-
     } else {
       final String effectiveServerName = !StringUtils.isNullOrEmpty(serverName)
           ? serverName
@@ -109,14 +101,16 @@ public final class DataSourceConfigHelper {
       }
 
       finalUrl = ConnectionUrlBuilder.buildUrl(jdbcProtocol, effectiveServerName, port, databaseName);
+    }
 
-      // Override credentials with the ones provided through the data source property.
-      setCredentialProperties(props, user, password);
+    // Override credentials with the ones provided through the data source property.
+    setCredentialProperties(props, user, password);
 
-      // Override database with the one provided through the data source property.
-      if (!StringUtils.isNullOrEmpty(databaseName)) {
-        PropertyDefinition.DATABASE.set(props, databaseName);
-      }
+    // Override database with the one provided through the data source property. In the
+    // server/port/database branch an absent `database` already fell back to the value read from
+    // `props`, so applying `database` here is equivalent (an empty value leaves `props` untouched).
+    if (!StringUtils.isNullOrEmpty(database)) {
+      PropertyDefinition.DATABASE.set(props, database);
     }
 
     return finalUrl;
@@ -149,8 +143,9 @@ public final class DataSourceConfigHelper {
 
     // Collect the parameter names, then let PropertyDefinition.removeAll decide which are AWS
     // Wrapper properties; whatever it leaves behind are the target-driver parameters to keep.
+    final String[] tokens = query.split("&");
     final Properties names = new Properties();
-    for (final String token : query.split("&")) {
+    for (final String token : tokens) {
       if (StringUtils.isNullOrEmpty(token)) {
         continue;
       }
@@ -160,7 +155,7 @@ public final class DataSourceConfigHelper {
     PropertyDefinition.removeAll(names);
 
     final StringBuilder kept = new StringBuilder();
-    for (final String token : query.split("&")) {
+    for (final String token : tokens) {
       if (StringUtils.isNullOrEmpty(token)) {
         continue;
       }

--- a/wrapper/src/main/java/software/amazon/jdbc/ds/xa/XAConnectionWrapper.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/ds/xa/XAConnectionWrapper.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.jdbc.ds.xa;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.logging.Logger;
+import javax.sql.ConnectionEventListener;
+import javax.sql.StatementEventListener;
+import javax.sql.XAConnection;
+import javax.transaction.xa.XAResource;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import software.amazon.jdbc.wrapper.ConnectionWrapper;
+
+/**
+ * A {@link XAConnection} that exposes the wrapper's plugin pipeline to the application while
+ * delegating the XA control surface to the target driver's {@code XAConnection}.
+ *
+ * <p>Per the JDBC {@code PooledConnection} contract, each {@link #getConnection()} returns a new
+ * logical connection over the same physical XA connection, and the previous logical connection is
+ * closed. In this implementation each logical handle is a fresh {@link ConnectionWrapper} with its
+ * own plugin pipeline (built by {@code logicalConnectionBuilder}), so no plugin state leaks between
+ * successive checkouts. The physical XA connection is owned by the
+ * {@link XADataSourceConnectionProvider} and reused across handles.
+ */
+public class XAConnectionWrapper implements XAConnection {
+
+  private static final Logger LOGGER = Logger.getLogger(XAConnectionWrapper.class.getName());
+
+  /** Builds a fresh logical connection (a {@link ConnectionWrapper} with a fresh pipeline). */
+  @FunctionalInterface
+  public interface LogicalConnectionBuilder {
+    ConnectionWrapper build() throws SQLException;
+  }
+
+  private final XADataSourceConnectionProvider provider;
+  private final LogicalConnectionBuilder logicalConnectionBuilder;
+  private volatile @Nullable ConnectionWrapper currentHandle;
+
+  public XAConnectionWrapper(
+      final XADataSourceConnectionProvider provider,
+      final LogicalConnectionBuilder logicalConnectionBuilder) {
+    this.provider = provider;
+    this.logicalConnectionBuilder = logicalConnectionBuilder;
+  }
+
+  @Override
+  public Connection getConnection() throws SQLException {
+    // Per the PooledConnection contract, only one logical connection may be open at a time; close
+    // the previous handle before returning a new one.
+    closeCurrentHandleQuietly();
+    final ConnectionWrapper handle = this.logicalConnectionBuilder.build();
+    this.currentHandle = handle;
+    return handle;
+  }
+
+  @Override
+  public XAResource getXAResource() throws SQLException {
+    final XAConnection targetXaConnection = this.provider.getOrOpenXaConnection();
+    return new XAResourceWrapper(
+        targetXaConnection.getXAResource(),
+        active -> {
+          final ConnectionWrapper handle = this.currentHandle;
+          if (handle != null) {
+            handle.getServicesContainer().getPluginService().setXaTransactionActive(active);
+          }
+        });
+  }
+
+  @Override
+  public void close() throws SQLException {
+    closeCurrentHandleQuietly();
+    final XAConnection targetXaConnection = this.provider.getXaConnectionOrNull();
+    if (targetXaConnection != null) {
+      targetXaConnection.close();
+    }
+  }
+
+  private void closeCurrentHandleQuietly() {
+    final ConnectionWrapper handle = this.currentHandle;
+    this.currentHandle = null;
+    if (handle == null) {
+      return;
+    }
+    try {
+      if (!handle.isClosed()) {
+        handle.close();
+      }
+    } catch (final SQLException e) {
+      LOGGER.finest(() -> "Ignoring error while closing the previous logical XA connection handle: "
+          + e.getMessage());
+    }
+  }
+
+  @Override
+  public void addConnectionEventListener(final ConnectionEventListener listener) {
+    delegateListenerOp(xaConn -> xaConn.addConnectionEventListener(listener));
+  }
+
+  @Override
+  public void removeConnectionEventListener(final ConnectionEventListener listener) {
+    delegateListenerOp(xaConn -> xaConn.removeConnectionEventListener(listener));
+  }
+
+  @Override
+  public void addStatementEventListener(final StatementEventListener listener) {
+    delegateListenerOp(xaConn -> xaConn.addStatementEventListener(listener));
+  }
+
+  @Override
+  public void removeStatementEventListener(final StatementEventListener listener) {
+    delegateListenerOp(xaConn -> xaConn.removeStatementEventListener(listener));
+  }
+
+  @FunctionalInterface
+  private interface ListenerOp {
+    void apply(XAConnection xaConn) throws SQLException;
+  }
+
+  private void delegateListenerOp(final ListenerOp op) {
+    try {
+      op.apply(this.provider.getOrOpenXaConnection());
+    } catch (final SQLException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/wrapper/src/main/java/software/amazon/jdbc/ds/xa/XAConnectionWrapper.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/ds/xa/XAConnectionWrapper.java
@@ -24,6 +24,7 @@ import javax.sql.StatementEventListener;
 import javax.sql.XAConnection;
 import javax.transaction.xa.XAResource;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import software.amazon.jdbc.util.Messages;
 import software.amazon.jdbc.wrapper.ConnectionWrapper;
 
 /**
@@ -101,8 +102,8 @@ public class XAConnectionWrapper implements XAConnection {
         handle.close();
       }
     } catch (final SQLException e) {
-      LOGGER.finest(() -> "Ignoring error while closing the previous logical XA connection handle: "
-          + e.getMessage());
+      LOGGER.finest(() -> Messages.get(
+          "XAConnectionWrapper.closingPreviousHandleFailed", new Object[] {e.getMessage()}));
     }
   }
 

--- a/wrapper/src/main/java/software/amazon/jdbc/ds/xa/XADataSourceConnectionProvider.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/ds/xa/XADataSourceConnectionProvider.java
@@ -87,6 +87,7 @@ public class XADataSourceConnectionProvider implements ConnectionProvider {
   private final @Nullable String resolvedUrl;
   private final ResourceLock lock = new ResourceLock();
   private volatile @Nullable XAConnection xaConnection;
+  private volatile @Nullable Connection logicalConnection;
 
   public XADataSourceConnectionProvider(final @NonNull XADataSource xaDataSource) {
     this(xaDataSource, null);
@@ -142,11 +143,37 @@ public class XADataSourceConnectionProvider implements ConnectionProvider {
     // XADataSource would keep the static password configured at getXAConnection() time and IAM
     // authentication would fail.
     final XAConnection xaConn = openXaConnection(props);
-    final Connection conn = xaConn.getConnection();
-    if (conn == null) {
-      throw new SQLLoginException(Messages.get("XADataSourceConnectionProvider.noConnection"));
+    return new ConnectionInfo(getOrCreateLogicalConnection(xaConn), false, xaConn);
+  }
+
+  /**
+   * Returns the current logical {@link Connection} over the owning XA connection, creating it on
+   * first use and reusing it while it is open.
+   *
+   * <p>A single physical XA connection supports only one live logical connection at a time, and each
+   * {@code XAConnection.getConnection()} closes the previously handed-out logical connection. The
+   * connect pipeline can call {@link #connect} more than once while establishing a single handle
+   * (for example the IAM authentication plugin retries the connect after regenerating its token). If
+   * each such call opened a fresh logical connection, the earlier one — which the caller is about to
+   * use — would be closed out from under it ("Physical Connection doesn't exist" / "This
+   * PooledConnection has already been closed"). Caching the logical connection until it is closed
+   * makes repeated connect calls idempotent. A new logical connection is created for the next
+   * {@code XAConnectionWrapper.getConnection()} because closing that handle closes this connection.
+   */
+  private @NonNull Connection getOrCreateLogicalConnection(final @NonNull XAConnection xaConn)
+      throws SQLException {
+    try (ResourceLock ignored = this.lock.obtain()) {
+      final Connection existing = this.logicalConnection;
+      if (existing != null && !existing.isClosed()) {
+        return existing;
+      }
+      final Connection conn = xaConn.getConnection();
+      if (conn == null) {
+        throw new SQLLoginException(Messages.get("XADataSourceConnectionProvider.noConnection"));
+      }
+      this.logicalConnection = conn;
+      return conn;
     }
-    return new ConnectionInfo(conn, false, xaConn);
   }
 
   /**

--- a/wrapper/src/main/java/software/amazon/jdbc/ds/xa/XADataSourceConnectionProvider.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/ds/xa/XADataSourceConnectionProvider.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.jdbc.ds.xa;
+
+import java.lang.reflect.Method;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import javax.sql.XAConnection;
+import javax.sql.XADataSource;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import software.amazon.jdbc.ConnectionInfo;
+import software.amazon.jdbc.ConnectionProvider;
+import software.amazon.jdbc.HighestLoadHostSelector;
+import software.amazon.jdbc.HighestWeightHostSelector;
+import software.amazon.jdbc.HostRole;
+import software.amazon.jdbc.HostSelector;
+import software.amazon.jdbc.HostSpec;
+import software.amazon.jdbc.LowestLoadHostSelector;
+import software.amazon.jdbc.PropertyDefinition;
+import software.amazon.jdbc.RandomHostSelector;
+import software.amazon.jdbc.RoundRobinHostSelector;
+import software.amazon.jdbc.WeightedRandomHostSelector;
+import software.amazon.jdbc.dialect.Dialect;
+import software.amazon.jdbc.ds.DataSourceConfigHelper;
+import software.amazon.jdbc.exceptions.SQLLoginException;
+import software.amazon.jdbc.targetdriverdialect.TargetDriverDialect;
+import software.amazon.jdbc.util.Messages;
+import software.amazon.jdbc.util.Pair;
+import software.amazon.jdbc.util.PropertyUtils;
+import software.amazon.jdbc.util.ResourceLock;
+import software.amazon.jdbc.util.StringUtils;
+
+/**
+ * A {@link ConnectionProvider} for the XA datasource path. It wraps a configured target
+ * {@link XADataSource}, opens a single {@link XAConnection} lazily on first use, and returns a fresh
+ * logical {@link Connection} handle over that same physical XA connection on each
+ * {@link #connect} call.
+ *
+ * <p>Because an XA branch is pinned to one physical session and the {@code XAResource} is bound to
+ * this {@code XAConnection}, the same {@code XAConnection} is reused for the lifetime of this
+ * provider (i.e. of the owning {@link XAConnectionWrapper}); it is never repointed to a different
+ * host. The target {@code XADataSource} is expected to be fully configured before it is handed to
+ * this provider.
+ */
+public class XADataSourceConnectionProvider implements ConnectionProvider {
+
+  private static final Map<String, HostSelector> acceptedStrategies =
+      Collections.unmodifiableMap(new HashMap<String, HostSelector>() {
+        {
+          put(HighestLoadHostSelector.STRATEGY_HIGHEST_LOAD, new HighestLoadHostSelector());
+          put(HighestLoadHostSelector.STRATEGY_HIGHEST_LOAD_BY_CPU, HighestLoadHostSelector.byCpu());
+          put(HighestLoadHostSelector.STRATEGY_HIGHEST_LOAD_BY_LAG, HighestLoadHostSelector.byLag());
+          put(HighestWeightHostSelector.STRATEGY_HIGHEST_WEIGHT, new HighestWeightHostSelector());
+          put(LowestLoadHostSelector.STRATEGY_LOWEST_LOAD, new LowestLoadHostSelector());
+          put(LowestLoadHostSelector.STRATEGY_LOWEST_LOAD_BY_CPU, LowestLoadHostSelector.byCpu());
+          put(LowestLoadHostSelector.STRATEGY_LOWEST_LOAD_BY_LAG, LowestLoadHostSelector.byLag());
+          put(RandomHostSelector.STRATEGY_RANDOM, new RandomHostSelector());
+          put(RoundRobinHostSelector.STRATEGY_ROUND_ROBIN, new RoundRobinHostSelector());
+          put(WeightedRandomHostSelector.STRATEGY_WEIGHTED_RANDOM, new WeightedRandomHostSelector());
+        }
+      });
+
+  private final @NonNull XADataSource xaDataSource;
+  private final @NonNull String xaDataSourceClassName;
+  private final @Nullable String resolvedUrl;
+  private final ResourceLock lock = new ResourceLock();
+  private volatile @Nullable XAConnection xaConnection;
+
+  public XADataSourceConnectionProvider(final @NonNull XADataSource xaDataSource) {
+    this(xaDataSource, null);
+  }
+
+  public XADataSourceConnectionProvider(
+      final @NonNull XADataSource xaDataSource, final @Nullable String resolvedUrl) {
+    this.xaDataSource = xaDataSource;
+    this.xaDataSourceClassName = xaDataSource.getClass().getName();
+    this.resolvedUrl = resolvedUrl;
+  }
+
+  @Override
+  public boolean acceptsUrl(
+      final @NonNull String protocol, final @NonNull HostSpec hostSpec, final @NonNull Properties props) {
+    return true;
+  }
+
+  @Override
+  public boolean acceptsStrategy(final @Nullable HostRole role, final @NonNull String strategy) {
+    return acceptedStrategies.containsKey(strategy);
+  }
+
+  @Override
+  public @Nullable HostSpec getHostSpecByStrategy(
+      final @NonNull List<HostSpec> hosts,
+      final @Nullable HostRole role,
+      final @NonNull String strategy,
+      final @Nullable Properties props)
+      throws SQLException {
+    final HostSelector hostSelector = acceptedStrategies.get(strategy);
+    if (hostSelector == null) {
+      throw new UnsupportedOperationException(
+          Messages.get(
+              "ConnectionProvider.unsupportedHostSpecSelectorStrategy",
+              new Object[] {strategy, XADataSourceConnectionProvider.class}));
+    }
+    return hostSelector.getHost(hosts, role, props);
+  }
+
+  @Override
+  public @NonNull ConnectionInfo connect(
+      final @NonNull String protocol,
+      final @NonNull Dialect dialect,
+      final @NonNull TargetDriverDialect targetDriverDialect,
+      final @NonNull HostSpec hostSpec,
+      final @NonNull Properties props)
+      throws SQLException {
+
+    // Open through the connect pipeline's props so plugin-provided credentials reach the target
+    // XADataSource. In particular, the IAM authentication plugin generates a short-lived token and
+    // sets it as the password on these per-connect props; without applying them here the target
+    // XADataSource would keep the static password configured at getXAConnection() time and IAM
+    // authentication would fail.
+    final XAConnection xaConn = openXaConnection(props);
+    final Connection conn = xaConn.getConnection();
+    if (conn == null) {
+      throw new SQLLoginException(Messages.get("XADataSourceConnectionProvider.noConnection"));
+    }
+    return new ConnectionInfo(conn, false, xaConn);
+  }
+
+  /**
+   * Returns the single owning {@link XAConnection}, opening it on first use. Reused for the lifetime
+   * of this provider so the {@code XAResource} and every logical handle share one physical session.
+   *
+   * @return the owning XA connection.
+   * @throws SQLException if the XA connection cannot be opened.
+   */
+  public @NonNull XAConnection getOrOpenXaConnection() throws SQLException {
+    return openXaConnection(null);
+  }
+
+  /**
+   * Opens (once) and returns the owning {@link XAConnection}. When {@code props} is non-null, the
+   * user/password from those per-connect properties are applied to the target XADataSource before it
+   * is opened, so plugin-provided credentials (e.g. an IAM token) take effect. The physical session
+   * is pinned for the lifetime of this provider, so credentials are only applied on the first open.
+   */
+  private @NonNull XAConnection openXaConnection(final @Nullable Properties props) throws SQLException {
+    XAConnection xaConn = this.xaConnection;
+    if (xaConn == null) {
+      try (ResourceLock ignored = this.lock.obtain()) {
+        xaConn = this.xaConnection;
+        if (xaConn == null) {
+          if (props != null) {
+            applyCredentials(props);
+            applyCleanUrl();
+          }
+          xaConn = this.xaDataSource.getXAConnection();
+          if (xaConn == null) {
+            throw new SQLLoginException(Messages.get("XADataSourceConnectionProvider.noConnection"));
+          }
+          this.xaConnection = xaConn;
+        }
+      }
+    }
+    return xaConn;
+  }
+
+  /**
+   * Applies the effective user/password from the per-connect properties to the target XADataSource
+   * via its bean setters. These may have been rewritten by the connect pipeline (for example the IAM
+   * plugin replaces the password with a generated authentication token).
+   */
+  private void applyCredentials(final @NonNull Properties props) {
+    final List<Method> methods = Arrays.asList(this.xaDataSource.getClass().getMethods());
+    final String user = PropertyDefinition.USER.getString(props);
+    if (user != null) {
+      PropertyUtils.setPropertyOnTarget(this.xaDataSource, PropertyDefinition.USER.name, user, methods);
+    }
+    final String password = PropertyDefinition.PASSWORD.getString(props);
+    if (password != null) {
+      PropertyUtils.setPropertyOnTarget(this.xaDataSource, PropertyDefinition.PASSWORD.name, password, methods);
+    }
+  }
+
+  /**
+   * Re-applies the target URL with AWS Wrapper-specific query parameters removed. This runs at
+   * connect time, when the configured plugin classes are loaded and every wrapper property name is
+   * registered, so the cleaning is complete (the best-effort cleaning done earlier at
+   * {@code getXAConnection()} time may miss plugin-specific properties whose classes were not yet
+   * loaded).
+   */
+  private void applyCleanUrl() {
+    if (StringUtils.isNullOrEmpty(this.resolvedUrl)) {
+      return;
+    }
+    final String cleanUrl = DataSourceConfigHelper.removeWrapperPropertiesFromUrl(this.resolvedUrl);
+    if (StringUtils.isNullOrEmpty(cleanUrl)) {
+      return;
+    }
+    final List<Method> methods = Arrays.asList(this.xaDataSource.getClass().getMethods());
+    PropertyUtils.setPropertyOnTarget(this.xaDataSource, "url", cleanUrl, methods);
+  }
+
+  /**
+   * Returns the owning {@link XAConnection} if it has been opened, otherwise null.
+   *
+   * @return the owning XA connection, or null if not yet opened.
+   */
+  public @Nullable XAConnection getXaConnectionOrNull() {
+    return this.xaConnection;
+  }
+
+  @Override
+  public String getTargetName() {
+    return this.xaDataSourceClassName;
+  }
+
+  @Override
+  public List<Pair<String, Object>> getSnapshotState() {
+    final List<Pair<String, Object>> state = new ArrayList<>();
+    state.add(Pair.create("xaDataSourceClassName", this.xaDataSourceClassName));
+    return state;
+  }
+}

--- a/wrapper/src/main/java/software/amazon/jdbc/ds/xa/XADataSourceConnectionProvider.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/ds/xa/XADataSourceConnectionProvider.java
@@ -86,8 +86,11 @@ public class XADataSourceConnectionProvider implements ConnectionProvider {
   private final @NonNull String xaDataSourceClassName;
   private final @Nullable String resolvedUrl;
   private final ResourceLock lock = new ResourceLock();
+  // volatile: read outside the lock by the double-checked open in openXaConnection() and by
+  // getXaConnectionOrNull().
   private volatile @Nullable XAConnection xaConnection;
-  private volatile @Nullable Connection logicalConnection;
+  // Not volatile: only ever read/written while holding this.lock (getOrCreateLogicalConnection).
+  private @Nullable Connection logicalConnection;
 
   public XADataSourceConnectionProvider(final @NonNull XADataSource xaDataSource) {
     this(xaDataSource, null);

--- a/wrapper/src/main/java/software/amazon/jdbc/ds/xa/XAResourceWrapper.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/ds/xa/XAResourceWrapper.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.jdbc.ds.xa;
+
+import javax.transaction.xa.XAException;
+import javax.transaction.xa.XAResource;
+import javax.transaction.xa.Xid;
+
+/**
+ * A pass-through {@link XAResource} that delegates every operation to the target driver's
+ * {@code XAResource} while tracking the XA-active state of the wrapper's connection.
+ *
+ * <p>The XA-active flag is maintained around the transaction <em>branch</em>, not per method:
+ * {@link #start} marks the connection XA-active; {@link #prepare} does <em>not</em> clear it (the
+ * branch is still live between prepare and commit/rollback); the terminal {@link #commit} and
+ * {@link #rollback} clear it. This flag is what causes voluntary connection switches to be skipped
+ * and failover to fail fast for the duration of the branch.
+ *
+ * <p>This wrapper is a plain delegator and is not routed through the plugin pipeline (XA control
+ * calls do not need per-call plugin interception).
+ */
+public class XAResourceWrapper implements XAResource {
+
+  private final XAResource target;
+  private final XaTransactionStateCallback stateCallback;
+
+  public XAResourceWrapper(final XAResource target, final XaTransactionStateCallback stateCallback) {
+    this.target = target;
+    this.stateCallback = stateCallback;
+  }
+
+  @Override
+  public void start(final Xid xid, final int flags) throws XAException {
+    this.target.start(xid, flags);
+    // Includes TMNOFLAGS, TMJOIN, and TMRESUME - in all cases the connection is now enlisted.
+    this.stateCallback.setXaTransactionActive(true);
+  }
+
+  @Override
+  public void end(final Xid xid, final int flags) throws XAException {
+    // The work association ends here, but the branch is still resolvable via commit/rollback, so
+    // the XA-active flag is intentionally NOT cleared.
+    this.target.end(xid, flags);
+  }
+
+  @Override
+  public int prepare(final Xid xid) throws XAException {
+    // The branch remains live between prepare and commit/rollback; do not clear the flag.
+    return this.target.prepare(xid);
+  }
+
+  @Override
+  public void commit(final Xid xid, final boolean onePhase) throws XAException {
+    try {
+      this.target.commit(xid, onePhase);
+    } finally {
+      this.stateCallback.setXaTransactionActive(false);
+    }
+  }
+
+  @Override
+  public void rollback(final Xid xid) throws XAException {
+    try {
+      this.target.rollback(xid);
+    } finally {
+      this.stateCallback.setXaTransactionActive(false);
+    }
+  }
+
+  @Override
+  public Xid[] recover(final int flag) throws XAException {
+    // Recovery is driven by the transaction manager by Xid and must never be blocked or altered.
+    return this.target.recover(flag);
+  }
+
+  @Override
+  public void forget(final Xid xid) throws XAException {
+    this.target.forget(xid);
+  }
+
+  @Override
+  public boolean isSameRM(final XAResource xares) throws XAException {
+    // Always report distinct resource managers so the transaction manager creates a separate branch
+    // for each wrapped connection and performs a full two-phase commit, rather than trying to join
+    // branches onto a single connection. Two AwsWrapperXADataSource connections are independent (and
+    // may even be routed to different physical hosts by the wrapper's topology awareness), so they
+    // must not be treated as a joinable single resource. This also avoids target drivers that do not
+    // support XA START ... JOIN (for example MySQL Connector/J), which reject a join with XAER_INVAL.
+    return false;
+  }
+
+  @Override
+  public int getTransactionTimeout() throws XAException {
+    return this.target.getTransactionTimeout();
+  }
+
+  @Override
+  public boolean setTransactionTimeout(final int seconds) throws XAException {
+    return this.target.setTransactionTimeout(seconds);
+  }
+}

--- a/wrapper/src/main/java/software/amazon/jdbc/ds/xa/XaTransactionStateCallback.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/ds/xa/XaTransactionStateCallback.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.jdbc.ds.xa;
+
+/**
+ * Callback used by {@link XAResourceWrapper} to mark the current logical connection's
+ * {@code PluginService} as XA-active (or not) as the transaction branch starts and completes.
+ * Implemented by {@link XAConnectionWrapper}, which knows the currently checked-out handle.
+ */
+@FunctionalInterface
+public interface XaTransactionStateCallback {
+
+  /**
+   * Marks the current connection XA-active or clears it.
+   *
+   * @param active true when a branch has started; false when it has committed/rolled back.
+   */
+  void setXaTransactionActive(boolean active);
+}

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/failover/FailoverConnectionPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/failover/FailoverConnectionPlugin.java
@@ -588,6 +588,13 @@ public class FailoverConnectionPlugin extends AbstractConnectionPlugin implement
    * @throws SQLException if an error occurs
    */
   protected void failover(final @Nullable HostSpec failedHost, boolean isInitialConnection) throws SQLException {
+    // Failover cannot be skipped (the current connection is broken) and cannot preserve an XA
+    // branch. Fail fast so the transaction manager rolls the branch back, instead of swapping the
+    // physical connection out from under the XA session.
+    if (this.pluginService.isXaTransactionActive()) {
+      throw new XaFailoverNotSupportedSQLException();
+    }
+
     if (failedHost != null) {
       this.pluginService.setAvailability(failedHost, HostAvailability.NOT_AVAILABLE);
     }

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/failover/XaFailoverNotSupportedSQLException.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/failover/XaFailoverNotSupportedSQLException.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.jdbc.plugin.failover;
+
+import software.amazon.jdbc.util.Messages;
+import software.amazon.jdbc.util.SqlState;
+
+/**
+ * Thrown when failover is triggered while the connection is enlisted in an active XA transaction
+ * branch. The broken connection cannot be retained and the branch cannot be preserved across a
+ * node change, so the driver fails fast (rather than swapping the physical connection) and lets the
+ * transaction manager roll the branch back.
+ *
+ * <p>Extends {@link FailoverSQLException} so existing {@code catch (FailoverSQLException)} handling
+ * (e.g. read/write splitting idle-connection cleanup) continues to apply. Uses SQL state
+ * {@code 08007} (connection failure during transaction), which a transaction manager interprets as
+ * a failed branch.
+ */
+public class XaFailoverNotSupportedSQLException extends FailoverSQLException {
+
+  public XaFailoverNotSupportedSQLException() {
+    super(Messages.get("Failover.failoverNotSupportedDuringXaTransaction"),
+        SqlState.CONNECTION_FAILURE_DURING_TRANSACTION.getState());
+  }
+}

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/failover2/FailoverConnectionPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/failover2/FailoverConnectionPlugin.java
@@ -49,6 +49,7 @@ import software.amazon.jdbc.plugin.failover.FailoverFailedSQLException;
 import software.amazon.jdbc.plugin.failover.FailoverMode;
 import software.amazon.jdbc.plugin.failover.FailoverSuccessSQLException;
 import software.amazon.jdbc.plugin.failover.TransactionStateUnknownSQLException;
+import software.amazon.jdbc.plugin.failover.XaFailoverNotSupportedSQLException;
 import software.amazon.jdbc.plugin.staledns.AuroraStaleDnsHelper;
 import software.amazon.jdbc.targetdriverdialect.TargetDriverDialect;
 import software.amazon.jdbc.util.FullServicesContainer;
@@ -358,6 +359,12 @@ public class FailoverConnectionPlugin extends AbstractConnectionPlugin implement
    * @throws SQLException if an error occurs
    */
   protected void failover() throws SQLException {
+    // Failover cannot be skipped (the current connection is broken) and cannot preserve an XA
+    // branch. Fail fast so the transaction manager rolls the branch back.
+    if (this.pluginService.isXaTransactionActive()) {
+      throw new XaFailoverNotSupportedSQLException();
+    }
+
     if (this.failoverMode == FailoverMode.STRICT_WRITER) {
       failoverWriter();
     } else {

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/gdbfailover/GlobalDbFailoverConnectionPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/gdbfailover/GlobalDbFailoverConnectionPlugin.java
@@ -34,6 +34,7 @@ import software.amazon.jdbc.HostSpec;
 import software.amazon.jdbc.PropertyDefinition;
 import software.amazon.jdbc.plugin.failover.FailoverFailedSQLException;
 import software.amazon.jdbc.plugin.failover.FailoverSuccessSQLException;
+import software.amazon.jdbc.plugin.failover.XaFailoverNotSupportedSQLException;
 import software.amazon.jdbc.plugin.failover2.FailoverConnectionPlugin;
 import software.amazon.jdbc.util.AccessibleRegions;
 import software.amazon.jdbc.util.FullServicesContainer;
@@ -186,6 +187,12 @@ public class GlobalDbFailoverConnectionPlugin extends FailoverConnectionPlugin {
 
   @Override
   protected void failover() throws SQLException {
+    // Failover cannot be skipped (the current connection is broken) and cannot preserve an XA
+    // branch. Fail fast so the transaction manager rolls the branch back.
+    if (this.pluginService.isXaTransactionActive()) {
+      throw new XaFailoverNotSupportedSQLException();
+    }
+
     TelemetryFactory telemetryFactory = this.pluginService.getTelemetryFactory();
     TelemetryContext telemetryContext = telemetryFactory.openTelemetryContext(
         TELEMETRY_FAILOVER, TelemetryTraceLevel.NESTED);

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/gate/TransactionAwareGate.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/gate/TransactionAwareGate.java
@@ -18,11 +18,13 @@ package software.amazon.jdbc.plugin.readwritesplitting.gate;
 
 import java.sql.SQLException;
 import java.util.Optional;
+import java.util.logging.Logger;
 import software.amazon.jdbc.PluginCallContext;
 import software.amazon.jdbc.parser.RoutingHint;
 import software.amazon.jdbc.parser.SqlContextKeys;
 import software.amazon.jdbc.plugin.readwritesplitting.RwSplitContext;
 import software.amazon.jdbc.plugin.readwritesplitting.signal.TargetRole;
+import software.amazon.jdbc.util.Messages;
 
 /**
  * {@link SwitchGate} that pins the current connection at transaction boundaries.
@@ -40,6 +42,8 @@ import software.amazon.jdbc.plugin.readwritesplitting.signal.TargetRole;
  * which owns the role check; this gate only decides pinning.
  */
 public class TransactionAwareGate implements SwitchGate {
+
+  private static final Logger LOGGER = Logger.getLogger(TransactionAwareGate.class.getName());
 
   private final boolean honorKeepHint;
   private final boolean pinOnAutoCommitOff;
@@ -67,6 +71,14 @@ public class TransactionAwareGate implements SwitchGate {
               == RoutingHint.KEEP) {
         return false;
       }
+    }
+
+    // An active XA transaction branch pins the connection just like a local transaction: the
+    // physical session must not change until the transaction manager resolves the branch. This is
+    // tracked separately from isInTransaction() because XA branches run without BEGIN/COMMIT SQL.
+    if (ctx.pluginService().isXaTransactionActive()) {
+      LOGGER.fine(() -> Messages.get("ReadWriteSplittingPlugin.stayedOnConnectionForXaTransaction"));
+      return false;
     }
 
     if (ctx.pluginService().isInTransaction()) {

--- a/wrapper/src/main/java/software/amazon/jdbc/util/SqlMethodAnalyzer.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/SqlMethodAnalyzer.java
@@ -142,7 +142,13 @@ public class SqlMethodAnalyzer {
     return statement.startsWith("COMMIT")
         || statement.startsWith("ROLLBACK")
         || statement.startsWith("END")
-        || statement.startsWith("ABORT");
+        || statement.startsWith("ABORT")
+        // Two-phase commit control statements. "PREPARE TRANSACTION" detaches the current
+        // transaction from the session (the session leaves the active transaction); "COMMIT
+        // PREPARED"/"ROLLBACK PREPARED" resolve a previously-prepared branch and already match the
+        // COMMIT/ROLLBACK prefixes above. Note: this matches only "PREPARE TRANSACTION", not the
+        // unrelated "PREPARE <name> AS ..." prepared-statement command.
+        || statement.startsWith("PREPARE TRANSACTION");
   }
 
   public boolean isStatementSettingAutoCommit(final String methodName, final @Nullable Object[] args) {

--- a/wrapper/src/main/java/software/amazon/jdbc/util/WrapperUtils.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/WrapperUtils.java
@@ -249,7 +249,14 @@ public class WrapperUtils {
       connectionWrapper.getServicesContainer().getPluginManagerService().resetCallContext();
 
       // The target driver may block on Statement.getConnection().
-      if (jdbcMethod.shouldLockConnection && jdbcMethod.checkBoundedConnection) {
+      // This guard detects a statement bound to a connection that was swapped out by failover or
+      // read/write splitting. On the XA path the physical connection is pinned for the branch (a
+      // swap is rejected by PluginServiceImpl.setCurrentConnection), so this can only be a false
+      // positive there: some target XA drivers (e.g. PostgreSQL's pooled XA connection) hand out a
+      // statement whose getConnection() is not reference-identical to the logical handle the wrapper
+      // holds, even though it is the same physical session. Skip while an XA transaction is active.
+      if (jdbcMethod.shouldLockConnection && jdbcMethod.checkBoundedConnection
+          && !connectionWrapper.getServicesContainer().getPluginService().isXaTransactionActive()) {
         final Connection conn = WrapperUtils.getConnectionFromSqlObject(methodInvokeOn);
         if (conn != null && conn != connectionWrapper.getCurrentConnection()) {
           throw new SQLException(Messages.get(
@@ -366,7 +373,14 @@ public class WrapperUtils {
       }
 
       // The target driver may block on Statement.getConnection().
-      if (jdbcMethod.shouldLockConnection && jdbcMethod.checkBoundedConnection) {
+      // This guard detects a statement bound to a connection that was swapped out by failover or
+      // read/write splitting. On the XA path the physical connection is pinned for the branch (a
+      // swap is rejected by PluginServiceImpl.setCurrentConnection), so this can only be a false
+      // positive there: some target XA drivers (e.g. PostgreSQL's pooled XA connection) hand out a
+      // statement whose getConnection() is not reference-identical to the logical handle the wrapper
+      // holds, even though it is the same physical session. Skip while an XA transaction is active.
+      if (jdbcMethod.shouldLockConnection && jdbcMethod.checkBoundedConnection
+          && !connectionWrapper.getServicesContainer().getPluginService().isXaTransactionActive()) {
         final Connection conn = WrapperUtils.getConnectionFromSqlObject(methodInvokeOn);
         if (conn != null && conn != connectionWrapper.getCurrentConnection()) {
           throw new SQLException(Messages.get(

--- a/wrapper/src/main/resources/aws_advanced_jdbc_wrapper_messages.properties
+++ b/wrapper/src/main/resources/aws_advanced_jdbc_wrapper_messages.properties
@@ -65,6 +65,12 @@ AwsSecretsManagerConnectionPlugin2.fetchTimeout=Timed out after {0}s waiting for
 
 AwsWrapperDataSource.missingJdbcProtocol=Missing JDBC protocol. Could not construct URL.
 AwsWrapperDataSource.missingTarget=JDBC url or Server name is required.
+AwsWrapperXADataSource.missingTarget=A target ''javax.sql.XADataSource'' class name is required for XA connections. Please set ''targetDataSourceClassName'' to an XADataSource implementation, for example ''org.postgresql.xa.PGXADataSource'' or ''com.mysql.cj.jdbc.MysqlXADataSource''.
+AwsWrapperXADataSource.targetNotXaDataSource=The configured target class ''{0}'' does not implement ''javax.sql.XADataSource''. XA connections require the target datasource to be an XADataSource.
+AwsWrapperXADataSource.internalConnectionPoolNotSupportedWithXa=The wrapper''s internal connection pool ({0}) cannot be used with an XA datasource, because it pools plain connections and cannot provide an XAResource. Remove the internal connection pool configuration when using AwsWrapperXADataSource; in a JTA deployment the transaction manager provides XA connection pooling.
+AwsWrapperXADataSource.customConnectionProviderNotSupportedWithXa=A custom connection provider is configured (Driver.setCustomConnectionProvider). It cannot be used with an XA datasource, because it would open a non-XA connection that has no XAResource. Remove the custom connection provider when using AwsWrapperXADataSource.
+AwsWrapperXADataSource.readWriteSplittingNotSupportedWithXa=The read/write splitting plugin ''{0}'' is not supported on the XA datasource and will not switch connections during an XA transaction. Configure read/write splitting on a separate non-XA datasource for the read path (see the two-datasource pattern in the XA documentation).
+AwsWrapperXADataSource.negativeLoginTimeout=Login timeout cannot be a negative value.
 AwsWrapperDataSource.configurationProfileNotFound=Configuration profile ''{0}'' not found.
 
 ClusterAwareReaderFailoverHandler.interruptedThread=Thread was interrupted.
@@ -103,6 +109,7 @@ ConnectionPluginManager.unableToLoadPlugin=Unable to load connection plugin fact
 ConnectionPluginManager.invokedAgainstOldConnection=The internal connection has changed since ''{0}'' was created. This is likely due to failover or read-write splitting functionality. To ensure you are using the updated connection, please re-create Statement and ResultSet objects after failover and/or calling setReadOnly.
 
 ConnectionProvider.noConnection=The target driver did not return a connection.
+XADataSourceConnectionProvider.noConnection=The target XADataSource did not return an XA connection.
 ConnectionProvider.unsupportedHostSpecSelectorStrategy=Unsupported host selection strategy ''{0}'' specified for this connection provider ''{1}''. Please visit the documentation for all supported strategies.
 
 ConnectionUrlBuilder.missingJdbcProtocol=Missing JDBC protocol and/or host name. Could not construct URL.
@@ -244,6 +251,7 @@ ExpirationCache.exceptionWhileRemovingEntry=An exception occurred while removing
 ExternallyManagedCache.extendExpirationOnNonExistingKey=A request was made to extend the expiration of the entry at key ''{0}'', but the key does not exist.
 
 Failover.transactionResolutionUnknownError=Transaction resolution unknown. Please re-configure session state if required and try restarting the transaction.
+Failover.failoverNotSupportedDuringXaTransaction=Failover cannot be performed while an XA transaction is active on this connection. The current connection is no longer usable, so the XA transaction branch cannot continue and must be rolled back by the transaction manager.
 Failover.connectionClosedExplicitly=Unable to failover, the connection has been explicitly closed.
 Failover.connectionChangedError=The active SQL connection has changed due to a connection failure. Please re-configure session state if required.
 Failover.exceptionConnectingToWriter=An exception occurred while trying to connect to the new writer ''{0}''.
@@ -380,6 +388,7 @@ PluginServiceImpl.hostListEmpty=Current host list is empty.
 PluginServiceImpl.releaseResources=Releasing resources.
 PluginServiceImpl.forceRefreshTimeout=A timeout exception occurred after waiting {0}ms for refreshed topology.
 PluginServiceImpl.errorIdentifyConnection=An error occurred while obtaining the connection's host ID.
+PluginServiceImpl.connectionSwitchDuringXaTransaction=Cannot change the internal connection while an XA transaction is active. The physical connection must remain unchanged until the transaction manager completes the current XA transaction branch.
 
 PropertyUtils.setMethodDoesNotExistOnTarget=Set method for property ''{0}'' does not exist on target ''{1}''.
 PropertyUtils.failedToSetProperty=Failed to set property ''{0}'' on target ''{1}''.
@@ -394,6 +403,7 @@ ReadWriteSplittingPlugin.closingInternalConnections=Closing all internal connect
 ReadWriteSplittingPlugin.setReaderConnection=Reader connection set to ''{0}''
 ReadWriteSplittingPlugin.setWriterConnection=Writer connection set to ''{0}''
 ReadWriteSplittingPlugin.setReadOnlyFalseInTransaction=setReadOnly(false) was called on a read-only connection inside a transaction. Please complete the transaction before calling setReadOnly(false).
+ReadWriteSplittingPlugin.stayedOnConnectionForXaTransaction=An XA transaction is active on the current connection, so the connection was not switched. Read/write splitting is skipped for the duration of the XA transaction.
 ReadWriteSplittingPlugin.switchedFromWriterToReader=Switched from a writer to a reader host. New reader host: ''{0}''
 ReadWriteSplittingPlugin.switchedFromReaderToWriter=Switched from a reader to a writer host. New writer host: ''{0}''
 ReadWriteSplittingPlugin.settingCurrentConnection=Setting the current connection to ''{0}''

--- a/wrapper/src/main/resources/aws_advanced_jdbc_wrapper_messages.properties
+++ b/wrapper/src/main/resources/aws_advanced_jdbc_wrapper_messages.properties
@@ -110,6 +110,7 @@ ConnectionPluginManager.invokedAgainstOldConnection=The internal connection has 
 
 ConnectionProvider.noConnection=The target driver did not return a connection.
 XADataSourceConnectionProvider.noConnection=The target XADataSource did not return an XA connection.
+XAConnectionWrapper.closingPreviousHandleFailed=Ignoring error while closing the previous logical XA connection handle: {0}
 ConnectionProvider.unsupportedHostSpecSelectorStrategy=Unsupported host selection strategy ''{0}'' specified for this connection provider ''{1}''. Please visit the documentation for all supported strategies.
 
 ConnectionUrlBuilder.missingJdbcProtocol=Missing JDBC protocol and/or host name. Could not construct URL.

--- a/wrapper/src/test/build.gradle.kts
+++ b/wrapper/src/test/build.gradle.kts
@@ -63,6 +63,15 @@ dependencies {
     testImplementation("de.vandermeer:asciitable:0.3.2")
     testImplementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.19.2")
     testImplementation("com.github.jsqlparser:jsqlparser:4.9")
+    // XA transaction managers for XADataSource integration tests (both are exercised for
+    // compatibility). Must match the host build file (wrapper/build.gradle.kts). Narayana 5.11.x is
+    // the last Java 8-compatible line.
+    testImplementation("org.jboss.narayana.jta:narayana-jta:5.11.4.Final")
+    // Narayana declares jboss-logging as an optional/provided dependency, so it is not pulled
+    // transitively; add it explicitly or Narayana's jtaLogger fails to initialize at runtime.
+    testImplementation("org.jboss.logging:jboss-logging:3.4.3.Final")
+    testImplementation("com.atomikos:transactions-jta:5.0.9")
+    testImplementation("com.atomikos:transactions-jdbc:5.0.9")
     val arch = System.getProperty("os.arch").let {
         when (it) {
             "aarch64", "arm64" -> "aarch_64"

--- a/wrapper/src/test/config/mysql-grant-xa-recover.sh
+++ b/wrapper/src/test/config/mysql-grant-xa-recover.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Grants the XA_RECOVER_ADMIN dynamic privilege (required since MySQL 8.0 for "XA RECOVER") to the
+# test user, so XADataSource integration tests can call XAResource.recover().
+set -e
+
+if [ -n "${MYSQL_USER}" ]; then
+  mysql -u root -p"${MYSQL_ROOT_PASSWORD}" \
+    -e "GRANT XA_RECOVER_ADMIN ON *.* TO '${MYSQL_USER}'@'%'; FLUSH PRIVILEGES;"
+fi

--- a/wrapper/src/test/java/integration/DriverHelper.java
+++ b/wrapper/src/test/java/integration/DriverHelper.java
@@ -150,6 +150,25 @@ public class DriverHelper {
     }
   }
 
+  public static String getXaDataSourceClassname() {
+    return getXaDataSourceClassname(TestEnvironment.getCurrent().getCurrentDriver());
+  }
+
+  public static String getXaDataSourceClassname(TestDriver testDriver) {
+    switch (testDriver) {
+      case MYSQL:
+        return "com.mysql.cj.jdbc.MysqlXADataSource";
+      case PG:
+        return "org.postgresql.xa.PGXADataSource";
+      case MARIADB:
+        // MariaDB Connector/J exposes a single unified class that implements javax.sql.DataSource,
+        // javax.sql.ConnectionPoolDataSource, and javax.sql.XADataSource.
+        return "org.mariadb.jdbc.MariaDbDataSource";
+      default:
+        throw new NotImplementedException("XADataSource not supported for driver " + testDriver);
+    }
+  }
+
   public static Class<?> getConnectionClass() {
     return getConnectionClass(TestEnvironment.getCurrent().getCurrentDriver());
   }

--- a/wrapper/src/test/java/integration/container/tests/XaFailoverTest.java
+++ b/wrapper/src/test/java/integration/container/tests/XaFailoverTest.java
@@ -1,0 +1,286 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integration.container.tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import integration.DatabaseEngine;
+import integration.DatabaseEngineDeployment;
+import integration.DriverHelper;
+import integration.TestEnvironmentFeatures;
+import integration.TestInstanceInfo;
+import integration.container.ConnectionStringHelper;
+import integration.container.TestDriverProvider;
+import integration.container.TestEnvironment;
+import integration.container.condition.DisableOnTestFeature;
+import integration.container.condition.EnableOnDatabaseEngine;
+import integration.container.condition.EnableOnDatabaseEngineDeployment;
+import integration.container.condition.EnableOnNumOfInstances;
+import integration.container.condition.EnableOnTestFeature;
+import integration.container.condition.MakeSureFirstInstanceWriter;
+import integration.util.AuroraTestUtility;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Properties;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import javax.sql.XAConnection;
+import javax.transaction.xa.XAResource;
+import javax.transaction.xa.Xid;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import software.amazon.jdbc.PropertyDefinition;
+import software.amazon.jdbc.ds.AwsWrapperXADataSource;
+import software.amazon.jdbc.hostlistprovider.RdsHostListProvider;
+import software.amazon.jdbc.plugin.failover.XaFailoverNotSupportedSQLException;
+
+/**
+ * Integration test verifying that a failover forced during an active XA branch surfaces the
+ * XA-specific fail-fast exception ({@link XaFailoverNotSupportedSQLException}), and that a new XA
+ * transaction started afterward succeeds against the promoted writer. Requires a real Aurora/RDS
+ * environment with failover support and multiple instances.
+ */
+@TestMethodOrder(MethodOrderer.MethodName.class)
+@ExtendWith(TestDriverProvider.class)
+@EnableOnTestFeature(TestEnvironmentFeatures.FAILOVER_SUPPORTED)
+@EnableOnDatabaseEngine({DatabaseEngine.PG, DatabaseEngine.MYSQL})
+@EnableOnDatabaseEngineDeployment({
+    DatabaseEngineDeployment.AURORA,
+    DatabaseEngineDeployment.RDS_MULTI_AZ_CLUSTER})
+@DisableOnTestFeature({
+    TestEnvironmentFeatures.PERFORMANCE,
+    TestEnvironmentFeatures.RUN_HIBERNATE_TESTS_ONLY,
+    TestEnvironmentFeatures.RUN_ENCRYPTION_TESTS_ONLY,
+    TestEnvironmentFeatures.RUN_AUTOSCALING_TESTS_ONLY,
+    TestEnvironmentFeatures.BLUE_GREEN_DEPLOYMENT,
+    TestEnvironmentFeatures.RUN_DB_METRICS_ONLY})
+@MakeSureFirstInstanceWriter
+@Order(26)
+@Tag("xa")
+public class XaFailoverTest {
+
+  private static final String TABLE = "xa_failover_table";
+  private static final AuroraTestUtility auroraUtil = AuroraTestUtility.getUtility();
+
+  private ExecutorService executor;
+  private String currentWriter;
+
+  @BeforeEach
+  public void setUpEach() {
+    this.currentWriter =
+        TestEnvironment.getCurrent().getInfo().getProxyDatabaseInfo().getInstances().get(0).getInstanceId();
+    this.executor = Executors.newFixedThreadPool(1, r -> {
+      final Thread thread = new Thread(r);
+      thread.setDaemon(true);
+      return thread;
+    });
+  }
+
+  @AfterEach
+  public void tearDownEach() {
+    this.executor.shutdownNow();
+  }
+
+  @TestTemplate
+  @EnableOnNumOfInstances(min = 2)
+  public void test_failoverDuringXaBranch_failsFast() throws Exception {
+    recreateTable();
+
+    final TestInstanceInfo writer =
+        TestEnvironment.getCurrent().getInfo().getProxyDatabaseInfo().getInstance(this.currentWriter);
+
+    final AwsWrapperXADataSource ds = createProxiedFailoverXaDataSource(writer);
+    final XAConnection xaConn = ds.getXAConnection();
+    try {
+      final Connection conn = xaConn.getConnection();
+      final XAResource xaResource = xaConn.getXAResource();
+      final Xid xid = new XaTransactionTest.TestXid(30);
+
+      xaResource.start(xid, XAResource.TMNOFLAGS);
+      try (final Statement stmt = conn.createStatement()) {
+        stmt.executeUpdate("INSERT INTO " + TABLE + " (id) VALUES (30)");
+      }
+
+      // Crash the writer; the next statement triggers driver failover, which must fail fast because
+      // an XA branch is active (the branch cannot be preserved across a node change).
+      auroraUtil.crashInstance(executor, this.currentWriter);
+      auroraUtil.assertFirstQueryThrows(conn, XaFailoverNotSupportedSQLException.class);
+
+      // The transaction manager would now roll the branch back.
+      try {
+        xaResource.end(xid, XAResource.TMFAIL);
+      } catch (final Exception ignore) {
+        // The connection is broken; the branch is abandoned and will be rolled back / recovered.
+      }
+      try {
+        xaResource.rollback(xid);
+      } catch (final Exception ignore) {
+        // Best-effort rollback on a broken connection.
+      }
+    } finally {
+      try {
+        xaConn.close();
+      } catch (final SQLException ignore) {
+        // ignore
+      }
+    }
+
+    // A new XA transaction started after failover should succeed against the promoted writer.
+    // Use the cluster endpoint so the wrapper connects to the current writer.
+    final AwsWrapperXADataSource newDs = new AwsWrapperXADataSource();
+    newDs.setTargetDataSourceClassName(DriverHelper.getXaDataSourceClassname());
+    newDs.setJdbcUrl(ConnectionStringHelper.getWrapperUrl());
+    newDs.setUser(TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getUsername());
+    newDs.setPassword(TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getPassword());
+    final Properties newProps = new Properties();
+    newProps.setProperty(PropertyDefinition.PLUGINS.name, "");
+    newDs.setTargetDataSourceProperties(newProps);
+
+    final XAConnection xaConn2 = newDs.getXAConnection();
+    try {
+      final Connection conn = xaConn2.getConnection();
+      final XAResource xaResource = xaConn2.getXAResource();
+      final Xid xid = new XaTransactionTest.TestXid(31);
+
+      xaResource.start(xid, XAResource.TMNOFLAGS);
+      try (final Statement stmt = conn.createStatement()) {
+        stmt.executeUpdate("INSERT INTO " + TABLE + " (id) VALUES (31)");
+      }
+      xaResource.end(xid, XAResource.TMSUCCESS);
+      xaResource.prepare(xid);
+      xaResource.commit(xid, false);
+    } finally {
+      xaConn2.close();
+    }
+
+    assertEquals(1, countRows(31), "a new XA transaction after failover should commit on the promoted writer");
+  }
+
+  /**
+   * Opens an XA branch, writes a row, then forces a cluster failover before the branch is prepared or
+   * committed. Because the physical session cannot be moved to the promoted node, the wrapper fails
+   * fast and the unprepared branch is rolled back by the database. The test asserts the row is NOT
+   * present on the promoted writer, i.e. the XA transaction was effectively rolled back.
+   */
+  @TestTemplate
+  @EnableOnNumOfInstances(min = 2)
+  public void test_failoverDuringXaBranch_transactionIsRolledBack() throws Exception {
+    recreateTable();
+    final int id = 40;
+
+    final TestInstanceInfo writer =
+        TestEnvironment.getCurrent().getInfo().getProxyDatabaseInfo().getInstance(this.currentWriter);
+
+    final AwsWrapperXADataSource ds = createProxiedFailoverXaDataSource(writer);
+    final XAConnection xaConn = ds.getXAConnection();
+    try {
+      final Connection conn = xaConn.getConnection();
+      final XAResource xaResource = xaConn.getXAResource();
+      final Xid xid = new XaTransactionTest.TestXid(id);
+
+      xaResource.start(xid, XAResource.TMNOFLAGS);
+      try (final Statement stmt = conn.createStatement()) {
+        stmt.executeUpdate("INSERT INTO " + TABLE + " (id) VALUES (" + id + ")");
+      }
+
+      // Crash the writer mid-branch. The in-flight branch was never prepared, so failing fast leaves
+      // it to be rolled back by the database (an unprepared XA transaction on a lost session).
+      auroraUtil.crashInstance(executor, this.currentWriter);
+      auroraUtil.assertFirstQueryThrows(conn, XaFailoverNotSupportedSQLException.class);
+
+      // A transaction manager would now roll the branch back; on a broken connection this is
+      // best-effort and the database discards the unprepared branch regardless.
+      try {
+        xaResource.end(xid, XAResource.TMFAIL);
+      } catch (final Exception ignore) {
+        // expected on a broken connection
+      }
+      try {
+        xaResource.rollback(xid);
+      } catch (final Exception ignore) {
+        // expected on a broken connection
+      }
+    } finally {
+      try {
+        xaConn.close();
+      } catch (final SQLException ignore) {
+        // ignore
+      }
+    }
+
+    // The branch was never prepared/committed, so after failover the promoted writer must not contain
+    // the row: the XA transaction was effectively rolled back.
+    assertEquals(
+        0,
+        countRows(id),
+        "the XA branch active during failover must be rolled back (its row must not be persisted)");
+  }
+
+  private AwsWrapperXADataSource createProxiedFailoverXaDataSource(final TestInstanceInfo writer) {
+    final AwsWrapperXADataSource ds = new AwsWrapperXADataSource();
+    ds.setJdbcProtocol(DriverHelper.getDriverProtocol());
+    ds.setServerName(writer.getHost());
+    ds.setServerPort(Integer.toString(writer.getPort()));
+    ds.setDatabase(TestEnvironment.getCurrent().getInfo().getProxyDatabaseInfo().getDefaultDbName());
+    ds.setTargetDataSourceClassName(DriverHelper.getXaDataSourceClassname());
+    ds.setUser(TestEnvironment.getCurrent().getInfo().getProxyDatabaseInfo().getUsername());
+    ds.setPassword(TestEnvironment.getCurrent().getInfo().getProxyDatabaseInfo().getPassword());
+
+    final Properties targetProps = ConnectionStringHelper.getDefaultProperties();
+    targetProps.setProperty(PropertyDefinition.PLUGINS.name, "failover2,efm2");
+    PropertyDefinition.CONNECT_TIMEOUT.set(targetProps, "10000");
+    PropertyDefinition.SOCKET_TIMEOUT.set(targetProps, "2000");
+    RdsHostListProvider.CLUSTER_INSTANCE_HOST_PATTERN.set(
+        targetProps,
+        "?." + TestEnvironment.getCurrent().getInfo().getProxyDatabaseInfo().getInstanceEndpointSuffix()
+            + ":" + TestEnvironment.getCurrent().getInfo().getProxyDatabaseInfo().getInstanceEndpointPort());
+    ds.setTargetDataSourceProperties(targetProps);
+    return ds;
+  }
+
+  private Connection openPlainConnection() throws SQLException {
+    return java.sql.DriverManager.getConnection(
+        ConnectionStringHelper.getWrapperUrl(),
+        TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getUsername(),
+        TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getPassword());
+  }
+
+  private void recreateTable() throws SQLException {
+    try (final Connection conn = openPlainConnection();
+        final Statement stmt = conn.createStatement()) {
+      stmt.execute("DROP TABLE IF EXISTS " + TABLE);
+      stmt.execute("CREATE TABLE " + TABLE + " (id INT NOT NULL PRIMARY KEY)");
+    }
+  }
+
+  private int countRows(final int id) throws SQLException {
+    try (final Connection conn = openPlainConnection();
+        final Statement stmt = conn.createStatement();
+        final java.sql.ResultSet rs =
+            stmt.executeQuery("SELECT COUNT(*) FROM " + TABLE + " WHERE id = " + id)) {
+      rs.next();
+      return rs.getInt(1);
+    }
+  }
+}

--- a/wrapper/src/test/java/integration/container/tests/XaFailoverTest.java
+++ b/wrapper/src/test/java/integration/container/tests/XaFailoverTest.java
@@ -17,6 +17,7 @@
 package integration.container.tests;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import integration.DatabaseEngine;
 import integration.DatabaseEngineDeployment;
@@ -39,6 +40,7 @@ import java.sql.Statement;
 import java.util.Properties;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import javax.sql.XAConnection;
 import javax.transaction.xa.XAResource;
 import javax.transaction.xa.Xid;
@@ -146,35 +148,59 @@ public class XaFailoverTest {
       }
     }
 
-    // A new XA transaction started after failover should succeed against the promoted writer.
-    // Use the cluster endpoint so the wrapper connects to the current writer.
-    final AwsWrapperXADataSource newDs = new AwsWrapperXADataSource();
-    newDs.setTargetDataSourceClassName(DriverHelper.getXaDataSourceClassname());
-    newDs.setJdbcUrl(ConnectionStringHelper.getWrapperUrl());
-    newDs.setUser(TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getUsername());
-    newDs.setPassword(TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getPassword());
-    final Properties newProps = new Properties();
-    newProps.setProperty(PropertyDefinition.PLUGINS.name, "");
-    newDs.setTargetDataSourceProperties(newProps);
+    // A new XA transaction started after failover should succeed against the promoted writer. The
+    // cluster needs time to promote the new writer and update the cluster-endpoint DNS, so retry
+    // until it settles. Each attempt uses a distinct row id and Xid so a partially-completed attempt
+    // (e.g. prepared-but-not-committed on a connection that dropped) cannot block the next one.
+    final long deadlineNanos = System.nanoTime() + TimeUnit.MINUTES.toNanos(3);
+    int committedId = -1;
+    Exception lastError = null;
+    for (int attempt = 0; committedId < 0 && System.nanoTime() < deadlineNanos; attempt++) {
+      final int rowId = 31 + attempt;
 
-    final XAConnection xaConn2 = newDs.getXAConnection();
-    try {
-      final Connection conn = xaConn2.getConnection();
-      final XAResource xaResource = xaConn2.getXAResource();
-      final Xid xid = new XaTransactionTest.TestXid(31);
+      final AwsWrapperXADataSource newDs = new AwsWrapperXADataSource();
+      newDs.setTargetDataSourceClassName(DriverHelper.getXaDataSourceClassname());
+      newDs.setJdbcUrl(ConnectionStringHelper.getWrapperUrl());
+      newDs.setUser(TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getUsername());
+      newDs.setPassword(TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getPassword());
+      final Properties newProps = new Properties();
+      newProps.setProperty(PropertyDefinition.PLUGINS.name, "");
+      newDs.setTargetDataSourceProperties(newProps);
 
-      xaResource.start(xid, XAResource.TMNOFLAGS);
-      try (final Statement stmt = conn.createStatement()) {
-        stmt.executeUpdate("INSERT INTO " + TABLE + " (id) VALUES (31)");
+      XAConnection xaConn2 = null;
+      try {
+        xaConn2 = newDs.getXAConnection();
+        final Connection conn = xaConn2.getConnection();
+        final XAResource xaResource = xaConn2.getXAResource();
+        final Xid xid = new XaTransactionTest.TestXid(rowId);
+
+        xaResource.start(xid, XAResource.TMNOFLAGS);
+        try (final Statement stmt = conn.createStatement()) {
+          stmt.executeUpdate("INSERT INTO " + TABLE + " (id) VALUES (" + rowId + ")");
+        }
+        xaResource.end(xid, XAResource.TMSUCCESS);
+        xaResource.prepare(xid);
+        xaResource.commit(xid, false);
+        committedId = rowId;
+      } catch (final Exception e) {
+        lastError = e;
+        TimeUnit.SECONDS.sleep(10);
+      } finally {
+        if (xaConn2 != null) {
+          try {
+            xaConn2.close();
+          } catch (final SQLException ignore) {
+            // ignore
+          }
+        }
       }
-      xaResource.end(xid, XAResource.TMSUCCESS);
-      xaResource.prepare(xid);
-      xaResource.commit(xid, false);
-    } finally {
-      xaConn2.close();
     }
 
-    assertEquals(1, countRows(31), "a new XA transaction after failover should commit on the promoted writer");
+    assertTrue(committedId >= 0,
+        "a new XA transaction after failover should commit on the promoted writer"
+            + (lastError != null ? " (last error: " + lastError.getMessage() + ")" : ""));
+    assertEquals(1, countRows(committedId),
+        "the new XA transaction should be committed on the promoted writer");
   }
 
   /**

--- a/wrapper/src/test/java/integration/container/tests/XaFailoverTest.java
+++ b/wrapper/src/test/java/integration/container/tests/XaFailoverTest.java
@@ -152,6 +152,9 @@ public class XaFailoverTest {
     // cluster needs time to promote the new writer and update the cluster-endpoint DNS, so retry
     // until it settles. Each attempt uses a distinct row id and Xid so a partially-completed attempt
     // (e.g. prepared-but-not-committed on a connection that dropped) cannot block the next one.
+    // The recovery datasource must target the cluster writer endpoint (which follows failover and
+    // resolves to the promoted writer once DNS updates); pointing at a fixed instance host would hit
+    // the demoted node, now a reader, and every write would fail with "read only transaction".
     final long deadlineNanos = System.nanoTime() + TimeUnit.MINUTES.toNanos(3);
     int committedId = -1;
     Exception lastError = null;
@@ -160,7 +163,7 @@ public class XaFailoverTest {
 
       final AwsWrapperXADataSource newDs = new AwsWrapperXADataSource();
       newDs.setTargetDataSourceClassName(DriverHelper.getXaDataSourceClassname());
-      newDs.setJdbcUrl(ConnectionStringHelper.getWrapperUrl());
+      newDs.setJdbcUrl(ConnectionStringHelper.getWrapperClusterEndpointUrl());
       newDs.setUser(TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getUsername());
       newDs.setPassword(TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getPassword());
       final Properties newProps = new Properties();
@@ -286,8 +289,11 @@ public class XaFailoverTest {
   }
 
   private Connection openPlainConnection() throws SQLException {
+    // Use the cluster writer endpoint so reads/writes always target the current writer. After a
+    // failover this follows the promoted node; a fixed instance host would resolve to the demoted
+    // reader and either serve stale (replica-lagged) rows or reject writes.
     return java.sql.DriverManager.getConnection(
-        ConnectionStringHelper.getWrapperUrl(),
+        ConnectionStringHelper.getWrapperClusterEndpointUrl(),
         TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getUsername(),
         TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getPassword());
   }

--- a/wrapper/src/test/java/integration/container/tests/XaIamAuthenticationTest.java
+++ b/wrapper/src/test/java/integration/container/tests/XaIamAuthenticationTest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integration.container.tests;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import integration.DatabaseEngine;
+import integration.DriverHelper;
+import integration.TestEnvironmentFeatures;
+import integration.container.ConnectionStringHelper;
+import integration.container.TestDriver;
+import integration.container.TestDriverProvider;
+import integration.container.TestEnvironment;
+import integration.container.condition.DisableOnTestDriver;
+import integration.container.condition.DisableOnTestFeature;
+import integration.container.condition.EnableOnDatabaseEngine;
+import integration.container.condition.EnableOnTestFeature;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.Properties;
+import javax.sql.XAConnection;
+import javax.transaction.xa.XAResource;
+import javax.transaction.xa.Xid;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import software.amazon.jdbc.PropertyDefinition;
+import software.amazon.jdbc.ds.AwsWrapperXADataSource;
+import software.amazon.jdbc.plugin.iam.IamAuthConnectionPlugin;
+
+/**
+ * Integration test proving that IAM database authentication works through
+ * {@link AwsWrapperXADataSource}. The IAM authentication plugin runs in the wrapper's connect
+ * pipeline for the XA connection, generates a short-lived token, and that token must reach the
+ * target driver's {@code XADataSource} so the physical XA connection authenticates. This exercises
+ * the wrapper's connect-time value on the XA path (IAM auth is one of the reasons to use the XA
+ * datasource even though connection-switching plugins are not supported there).
+ *
+ * <p>Requires an IAM-enabled RDS/Aurora environment (feature {@code IAM}). Restricted to PostgreSQL
+ * and MySQL (which provide XA datasource implementations). The MariaDB driver is disabled because it
+ * does not force {@code mysql_clear_password} authentication, which IAM requires (see
+ * {@code AwsIamIntegrationTest}).
+ */
+@TestMethodOrder(MethodOrderer.MethodName.class)
+@ExtendWith(TestDriverProvider.class)
+@EnableOnTestFeature(TestEnvironmentFeatures.IAM)
+@EnableOnDatabaseEngine({DatabaseEngine.PG, DatabaseEngine.MYSQL})
+@DisableOnTestFeature({
+    TestEnvironmentFeatures.PERFORMANCE,
+    TestEnvironmentFeatures.RUN_HIBERNATE_TESTS_ONLY,
+    TestEnvironmentFeatures.RUN_ENCRYPTION_TESTS_ONLY,
+    TestEnvironmentFeatures.RUN_AUTOSCALING_TESTS_ONLY,
+    TestEnvironmentFeatures.BLUE_GREEN_DEPLOYMENT,
+    TestEnvironmentFeatures.RUN_DB_METRICS_ONLY})
+@Order(26)
+@Tag("xa")
+public class XaIamAuthenticationTest {
+
+  @BeforeEach
+  void clearIamCache() {
+    IamAuthConnectionPlugin.clearCache();
+  }
+
+  private AwsWrapperXADataSource createIamXaDataSource() {
+    final AwsWrapperXADataSource ds = new AwsWrapperXADataSource();
+    ds.setTargetDataSourceClassName(DriverHelper.getXaDataSourceClassname());
+    ds.setJdbcUrl(ConnectionStringHelper.getWrapperUrl());
+
+    final Properties props = new Properties();
+    // IAM only: no password. The IAM plugin generates a token and sets it as the password; the XA
+    // connection provider applies it to the target XADataSource before opening the physical session.
+    props.setProperty(PropertyDefinition.PLUGINS.name, "iam");
+    props.setProperty(
+        IamAuthConnectionPlugin.IAM_REGION.name, TestEnvironment.getCurrent().getInfo().getRegion());
+    // The IAM username must be on the pipeline properties so the plugin generates a token for it.
+    props.setProperty(
+        PropertyDefinition.USER.name, TestEnvironment.getCurrent().getInfo().getIamUsername());
+    props.setProperty(PropertyDefinition.TCP_KEEP_ALIVE.name, "false");
+    ds.setTargetDataSourceProperties(props);
+    return ds;
+  }
+
+  /** A valid IAM-authenticated logical connection can be obtained from the XA datasource. */
+  @TestTemplate
+  @DisableOnTestDriver(TestDriver.MARIADB)
+  public void test_iamAuth_getConnection() throws Exception {
+    final AwsWrapperXADataSource ds = createIamXaDataSource();
+    final XAConnection xaConn = ds.getXAConnection();
+    try {
+      final Connection conn = xaConn.getConnection();
+      assertTrue(conn.isValid(10), "IAM-authenticated XA connection should be valid");
+    } finally {
+      xaConn.close();
+    }
+  }
+
+  /** The XA control surface works over an IAM-authenticated XA connection. */
+  @TestTemplate
+  @DisableOnTestDriver(TestDriver.MARIADB)
+  public void test_iamAuth_xaBranchLifecycle() throws Exception {
+    final AwsWrapperXADataSource ds = createIamXaDataSource();
+    final XAConnection xaConn = ds.getXAConnection();
+    try {
+      final Connection conn = xaConn.getConnection();
+      final XAResource xaResource = xaConn.getXAResource();
+      final Xid xid = new TestXid(1);
+
+      xaResource.start(xid, XAResource.TMNOFLAGS);
+      try (final Statement stmt = conn.createStatement();
+          final ResultSet rs = stmt.executeQuery("SELECT 1")) {
+        assertTrue(rs.next());
+      }
+      xaResource.end(xid, XAResource.TMSUCCESS);
+
+      final int prepareResult = xaResource.prepare(xid);
+      // A read-only branch is fully resolved by prepare (XA_RDONLY); otherwise commit it.
+      if (prepareResult == XAResource.XA_OK) {
+        xaResource.commit(xid, false);
+      }
+    } finally {
+      xaConn.close();
+    }
+  }
+
+  /** A minimal {@link Xid} implementation for driving an XA branch directly in tests. */
+  static final class TestXid implements Xid {
+    private static final int FORMAT_ID = 0xA5A5;
+    private final byte[] gtrid;
+    private final byte[] bqual;
+
+    TestXid(final int seed) {
+      this.gtrid = new byte[] {(byte) seed, 0x1, 0x2, 0x3};
+      this.bqual = new byte[] {(byte) seed, 0x4, 0x5, 0x6};
+    }
+
+    @Override
+    public int getFormatId() {
+      return FORMAT_ID;
+    }
+
+    @Override
+    public byte[] getGlobalTransactionId() {
+      return this.gtrid.clone();
+    }
+
+    @Override
+    public byte[] getBranchQualifier() {
+      return this.bqual.clone();
+    }
+  }
+}

--- a/wrapper/src/test/java/integration/container/tests/XaTransactionTest.java
+++ b/wrapper/src/test/java/integration/container/tests/XaTransactionTest.java
@@ -30,6 +30,7 @@ import integration.container.TestEnvironment;
 import integration.container.condition.DisableOnTestFeature;
 import integration.container.condition.EnableOnDatabaseEngine;
 import integration.container.condition.EnableOnNumOfInstances;
+import integration.util.AuroraTestUtility;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -234,8 +235,7 @@ public class XaTransactionTest {
   @TestTemplate
   @EnableOnNumOfInstances(min = 2)
   public void test_readWriteSplittingDoesNotSwitchDuringXaBranch() throws Exception {
-    recreateTable();
-    final int id = 5;
+    final AuroraTestUtility auroraUtil = AuroraTestUtility.getUtility();
     final AwsWrapperXADataSource ds = createXaDataSource();
     // Enable read/write splitting on the XA datasource; it must be skipped during the XA branch.
     final Properties targetProps = new Properties();
@@ -249,20 +249,25 @@ public class XaTransactionTest {
       final Xid xid = new TestXid(5);
 
       xaResource.start(xid, XAResource.TMNOFLAGS);
-      // Requesting read-only inside an XA branch must NOT switch to a reader (the gate pins the
-      // connection). If it switched to a reader, the following write would fail.
+      final String instanceInBranch = auroraUtil.queryInstanceId(conn);
+
+      // Requesting read-only inside an XA branch must NOT switch to a reader: the transaction-aware
+      // gate pins the physical connection for the branch. If the connection had switched, the
+      // reported instance id would change. We assert on the instance id rather than performing a
+      // write, because when the switch is skipped the underlying driver still applies read-only to
+      // the pinned session, which would block a subsequent INSERT (that is expected driver behavior,
+      // not a switch).
       conn.setReadOnly(true);
-      try (final Statement stmt = conn.createStatement()) {
-        stmt.executeUpdate("INSERT INTO " + TABLE + " (id) VALUES (" + id + ")");
-      }
+      final String instanceAfterSetReadOnly = auroraUtil.queryInstanceId(conn);
+      assertEquals(instanceInBranch, instanceAfterSetReadOnly,
+          "read/write splitting must not switch the connection during an XA branch");
+
+      conn.setReadOnly(false);
       xaResource.end(xid, XAResource.TMSUCCESS);
-      xaResource.prepare(xid);
-      xaResource.commit(xid, false);
+      xaResource.rollback(xid);
     } finally {
       xaConn.close();
     }
-
-    assertEquals(1, countRows(id), "the write must have stayed on the writer during the XA branch");
   }
 
   private static boolean xidEquals(final Xid a, final Xid b) {

--- a/wrapper/src/test/java/integration/container/tests/XaTransactionTest.java
+++ b/wrapper/src/test/java/integration/container/tests/XaTransactionTest.java
@@ -1,0 +1,300 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integration.container.tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import integration.DatabaseEngine;
+import integration.DriverHelper;
+import integration.TestEnvironmentFeatures;
+import integration.container.ConnectionStringHelper;
+import integration.container.TestDriverProvider;
+import integration.container.TestEnvironment;
+import integration.container.condition.DisableOnTestFeature;
+import integration.container.condition.EnableOnDatabaseEngine;
+import integration.container.condition.EnableOnNumOfInstances;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Arrays;
+import java.util.Properties;
+import javax.sql.XAConnection;
+import javax.transaction.xa.XAResource;
+import javax.transaction.xa.Xid;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import software.amazon.jdbc.PropertyDefinition;
+import software.amazon.jdbc.ds.AwsWrapperXADataSource;
+import software.amazon.jdbc.wrapper.ConnectionWrapper;
+
+/**
+ * Integration tests that run real XA (two-phase commit) transactions through
+ * {@link AwsWrapperXADataSource} against a real database, driving the {@link XAResource} lifecycle
+ * directly (no external transaction manager). Restricted to PostgreSQL and MySQL, which provide XA
+ * datasource implementations.
+ */
+@TestMethodOrder(MethodOrderer.MethodName.class)
+@ExtendWith(TestDriverProvider.class)
+@EnableOnDatabaseEngine({DatabaseEngine.PG, DatabaseEngine.MYSQL})
+@DisableOnTestFeature({
+    TestEnvironmentFeatures.PERFORMANCE,
+    TestEnvironmentFeatures.RUN_HIBERNATE_TESTS_ONLY,
+    TestEnvironmentFeatures.RUN_ENCRYPTION_TESTS_ONLY,
+    TestEnvironmentFeatures.RUN_AUTOSCALING_TESTS_ONLY,
+    TestEnvironmentFeatures.BLUE_GREEN_DEPLOYMENT,
+    TestEnvironmentFeatures.RUN_DB_METRICS_ONLY})
+@Order(24)
+@Tag("xa")
+public class XaTransactionTest {
+
+  private static final String TABLE = "xa_test_table";
+
+  private AwsWrapperXADataSource createXaDataSource() {
+    final AwsWrapperXADataSource ds = new AwsWrapperXADataSource();
+    ds.setTargetDataSourceClassName(DriverHelper.getXaDataSourceClassname());
+    ds.setJdbcUrl(ConnectionStringHelper.getWrapperUrl());
+    ds.setUser(TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getUsername());
+    ds.setPassword(TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getPassword());
+    // No connection-switching plugins on the XA path (see the two-datasource pattern). An empty
+    // plugin list also avoids the default Aurora/topology plugins interfering with XA semantics
+    // against a plain database.
+    final Properties props = new Properties();
+    props.setProperty(PropertyDefinition.PLUGINS.name, "");
+    ds.setTargetDataSourceProperties(props);
+    return ds;
+  }
+
+  private void recreateTable() throws SQLException {
+    try (final Connection conn = openPlainConnection();
+        final Statement stmt = conn.createStatement()) {
+      stmt.execute("DROP TABLE IF EXISTS " + TABLE);
+      stmt.execute("CREATE TABLE " + TABLE + " (id INT NOT NULL PRIMARY KEY)");
+    }
+  }
+
+  private Connection openPlainConnection() throws SQLException {
+    return java.sql.DriverManager.getConnection(
+        ConnectionStringHelper.getWrapperUrl(),
+        TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getUsername(),
+        TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getPassword());
+  }
+
+  private int countRows(final int id) throws SQLException {
+    try (final Connection conn = openPlainConnection();
+        final Statement stmt = conn.createStatement();
+        final ResultSet rs = stmt.executeQuery("SELECT COUNT(*) FROM " + TABLE + " WHERE id = " + id)) {
+      rs.next();
+      return rs.getInt(1);
+    }
+  }
+
+  @TestTemplate
+  public void test_getConnection_returnsPipelinedWrapper() throws SQLException {
+    final AwsWrapperXADataSource ds = createXaDataSource();
+    final XAConnection xaConn = ds.getXAConnection();
+    try {
+      final Connection conn = xaConn.getConnection();
+      assertTrue(conn instanceof ConnectionWrapper);
+      assertNotNull(xaConn.getXAResource());
+    } finally {
+      xaConn.close();
+    }
+  }
+
+  @TestTemplate
+  public void test_xaLifecycle_commitPersists() throws Exception {
+    recreateTable();
+    final int id = 1;
+    final AwsWrapperXADataSource ds = createXaDataSource();
+    final XAConnection xaConn = ds.getXAConnection();
+    try {
+      final Connection conn = xaConn.getConnection();
+      final XAResource xaResource = xaConn.getXAResource();
+      final Xid xid = new TestXid(1);
+
+      xaResource.start(xid, XAResource.TMNOFLAGS);
+      try (final Statement stmt = conn.createStatement()) {
+        stmt.executeUpdate("INSERT INTO " + TABLE + " (id) VALUES (" + id + ")");
+      }
+      xaResource.end(xid, XAResource.TMSUCCESS);
+
+      final int prepareResult = xaResource.prepare(xid);
+      assertTrue(prepareResult == XAResource.XA_OK || prepareResult == XAResource.XA_RDONLY);
+      xaResource.commit(xid, false);
+    } finally {
+      xaConn.close();
+    }
+
+    assertEquals(1, countRows(id));
+  }
+
+  @TestTemplate
+  public void test_xaLifecycle_rollbackDiscards() throws Exception {
+    recreateTable();
+    final int id = 2;
+    final AwsWrapperXADataSource ds = createXaDataSource();
+    final XAConnection xaConn = ds.getXAConnection();
+    try {
+      final Connection conn = xaConn.getConnection();
+      final XAResource xaResource = xaConn.getXAResource();
+      final Xid xid = new TestXid(2);
+
+      xaResource.start(xid, XAResource.TMNOFLAGS);
+      try (final Statement stmt = conn.createStatement()) {
+        stmt.executeUpdate("INSERT INTO " + TABLE + " (id) VALUES (" + id + ")");
+      }
+      xaResource.end(xid, XAResource.TMSUCCESS);
+      xaResource.prepare(xid);
+      xaResource.rollback(xid);
+    } finally {
+      xaConn.close();
+    }
+
+    assertEquals(0, countRows(id));
+  }
+
+  @TestTemplate
+  public void test_xaLifecycle_onePhaseCommit() throws Exception {
+    recreateTable();
+    final int id = 3;
+    final AwsWrapperXADataSource ds = createXaDataSource();
+    final XAConnection xaConn = ds.getXAConnection();
+    try {
+      final Connection conn = xaConn.getConnection();
+      final XAResource xaResource = xaConn.getXAResource();
+      final Xid xid = new TestXid(3);
+
+      xaResource.start(xid, XAResource.TMNOFLAGS);
+      try (final Statement stmt = conn.createStatement()) {
+        stmt.executeUpdate("INSERT INTO " + TABLE + " (id) VALUES (" + id + ")");
+      }
+      xaResource.end(xid, XAResource.TMSUCCESS);
+      // One-phase commit: no separate prepare.
+      xaResource.commit(xid, true);
+    } finally {
+      xaConn.close();
+    }
+
+    assertEquals(1, countRows(id));
+  }
+
+  @TestTemplate
+  public void test_recover_returnsPreparedBranch() throws Exception {
+    recreateTable();
+    final int id = 4;
+    final AwsWrapperXADataSource ds = createXaDataSource();
+    final XAConnection xaConn = ds.getXAConnection();
+    try {
+      final Connection conn = xaConn.getConnection();
+      final XAResource xaResource = xaConn.getXAResource();
+      final Xid xid = new TestXid(4);
+
+      xaResource.start(xid, XAResource.TMNOFLAGS);
+      try (final Statement stmt = conn.createStatement()) {
+        stmt.executeUpdate("INSERT INTO " + TABLE + " (id) VALUES (" + id + ")");
+      }
+      xaResource.end(xid, XAResource.TMSUCCESS);
+      xaResource.prepare(xid);
+
+      // The prepared (in-doubt) branch should be discoverable via recover and resolvable by Xid.
+      final Xid[] recovered = xaResource.recover(XAResource.TMSTARTRSCAN | XAResource.TMENDRSCAN);
+      final boolean found = recovered != null && Arrays.stream(recovered).anyMatch(r -> xidEquals(r, xid));
+      assertTrue(found, "prepared branch should be returned by recover()");
+
+      xaResource.commit(xid, false);
+    } finally {
+      xaConn.close();
+    }
+
+    assertEquals(1, countRows(id));
+  }
+
+  @TestTemplate
+  @EnableOnNumOfInstances(min = 2)
+  public void test_readWriteSplittingDoesNotSwitchDuringXaBranch() throws Exception {
+    recreateTable();
+    final int id = 5;
+    final AwsWrapperXADataSource ds = createXaDataSource();
+    // Enable read/write splitting on the XA datasource; it must be skipped during the XA branch.
+    final Properties targetProps = new Properties();
+    targetProps.setProperty(PropertyDefinition.PLUGINS.name, "readWriteSplitting");
+    ds.setTargetDataSourceProperties(targetProps);
+
+    final XAConnection xaConn = ds.getXAConnection();
+    try {
+      final Connection conn = xaConn.getConnection();
+      final XAResource xaResource = xaConn.getXAResource();
+      final Xid xid = new TestXid(5);
+
+      xaResource.start(xid, XAResource.TMNOFLAGS);
+      // Requesting read-only inside an XA branch must NOT switch to a reader (the gate pins the
+      // connection). If it switched to a reader, the following write would fail.
+      conn.setReadOnly(true);
+      try (final Statement stmt = conn.createStatement()) {
+        stmt.executeUpdate("INSERT INTO " + TABLE + " (id) VALUES (" + id + ")");
+      }
+      xaResource.end(xid, XAResource.TMSUCCESS);
+      xaResource.prepare(xid);
+      xaResource.commit(xid, false);
+    } finally {
+      xaConn.close();
+    }
+
+    assertEquals(1, countRows(id), "the write must have stayed on the writer during the XA branch");
+  }
+
+  private static boolean xidEquals(final Xid a, final Xid b) {
+    return a.getFormatId() == b.getFormatId()
+        && Arrays.equals(a.getGlobalTransactionId(), b.getGlobalTransactionId())
+        && Arrays.equals(a.getBranchQualifier(), b.getBranchQualifier());
+  }
+
+  /** A minimal {@link Xid} implementation for driving XA transactions directly in tests. */
+  static final class TestXid implements Xid {
+    private static final int FORMAT_ID = 0xA5A5;
+    private final byte[] gtrid;
+    private final byte[] bqual;
+
+    TestXid(final int seed) {
+      this.gtrid = new byte[] {(byte) seed, 0x1, 0x2, 0x3};
+      this.bqual = new byte[] {(byte) seed, 0x4, 0x5, 0x6};
+    }
+
+    @Override
+    public int getFormatId() {
+      return FORMAT_ID;
+    }
+
+    @Override
+    public byte[] getGlobalTransactionId() {
+      return this.gtrid.clone();
+    }
+
+    @Override
+    public byte[] getBranchQualifier() {
+      return this.bqual.clone();
+    }
+  }
+}

--- a/wrapper/src/test/java/integration/container/tests/XaTwoPhaseCommitTest.java
+++ b/wrapper/src/test/java/integration/container/tests/XaTwoPhaseCommitTest.java
@@ -1,0 +1,270 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integration.container.tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import integration.DatabaseEngine;
+import integration.DriverHelper;
+import integration.TestEnvironmentFeatures;
+import integration.container.ConnectionStringHelper;
+import integration.container.TestDriverProvider;
+import integration.container.TestEnvironment;
+import integration.container.condition.DisableOnTestFeature;
+import integration.container.condition.EnableOnDatabaseEngine;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicLong;
+import javax.sql.XAConnection;
+import javax.transaction.Transaction;
+import javax.transaction.TransactionManager;
+import javax.transaction.xa.XAResource;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import software.amazon.jdbc.PropertyDefinition;
+import software.amazon.jdbc.ds.AwsWrapperXADataSource;
+
+/**
+ * Integration tests that run a real two-resource, two-phase-commit transaction through
+ * {@link AwsWrapperXADataSource}, coordinated by a real transaction manager. Each scenario runs
+ * against BOTH Narayana and Atomikos to confirm compatibility with both, exercising each
+ * transaction manager the idiomatic way: Narayana with manual {@code enlistResource}, and Atomikos
+ * through its {@code AtomikosDataSourceBean} (which registers the resource for recovery and enlists
+ * automatically).
+ *
+ * <p>Restricted to PostgreSQL and MySQL (which provide XA datasource implementations). Requires a
+ * real database environment to execute.
+ */
+@TestMethodOrder(MethodOrderer.MethodName.class)
+@ExtendWith(TestDriverProvider.class)
+@EnableOnDatabaseEngine({DatabaseEngine.PG, DatabaseEngine.MYSQL})
+@DisableOnTestFeature({
+    TestEnvironmentFeatures.PERFORMANCE,
+    TestEnvironmentFeatures.RUN_HIBERNATE_TESTS_ONLY,
+    TestEnvironmentFeatures.RUN_ENCRYPTION_TESTS_ONLY,
+    TestEnvironmentFeatures.RUN_AUTOSCALING_TESTS_ONLY,
+    TestEnvironmentFeatures.BLUE_GREEN_DEPLOYMENT,
+    TestEnvironmentFeatures.RUN_DB_METRICS_ONLY})
+@Order(25)
+@Tag("xa")
+public class XaTwoPhaseCommitTest {
+
+  private static final String TABLE_1 = "xa_2pc_table_1";
+  private static final String TABLE_2 = "xa_2pc_table_2";
+
+  /** Ensures each Atomikos resource gets a unique name across test iterations. */
+  private static final AtomicLong RESOURCE_SEQ = new AtomicLong();
+
+  /** The transaction managers exercised by these tests. */
+  enum Tm {
+    /** Narayana, driven with manual {@code enlistResource}/{@code delistResource}. */
+    NARAYANA {
+      @Override
+      void runTwoResourceTransaction(
+          final AwsWrapperXADataSource ds1,
+          final AwsWrapperXADataSource ds2,
+          final String table1,
+          final String table2,
+          final int id,
+          final boolean commit)
+          throws Exception {
+        final TransactionManager tm = com.arjuna.ats.jta.TransactionManager.transactionManager();
+        XAConnection xaConn1 = null;
+        XAConnection xaConn2 = null;
+        try {
+          xaConn1 = ds1.getXAConnection();
+          xaConn2 = ds2.getXAConnection();
+
+          // Obtain the logical connection handles before enlisting, matching how a managed
+          // environment checks out the connection: this establishes the wrapper pipeline over the
+          // target XA connection and leaves the physical session clean so XA START succeeds.
+          final Connection conn1 = xaConn1.getConnection();
+          final Connection conn2 = xaConn2.getConnection();
+          // getXAResource() must be called once and the same instance reused for enlist/delist so
+          // the transaction manager tracks a single resource per branch.
+          final XAResource res1 = xaConn1.getXAResource();
+          final XAResource res2 = xaConn2.getXAResource();
+
+          tm.begin();
+          final Transaction txn = tm.getTransaction();
+          txn.enlistResource(res1);
+          txn.enlistResource(res2);
+
+          try (final Statement s1 = conn1.createStatement()) {
+            s1.executeUpdate("INSERT INTO " + table1 + " (id) VALUES (" + id + ")");
+          }
+          try (final Statement s2 = conn2.createStatement()) {
+            s2.executeUpdate("INSERT INTO " + table2 + " (id) VALUES (" + id + ")");
+          }
+
+          txn.delistResource(res1, XAResource.TMSUCCESS);
+          txn.delistResource(res2, XAResource.TMSUCCESS);
+
+          if (commit) {
+            tm.commit();
+          } else {
+            tm.rollback();
+          }
+        } finally {
+          if (xaConn1 != null) {
+            xaConn1.close();
+          }
+          if (xaConn2 != null) {
+            xaConn2.close();
+          }
+        }
+      }
+    },
+
+    /** Atomikos, driven through {@code AtomikosDataSourceBean} (idiomatic JTA usage). */
+    ATOMIKOS {
+      @Override
+      void runTwoResourceTransaction(
+          final AwsWrapperXADataSource ds1,
+          final AwsWrapperXADataSource ds2,
+          final String table1,
+          final String table2,
+          final int id,
+          final boolean commit)
+          throws Exception {
+        final com.atomikos.jdbc.AtomikosDataSourceBean bean1 = newBean(ds1);
+        final com.atomikos.jdbc.AtomikosDataSourceBean bean2 = newBean(ds2);
+        final com.atomikos.icatch.jta.UserTransactionManager utm =
+            new com.atomikos.icatch.jta.UserTransactionManager();
+        utm.setForceShutdown(true);
+        utm.init();
+        try {
+          utm.begin();
+          boolean thrown = true;
+          try {
+            // AtomikosDataSourceBean.getConnection() enlists the resource in the active JTA
+            // transaction automatically. Closing the handle returns it to the pool but keeps the
+            // branch enlisted until the transaction completes.
+            try (final Connection c1 = bean1.getConnection();
+                final Statement s1 = c1.createStatement()) {
+              s1.executeUpdate("INSERT INTO " + table1 + " (id) VALUES (" + id + ")");
+            }
+            try (final Connection c2 = bean2.getConnection();
+                final Statement s2 = c2.createStatement()) {
+              s2.executeUpdate("INSERT INTO " + table2 + " (id) VALUES (" + id + ")");
+            }
+            thrown = false;
+          } finally {
+            if (commit && !thrown) {
+              utm.commit();
+            } else {
+              utm.rollback();
+            }
+          }
+        } finally {
+          bean1.close();
+          bean2.close();
+          utm.close();
+        }
+      }
+
+      private com.atomikos.jdbc.AtomikosDataSourceBean newBean(final AwsWrapperXADataSource ds) {
+        final com.atomikos.jdbc.AtomikosDataSourceBean bean =
+            new com.atomikos.jdbc.AtomikosDataSourceBean();
+        bean.setUniqueResourceName("xa-res-" + RESOURCE_SEQ.incrementAndGet());
+        bean.setXaDataSource(ds);
+        bean.setMinPoolSize(1);
+        bean.setMaxPoolSize(1);
+        return bean;
+      }
+    };
+
+    abstract void runTwoResourceTransaction(
+        AwsWrapperXADataSource ds1,
+        AwsWrapperXADataSource ds2,
+        String table1,
+        String table2,
+        int id,
+        boolean commit)
+        throws Exception;
+  }
+
+  private AwsWrapperXADataSource createXaDataSource() {
+    final AwsWrapperXADataSource ds = new AwsWrapperXADataSource();
+    ds.setTargetDataSourceClassName(DriverHelper.getXaDataSourceClassname());
+    ds.setJdbcUrl(ConnectionStringHelper.getWrapperUrl());
+    ds.setUser(TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getUsername());
+    ds.setPassword(TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getPassword());
+    // No connection-switching / Aurora plugins on the XA path.
+    final Properties props = new Properties();
+    props.setProperty(PropertyDefinition.PLUGINS.name, "");
+    ds.setTargetDataSourceProperties(props);
+    return ds;
+  }
+
+  private Connection openPlainConnection() throws SQLException {
+    return java.sql.DriverManager.getConnection(
+        ConnectionStringHelper.getWrapperUrl(),
+        TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getUsername(),
+        TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getPassword());
+  }
+
+  private void recreateTables() throws SQLException {
+    try (final Connection conn = openPlainConnection();
+        final Statement stmt = conn.createStatement()) {
+      stmt.execute("DROP TABLE IF EXISTS " + TABLE_1);
+      stmt.execute("DROP TABLE IF EXISTS " + TABLE_2);
+      stmt.execute("CREATE TABLE " + TABLE_1 + " (id INT NOT NULL PRIMARY KEY)");
+      stmt.execute("CREATE TABLE " + TABLE_2 + " (id INT NOT NULL PRIMARY KEY)");
+    }
+  }
+
+  private int countRows(final String table, final int id) throws SQLException {
+    try (final Connection conn = openPlainConnection();
+        final Statement stmt = conn.createStatement();
+        final ResultSet rs = stmt.executeQuery("SELECT COUNT(*) FROM " + table + " WHERE id = " + id)) {
+      rs.next();
+      return rs.getInt(1);
+    }
+  }
+
+  @TestTemplate
+  public void test_twoResourceCommit_bothTransactionManagers() throws Exception {
+    for (final Tm tm : Tm.values()) {
+      recreateTables();
+      final int id = 10;
+      tm.runTwoResourceTransaction(createXaDataSource(), createXaDataSource(), TABLE_1, TABLE_2, id, true);
+
+      assertEquals(1, countRows(TABLE_1, id), tm + ": table 1 should be committed");
+      assertEquals(1, countRows(TABLE_2, id), tm + ": table 2 should be committed");
+    }
+  }
+
+  @TestTemplate
+  public void test_twoResourceRollback_bothTransactionManagers() throws Exception {
+    for (final Tm tm : Tm.values()) {
+      recreateTables();
+      final int id = 20;
+      tm.runTwoResourceTransaction(createXaDataSource(), createXaDataSource(), TABLE_1, TABLE_2, id, false);
+
+      assertEquals(0, countRows(TABLE_1, id), tm + ": table 1 should be rolled back");
+      assertEquals(0, countRows(TABLE_2, id), tm + ": table 2 should be rolled back");
+    }
+  }
+}

--- a/wrapper/src/test/java/integration/util/ContainerHelper.java
+++ b/wrapper/src/test/java/integration/util/ContainerHelper.java
@@ -359,6 +359,11 @@ public class ContainerHelper {
         .withCopyFileToContainer(
             MountableFile.forHostPath("./src/test/config/standard-mysql-grant-root.sql"),
             "/docker-entrypoint-initdb.d/standard-mysql-grant-root.sql")
+        // Grant XA_RECOVER_ADMIN (required since MySQL 8.0 for "XA RECOVER") to the test user so
+        // XADataSource integration tests can call XAResource.recover().
+        .withCopyFileToContainer(
+            MountableFile.forHostPath("./src/test/config/mysql-grant-xa-recover.sh"),
+            "/docker-entrypoint-initdb.d/mysql-grant-xa-recover.sh")
         .withCommand(
             "--local_infile=1",
             "--max_allowed_packet=40M",
@@ -380,7 +385,10 @@ public class ContainerHelper {
         .withNetworkAliases(networkAlias)
         .withDatabaseName(testDbName)
         .withUsername(username)
-        .withPassword(password);
+        .withPassword(password)
+        // Enable prepared (two-phase / XA) transactions; PostgreSQL disables them by default
+        // (max_prepared_transactions=0), which would make XAResource.prepare fail.
+        .withCommand("postgres", "-c", "max_prepared_transactions=10");
   }
 
   public GenericContainer createPostgisContainer(
@@ -401,7 +409,8 @@ public class ContainerHelper {
                         "-c", "shared_buffers=256MB",
                         "-c", "maintenance_work_mem=256MB",
                         "-c", "max_wal_size=1GB",
-                        "-c", "checkpoint_timeout=1d")
+                        "-c", "checkpoint_timeout=1d",
+                        "-c", "max_prepared_transactions=10")
                     .build()))
         .waitingFor(new LogMessageWaitStrategy()
             .withRegEx(".*database system is ready to accept connections.*\\s")

--- a/wrapper/src/test/java/software/amazon/jdbc/PluginServiceImplTests.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/PluginServiceImplTests.java
@@ -158,6 +158,60 @@ public class PluginServiceImplTests {
   }
 
   @Test
+  public void testSetCurrentConnection_rejectedDuringXaTransaction() throws SQLException {
+    PluginServiceImpl target =
+        spy(new PluginServiceImpl(
+            servicesContainer,
+            new ExceptionManager(),
+            PROPERTIES,
+            URL,
+            DRIVER_PROTOCOL,
+            dialectManager,
+            mockTargetDriverDialect,
+            configurationProfile,
+            sessionStateService));
+    target.currentConnection = oldConnection;
+    target.currentHostSpec = new HostSpecBuilder(new SimpleHostAvailabilityStrategy()).host("old-host").build();
+    target.setXaTransactionActive(true);
+
+    final SQLException ex = assertThrows(SQLException.class, () -> target.setCurrentConnection(newConnection,
+        new HostSpecBuilder(new SimpleHostAvailabilityStrategy()).host("new-host").build()));
+
+    assertEquals("25001", ex.getSQLState());
+    // The connection must not have been swapped.
+    assertEquals(oldConnection, target.currentConnection);
+    verify(pluginManager, never()).notifyConnectionChanged(any(), any());
+  }
+
+  @Test
+  public void testSetCurrentConnection_allowsSameConnectionHostSpecUpdateDuringXa() throws SQLException {
+    when(pluginManager.notifyConnectionChanged(any(), any()))
+        .thenReturn(EnumSet.of(OldConnectionSuggestedAction.NO_OPINION));
+
+    PluginServiceImpl target =
+        spy(new PluginServiceImpl(
+            servicesContainer,
+            new ExceptionManager(),
+            PROPERTIES,
+            URL,
+            DRIVER_PROTOCOL,
+            dialectManager,
+            mockTargetDriverDialect,
+            configurationProfile,
+            sessionStateService));
+    target.currentConnection = oldConnection;
+    target.currentHostSpec = new HostSpecBuilder(new SimpleHostAvailabilityStrategy())
+        .host("old-host").role(HostRole.WRITER).build();
+    target.setXaTransactionActive(true);
+
+    // Same connection object, only the HostSpec is updated (e.g. host-monitoring). Must be allowed.
+    target.setCurrentConnection(oldConnection,
+        new HostSpecBuilder(new SimpleHostAvailabilityStrategy()).host("old-host").role(HostRole.READER).build());
+
+    assertEquals(oldConnection, target.currentConnection);
+  }
+
+  @Test
   public void testOldConnectionDisposeSuggestion() throws SQLException {
     when(pluginManager.notifyConnectionChanged(any(), any()))
         .thenReturn(EnumSet.of(OldConnectionSuggestedAction.DISPOSE));

--- a/wrapper/src/test/java/software/amazon/jdbc/ds/AwsWrapperXADataSourceTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/ds/AwsWrapperXADataSourceTest.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.jdbc.ds;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.PrintWriter;
+import java.sql.SQLException;
+import java.util.Properties;
+import java.util.logging.Logger;
+import javax.sql.XAConnection;
+import javax.sql.XADataSource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.jdbc.ConnectionProvider;
+import software.amazon.jdbc.Driver;
+import software.amazon.jdbc.ds.AwsWrapperXADataSource.ResolvedConfig;
+
+/** Unit tests for {@link AwsWrapperXADataSource} configuration and fail-fast validation. */
+public class AwsWrapperXADataSourceTest {
+
+  @AfterEach
+  void tearDown() {
+    Driver.resetCustomConnectionProvider();
+  }
+
+  @Test
+  void missingTargetClass_failsFast() {
+    final AwsWrapperXADataSource ds = new AwsWrapperXADataSource();
+    ds.setJdbcUrl("jdbc:aws-wrapper:postgresql://host/db");
+    final SQLException ex = assertThrows(SQLException.class, ds::getXAConnection);
+    assertTrue(ex.getMessage().contains("XADataSource"));
+  }
+
+  @Test
+  void targetNotXaDataSource_failsFast() {
+    final AwsWrapperXADataSource ds = new AwsWrapperXADataSource();
+    ds.setJdbcUrl("jdbc:aws-wrapper:postgresql://host/db");
+    ds.setTargetDataSourceClassName("java.lang.String");
+    final SQLException ex = assertThrows(SQLException.class, ds::getXAConnection);
+    assertTrue(ex.getMessage().contains("java.lang.String"));
+  }
+
+  @Test
+  void internalConnectionPool_failsFast() {
+    final AwsWrapperXADataSource ds = new AwsWrapperXADataSource();
+    ds.setJdbcUrl("jdbc:aws-wrapper:postgresql://host/db");
+    ds.setTargetDataSourceClassName(FakeXaDataSource.class.getName());
+    final Properties props = new Properties();
+    props.setProperty("connectionPoolType", "HIKARI");
+    ds.setTargetDataSourceProperties(props);
+
+    final SQLException ex = assertThrows(SQLException.class, ds::getXAConnection);
+    assertTrue(ex.getMessage().contains("internal connection pool"));
+  }
+
+  @Test
+  void customConnectionProvider_failsFast() {
+    Driver.setCustomConnectionProvider(org.mockito.Mockito.mock(ConnectionProvider.class));
+
+    final AwsWrapperXADataSource ds = new AwsWrapperXADataSource();
+    ds.setJdbcUrl("jdbc:aws-wrapper:postgresql://host/db");
+    ds.setTargetDataSourceClassName(FakeXaDataSource.class.getName());
+
+    final SQLException ex = assertThrows(SQLException.class, ds::getXAConnection);
+    assertTrue(ex.getMessage().contains("custom connection provider"));
+  }
+
+  @Test
+  void createTargetXADataSource_returnsInstance() throws SQLException {
+    final AwsWrapperXADataSource ds = new AwsWrapperXADataSource();
+    ds.setTargetDataSourceClassName(FakeXaDataSource.class.getName());
+    final XADataSource target = ds.createTargetXADataSource();
+    assertTrue(target instanceof FakeXaDataSource);
+  }
+
+  @Test
+  void configureTargetXaDataSource_appliesUrlAndCredentials() throws SQLException {
+    final AwsWrapperXADataSource ds = new AwsWrapperXADataSource();
+    ds.setJdbcUrl("jdbc:aws-wrapper:postgresql://host:5432/mydb");
+    ds.setTargetDataSourceClassName(FakeXaDataSource.class.getName());
+    ds.setUser("alice");
+    ds.setPassword("secret");
+
+    final FakeXaDataSource target = new FakeXaDataSource();
+    final ResolvedConfig config = ds.resolveConfig();
+    ds.configureTargetXaDataSource(target, config);
+
+    assertEquals("jdbc:postgresql://host:5432/mydb", target.getUrl());
+    assertEquals("alice", target.getUser());
+    assertEquals("secret", target.getPassword());
+  }
+
+  @Test
+  void configureTargetXaDataSource_stripsWrapperParamsFromTargetUrl() throws SQLException {
+    // Wrapper-specific query parameters must not leak into the URL handed to the target driver;
+    // target-driver parameters (ssl, ApplicationName, ...) must be preserved.
+    final AwsWrapperXADataSource ds = new AwsWrapperXADataSource();
+    ds.setJdbcUrl(
+        "jdbc:aws-wrapper:postgresql://host:5432/mydb?wrapperPlugins=iam&ssl=true&ApplicationName=myapp");
+    ds.setTargetDataSourceClassName(FakeXaDataSource.class.getName());
+
+    final FakeXaDataSource target = new FakeXaDataSource();
+    final ResolvedConfig config = ds.resolveConfig();
+    ds.configureTargetXaDataSource(target, config);
+
+    final String targetUrl = target.getUrl();
+    assertFalse(targetUrl.contains("wrapperPlugins"), "wrapper parameter leaked to target URL: " + targetUrl);
+    assertTrue(targetUrl.contains("ssl=true"), "target parameter was dropped: " + targetUrl);
+    assertTrue(targetUrl.contains("ApplicationName=myapp"), "target parameter was dropped: " + targetUrl);
+    assertTrue(targetUrl.startsWith("jdbc:postgresql://host:5432/mydb"), "unexpected base URL: " + targetUrl);
+  }
+
+  /** A minimal fake XADataSource exposing bean setters that PropertyUtils can invoke by name. */
+  public static class FakeXaDataSource implements XADataSource {
+    private String url;
+    private String user;
+    private String password;
+
+    public String getUrl() {
+      return url;
+    }
+
+    public void setUrl(final String url) {
+      this.url = url;
+    }
+
+    public String getUser() {
+      return user;
+    }
+
+    public void setUser(final String user) {
+      this.user = user;
+    }
+
+    public String getPassword() {
+      return password;
+    }
+
+    public void setPassword(final String password) {
+      this.password = password;
+    }
+
+    @Override
+    public XAConnection getXAConnection() {
+      return null;
+    }
+
+    @Override
+    public XAConnection getXAConnection(final String user, final String password) {
+      return null;
+    }
+
+    @Override
+    public PrintWriter getLogWriter() {
+      return null;
+    }
+
+    @Override
+    public void setLogWriter(final PrintWriter out) {
+    }
+
+    @Override
+    public void setLoginTimeout(final int seconds) {
+    }
+
+    @Override
+    public int getLoginTimeout() {
+      return 0;
+    }
+
+    @Override
+    public Logger getParentLogger() {
+      return null;
+    }
+  }
+}

--- a/wrapper/src/test/java/software/amazon/jdbc/ds/xa/XADataSourceConnectionProviderTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/ds/xa/XADataSourceConnectionProviderTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.jdbc.ds.xa;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Properties;
+import javax.sql.XAConnection;
+import javax.sql.XADataSource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import software.amazon.jdbc.ConnectionInfo;
+import software.amazon.jdbc.HostSpec;
+import software.amazon.jdbc.dialect.Dialect;
+import software.amazon.jdbc.targetdriverdialect.TargetDriverDialect;
+
+/** Unit tests for {@link XADataSourceConnectionProvider}. */
+public class XADataSourceConnectionProviderTest {
+
+  private AutoCloseable closeable;
+
+  @Mock private XADataSource xaDataSource;
+  @Mock private XAConnection xaConnection;
+  @Mock private Dialect dialect;
+  @Mock private TargetDriverDialect targetDriverDialect;
+  @Mock private HostSpec hostSpec;
+
+  private final Properties props = new Properties();
+
+  @BeforeEach
+  void setUp() throws SQLException {
+    closeable = MockitoAnnotations.openMocks(this);
+    when(xaDataSource.getXAConnection()).thenReturn(xaConnection);
+  }
+
+  @AfterEach
+  void tearDown() throws Exception {
+    closeable.close();
+  }
+
+  @Test
+  void connect_opensXaConnectionOnce_andReturnsFreshLogicalHandles() throws SQLException {
+    final Connection logical1 = mock(Connection.class);
+    final Connection logical2 = mock(Connection.class);
+    when(xaConnection.getConnection()).thenReturn(logical1, logical2);
+
+    final XADataSourceConnectionProvider provider = new XADataSourceConnectionProvider(xaDataSource);
+
+    final ConnectionInfo info1 = provider.connect("jdbc:postgresql://", dialect, targetDriverDialect, hostSpec, props);
+    final ConnectionInfo info2 = provider.connect("jdbc:postgresql://", dialect, targetDriverDialect, hostSpec, props);
+
+    // The physical XA connection is opened exactly once and reused.
+    verify(xaDataSource, times(1)).getXAConnection();
+    // A fresh logical handle is produced per connect.
+    verify(xaConnection, times(2)).getConnection();
+    assertSame(logical1, info1.getConnection());
+    assertSame(logical2, info2.getConnection());
+    assertNotSame(info1.getConnection(), info2.getConnection());
+    // Each ConnectionInfo carries the owning XAConnection.
+    assertSame(xaConnection, info1.getXaConnection());
+    assertSame(xaConnection, info2.getXaConnection());
+  }
+
+  @Test
+  void getXaConnectionOrNull_nullBeforeOpen_thenSet() throws SQLException {
+    when(xaConnection.getConnection()).thenReturn(mock(Connection.class));
+    final XADataSourceConnectionProvider provider = new XADataSourceConnectionProvider(xaDataSource);
+
+    org.junit.jupiter.api.Assertions.assertNull(provider.getXaConnectionOrNull());
+    provider.getOrOpenXaConnection();
+    assertSame(xaConnection, provider.getXaConnectionOrNull());
+  }
+
+  @Test
+  void connect_throwsWhenXaConnectionNull() throws SQLException {
+    when(xaDataSource.getXAConnection()).thenReturn(null);
+    final XADataSourceConnectionProvider provider = new XADataSourceConnectionProvider(xaDataSource);
+
+    assertThrows(SQLException.class,
+        () -> provider.connect("jdbc:postgresql://", dialect, targetDriverDialect, hostSpec, props));
+  }
+
+  @Test
+  void connect_appliesPerConnectCredentialsToTarget() throws SQLException {
+    // Simulates the IAM plugin having rewritten the password to a generated token on the per-connect
+    // properties: the provider must apply it to the target XADataSource before opening it.
+    final RecordingXaDataSource recording = new RecordingXaDataSource(xaConnection);
+    when(xaConnection.getConnection()).thenReturn(mock(Connection.class));
+    final XADataSourceConnectionProvider provider = new XADataSourceConnectionProvider(recording);
+
+    final Properties p = new Properties();
+    p.setProperty("user", "iam_user");
+    p.setProperty("password", "generated-iam-token");
+
+    provider.connect("jdbc:postgresql://", dialect, targetDriverDialect, hostSpec, p);
+
+    assertEquals("iam_user", recording.user);
+    assertEquals("generated-iam-token", recording.password);
+  }
+
+  /**
+   * A concrete {@link XADataSource} that records the user/password applied via its bean setters.
+   * Must be public so {@code PropertyUtils} (in another package) can invoke the setters reflectively,
+   * as it does for real target XADataSource classes.
+   */
+  public static class RecordingXaDataSource implements XADataSource {
+    private final XAConnection xaConnection;
+    String user;
+    String password;
+
+    RecordingXaDataSource(final XAConnection xaConnection) {
+      this.xaConnection = xaConnection;
+    }
+
+    public void setUser(final String user) {
+      this.user = user;
+    }
+
+    public void setPassword(final String password) {
+      this.password = password;
+    }
+
+    @Override
+    public XAConnection getXAConnection() {
+      return this.xaConnection;
+    }
+
+    @Override
+    public XAConnection getXAConnection(final String user, final String password) {
+      return this.xaConnection;
+    }
+
+    @Override
+    public java.io.PrintWriter getLogWriter() {
+      return null;
+    }
+
+    @Override
+    public void setLogWriter(final java.io.PrintWriter out) {
+      // no-op
+    }
+
+    @Override
+    public void setLoginTimeout(final int seconds) {
+      // no-op
+    }
+
+    @Override
+    public int getLoginTimeout() {
+      return 0;
+    }
+
+    @Override
+    public java.util.logging.Logger getParentLogger() {
+      return null;
+    }
+  }
+}

--- a/wrapper/src/test/java/software/amazon/jdbc/ds/xa/XADataSourceConnectionProviderTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/ds/xa/XADataSourceConnectionProviderTest.java
@@ -65,8 +65,12 @@ public class XADataSourceConnectionProviderTest {
   }
 
   @Test
-  void connect_opensXaConnectionOnce_andReturnsFreshLogicalHandles() throws SQLException {
+  void connect_isIdempotent_reusesLogicalConnectionWhileOpen() throws SQLException {
+    // Repeated connect() calls while establishing one handle (e.g. the IAM plugin retrying after
+    // regenerating its token) must reuse the same logical connection. Opening a fresh one each time
+    // would close the previous one out from under the caller.
     final Connection logical1 = mock(Connection.class);
+    when(logical1.isClosed()).thenReturn(false);
     final Connection logical2 = mock(Connection.class);
     when(xaConnection.getConnection()).thenReturn(logical1, logical2);
 
@@ -75,16 +79,32 @@ public class XADataSourceConnectionProviderTest {
     final ConnectionInfo info1 = provider.connect("jdbc:postgresql://", dialect, targetDriverDialect, hostSpec, props);
     final ConnectionInfo info2 = provider.connect("jdbc:postgresql://", dialect, targetDriverDialect, hostSpec, props);
 
-    // The physical XA connection is opened exactly once and reused.
+    // The physical XA connection is opened once, and the logical connection is created once and reused.
     verify(xaDataSource, times(1)).getXAConnection();
-    // A fresh logical handle is produced per connect.
-    verify(xaConnection, times(2)).getConnection();
+    verify(xaConnection, times(1)).getConnection();
     assertSame(logical1, info1.getConnection());
-    assertSame(logical2, info2.getConnection());
-    assertNotSame(info1.getConnection(), info2.getConnection());
-    // Each ConnectionInfo carries the owning XAConnection.
+    assertSame(logical1, info2.getConnection());
     assertSame(xaConnection, info1.getXaConnection());
-    assertSame(xaConnection, info2.getXaConnection());
+  }
+
+  @Test
+  void connect_createsFreshLogicalConnection_afterPreviousClosed() throws SQLException {
+    // Once the current logical connection is closed (the owning handle was closed), the next connect
+    // creates a fresh logical connection over the same physical XA connection.
+    final Connection logical1 = mock(Connection.class);
+    when(logical1.isClosed()).thenReturn(true); // simulate the previous handle having been closed
+    final Connection logical2 = mock(Connection.class);
+    when(logical2.isClosed()).thenReturn(false);
+    when(xaConnection.getConnection()).thenReturn(logical1, logical2);
+
+    final XADataSourceConnectionProvider provider = new XADataSourceConnectionProvider(xaDataSource);
+
+    final ConnectionInfo info1 = provider.connect("jdbc:postgresql://", dialect, targetDriverDialect, hostSpec, props);
+    final ConnectionInfo info2 = provider.connect("jdbc:postgresql://", dialect, targetDriverDialect, hostSpec, props);
+
+    verify(xaDataSource, times(1)).getXAConnection();
+    verify(xaConnection, times(2)).getConnection();
+    assertNotSame(info1.getConnection(), info2.getConnection());
   }
 
   @Test

--- a/wrapper/src/test/java/software/amazon/jdbc/ds/xa/XAResourceWrapperTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/ds/xa/XAResourceWrapperTest.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.jdbc.ds.xa;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import javax.transaction.xa.XAException;
+import javax.transaction.xa.XAResource;
+import javax.transaction.xa.Xid;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/** Unit tests for {@link XAResourceWrapper}: delegation and XA-active flag lifecycle. */
+public class XAResourceWrapperTest {
+
+  private AutoCloseable closeable;
+
+  @Mock private XAResource target;
+  @Mock private Xid xid;
+
+  private final AtomicBoolean xaActive = new AtomicBoolean(false);
+  private XAResourceWrapper wrapper;
+
+  @BeforeEach
+  void setUp() {
+    closeable = MockitoAnnotations.openMocks(this);
+    xaActive.set(false);
+    wrapper = new XAResourceWrapper(target, xaActive::set);
+  }
+
+  @AfterEach
+  void tearDown() throws Exception {
+    closeable.close();
+  }
+
+  @Test
+  void start_setsXaActive_andDelegates() throws XAException {
+    wrapper.start(xid, XAResource.TMNOFLAGS);
+    verify(target).start(xid, XAResource.TMNOFLAGS);
+    assertTrue(xaActive.get());
+  }
+
+  @Test
+  void prepare_doesNotClearFlag() throws XAException {
+    wrapper.start(xid, XAResource.TMNOFLAGS);
+    when(target.prepare(xid)).thenReturn(XAResource.XA_OK);
+
+    final int rc = wrapper.prepare(xid);
+
+    assertEquals(XAResource.XA_OK, rc);
+    verify(target).prepare(xid);
+    // The branch is still live between prepare and commit/rollback.
+    assertTrue(xaActive.get());
+  }
+
+  @Test
+  void end_doesNotClearFlag() throws XAException {
+    wrapper.start(xid, XAResource.TMNOFLAGS);
+    wrapper.end(xid, XAResource.TMSUCCESS);
+    verify(target).end(xid, XAResource.TMSUCCESS);
+    assertTrue(xaActive.get());
+  }
+
+  @Test
+  void commit_clearsFlag_andDelegates() throws XAException {
+    wrapper.start(xid, XAResource.TMNOFLAGS);
+    wrapper.commit(xid, false);
+    verify(target).commit(xid, false);
+    assertFalse(xaActive.get());
+  }
+
+  @Test
+  void onePhaseCommit_clearsFlag() throws XAException {
+    wrapper.start(xid, XAResource.TMNOFLAGS);
+    wrapper.commit(xid, true);
+    verify(target).commit(xid, true);
+    assertFalse(xaActive.get());
+  }
+
+  @Test
+  void rollback_clearsFlag_andDelegates() throws XAException {
+    wrapper.start(xid, XAResource.TMNOFLAGS);
+    wrapper.rollback(xid);
+    verify(target).rollback(xid);
+    assertFalse(xaActive.get());
+  }
+
+  @Test
+  void commit_clearsFlagEvenWhenTargetThrows() throws XAException {
+    wrapper.start(xid, XAResource.TMNOFLAGS);
+    final XAException failure = new XAException(XAException.XAER_RMFAIL);
+    org.mockito.Mockito.doThrow(failure).when(target).commit(xid, false);
+
+    try {
+      wrapper.commit(xid, false);
+    } catch (final XAException expected) {
+      // expected
+    }
+    assertFalse(xaActive.get());
+  }
+
+  @Test
+  void recover_delegatesUnchanged() throws XAException {
+    final Xid[] recovered = new Xid[] {xid};
+    when(target.recover(XAResource.TMSTARTRSCAN)).thenReturn(recovered);
+
+    final Xid[] result = wrapper.recover(XAResource.TMSTARTRSCAN);
+
+    assertEquals(recovered, result);
+    verify(target).recover(XAResource.TMSTARTRSCAN);
+    // recover must never toggle the flag.
+    assertFalse(xaActive.get());
+  }
+
+  @Test
+  void forget_delegates() throws XAException {
+    wrapper.forget(xid);
+    verify(target).forget(xid);
+  }
+
+  @Test
+  void transactionTimeout_delegates() throws XAException {
+    when(target.getTransactionTimeout()).thenReturn(42);
+    when(target.setTransactionTimeout(42)).thenReturn(true);
+
+    assertTrue(wrapper.setTransactionTimeout(42));
+    assertEquals(42, wrapper.getTransactionTimeout());
+    verify(target).setTransactionTimeout(42);
+    verify(target).getTransactionTimeout();
+  }
+
+  @Test
+  void isSameRM_alwaysFalse_forWrappedResource() throws XAException {
+    final XAResource otherTarget = org.mockito.Mockito.mock(XAResource.class);
+    final XAResourceWrapper other = new XAResourceWrapper(otherTarget, b -> { });
+
+    // Each wrapped connection is reported as a distinct resource manager so the transaction manager
+    // performs a full two-phase commit across separate branches (never a JOIN onto one connection).
+    assertFalse(wrapper.isSameRM(other));
+    verify(target, never()).isSameRM(org.mockito.ArgumentMatchers.any());
+  }
+
+  @Test
+  void isSameRM_alwaysFalse_forPlainResource() throws XAException {
+    final XAResource plain = org.mockito.Mockito.mock(XAResource.class);
+
+    assertFalse(wrapper.isSameRM(plain));
+    verify(target, never()).isSameRM(org.mockito.ArgumentMatchers.any());
+  }
+}

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/failover/FailoverConnectionPluginTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/failover/FailoverConnectionPluginTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
@@ -217,6 +218,31 @@ class FailoverConnectionPluginTest {
   @Test
   void test_failover_failoverWriter() throws SQLException {
     when(mockPluginService.isInTransaction()).thenReturn(true);
+
+    initializePlugin();
+    doThrow(FailoverSuccessSQLException.class).when(spyPlugin).failoverWriter(false);
+    spyPlugin.failoverMode = FailoverMode.STRICT_WRITER;
+
+    assertThrows(FailoverSuccessSQLException.class, () -> spyPlugin.failover(mockHostSpec, false));
+    verify(spyPlugin).failoverWriter(false);
+  }
+
+  @Test
+  void test_failover_failsFastDuringXaTransaction() throws SQLException {
+    when(mockPluginService.isXaTransactionActive()).thenReturn(true);
+
+    initializePlugin();
+    spyPlugin.failoverMode = FailoverMode.STRICT_WRITER;
+
+    assertThrows(XaFailoverNotSupportedSQLException.class, () -> spyPlugin.failover(mockHostSpec, false));
+    // Failover must not attempt to swap the connection while an XA branch is active.
+    verify(spyPlugin, never()).failoverWriter(anyBoolean());
+    verify(spyPlugin, never()).failoverReader(any());
+  }
+
+  @Test
+  void test_failover_notXaActive_proceedsNormally() throws SQLException {
+    when(mockPluginService.isXaTransactionActive()).thenReturn(false);
 
     initializePlugin();
     doThrow(FailoverSuccessSQLException.class).when(spyPlugin).failoverWriter(false);

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/readwritesplitting/gate/TransactionAwareGateTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/readwritesplitting/gate/TransactionAwareGateTest.java
@@ -102,6 +102,27 @@ public class TransactionAwareGateTest {
   }
 
   @Test
+  void xaTransactionActive_pins() throws SQLException {
+    // Even when there is no local (SQL-heuristic) transaction, an active XA branch must pin the
+    // connection so read/write splitting does not route work off the XA session.
+    when(pluginService.isInTransaction()).thenReturn(false);
+    when(pluginService.isXaTransactionActive()).thenReturn(true);
+
+    final TransactionAwareGate gate = new TransactionAwareGate();
+    assertFalse(gate.canSwitch(ctx, TargetRole.READER));
+    assertFalse(gate.canSwitch(ctx, TargetRole.WRITER));
+  }
+
+  @Test
+  void xaTransactionInactive_allowsSwitch() throws SQLException {
+    when(pluginService.isInTransaction()).thenReturn(false);
+    when(pluginService.isXaTransactionActive()).thenReturn(false);
+
+    final TransactionAwareGate gate = new TransactionAwareGate();
+    assertTrue(gate.canSwitch(ctx, TargetRole.READER));
+  }
+
+  @Test
   void autoCommitOff_pinsWhenConfigured() throws SQLException {
     when(pluginService.isInTransaction()).thenReturn(false);
     when(pluginService.getCallContext()).thenReturn(callContext);

--- a/wrapper/src/test/java/software/amazon/jdbc/util/SqlMethodAnalyzerTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/util/SqlMethodAnalyzerTest.java
@@ -196,6 +196,12 @@ class SqlMethodAnalyzerTest {
         Arguments.of("Statement.execute", "commit;", true),
         Arguments.of("Statement.executeUpdate", "end", true),
         Arguments.of("Statement.executeUpdate", "abort;", true),
+        // Two-phase commit control statements.
+        Arguments.of("Statement.execute", "PREPARE TRANSACTION 'gid-1'", true),
+        Arguments.of("Statement.execute", "COMMIT PREPARED 'gid-1'", true),
+        Arguments.of("Statement.execute", "ROLLBACK PREPARED 'gid-1'", true),
+        // "PREPARE <name> AS ..." is a prepared statement, not transaction control.
+        Arguments.of("Statement.execute", "PREPARE myplan AS SELECT 1", false),
         Arguments.of("Statement.execute", "select 1", false),
         Arguments.of("Statement.close", null, false),
         Arguments.of("Statement.isClosed", null, false),


### PR DESCRIPTION
## Summary

Adds XA / distributed-transaction support to the AWS Advanced JDBC Wrapper via a new
`software.amazon.jdbc.ds.AwsWrapperXADataSource` (`javax.sql.XADataSource`). It wraps a target
driver-specific `XADataSource` (PostgreSQL, MySQL, MariaDB) so the wrapper's plugin pipeline applies
to the application-facing `Connection`, while the XA control surface (`XAConnection` / `XAResource`)
is delegated to the target driver and coordinated by a JTA transaction manager (WildFly/Narayana,
Atomikos, Bitronix).

## What's included

**XA datasource and wrappers**
- `AwsWrapperXADataSource` - same configuration surface as `AwsWrapperDataSource`; requires a target
  `XADataSource` class and fails fast otherwise.
- `ds/xa/`: `XADataSourceConnectionProvider`, `XAConnectionWrapper`, `XAResourceWrapper`,
  `XaTransactionStateCallback`. Each `getConnection()` builds a fresh `ConnectionWrapper`/pipeline over
  the same pinned physical XA connection.
- Shared `DataSourceConfigHelper` extracted from `AwsWrapperDataSource` (no behavior change on the
  non-XA path).

**Connection pinning for XA correctness**
- `PluginService.isXaTransactionActive()` flag, set around the XA branch by `XAResourceWrapper`.
- Read/write splitting is skipped while a branch is active (`TransactionAwareGate`); failover fails
  fast with `XaFailoverNotSupportedSQLException` (SQLSTATE `08007`) in failover v1/v2/gdb.
- `PluginServiceImpl.setCurrentConnection` backstop rejects a connection swap during an active branch
  (SQLSTATE `25001`).
- Internal connection pool / custom connection provider are rejected on the XA path (they can't
  expose an `XAResource`).

**Auth and configuration**
- IAM authentication works on the XA path: `XADataSourceConnectionProvider.connect()` applies the
  per-connect credentials (the IAM token) to the target `XADataSource` before opening the session.
- Wrapper parameters are stripped from the URL handed to the target driver
  (`DataSourceConfigHelper.removeWrapperPropertiesFromUrl`), so `wrapperPlugins`, `wrapperDialect`,
  etc. never leak to the target (which some drivers reject as unknown parameters). Configuration is
  via the `jdbcUrl` query string and/or `targetDataSourceProperties`.
- `XAResourceWrapper.isSameRM` returns `false` so the transaction manager performs a full 2PC across
  separate branches (avoids MySQL Connector/J rejecting `XA START ... JOIN`).
- All user-facing strings are externalized to the message bundle.

## Testing

- **Unit tests** (all passing, full suite green): `AwsWrapperXADataSourceTest`,
  `XADataSourceConnectionProviderTest`, `XAResourceWrapperTest`, plus backstop/fail-fast/analyzer
  cases in `PluginServiceImplTests`, `FailoverConnectionPluginTest`, `TransactionAwareGateTest`,
  `SqlMethodAnalyzerTest`.
- **Integration tests, run against real databases via `test-all-docker` (PostgreSQL + MySQL) - 21
  passed / 0 failed** across the PG, MySQL, and MariaDB drivers:
  - `XaTransactionTest`: direct `XAResource` lifecycle (commit, rollback, one-phase commit, recovery).
  - `XaTwoPhaseCommitTest`: TM-coordinated two-resource 2PC under **both** Narayana and Atomikos.
- **Integration tests authored for a real Aurora/RDS environment** (not runnable on the docker suite):
  - `XaFailoverTest`: failover mid-branch fails fast; the unprepared branch is rolled back; a new
    transaction commits on the promoted writer.
  - `XaIamAuthenticationTest`: IAM-authenticated XA connection and branch lifecycle.

## Documentation

- New `docs/using-the-jdbc-driver/UsingXADataSource.md` (configuration, per-driver target classes,
  WildFly + IAM examples, benefits/limitations, the recommended two-datasource pattern), linked from
  `docs/Documentation.md` and `docs/using-the-jdbc-driver/DataSource.md`.
- XA coverage added to the configuration assistant skill (`docs/JDBC-WRAPPER-CONFIGURATION-ASSISTANT.md`).
