### PR TITLE
fix: wrap Hikari pool init failure as SQLException during failover

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/HikariPooledConnectionProvider.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/HikariPooledConnectionProvider.java
@@ -19,6 +19,7 @@ package software.amazon.jdbc;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import com.zaxxer.hikari.HikariPoolMXBean;
+import com.zaxxer.hikari.pool.HikariPool;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.sql.Connection;
@@ -319,11 +320,23 @@ public class HikariPooledConnectionProvider implements PooledConnectionProvider,
     final HostSpec finalHostSpec = connectionHostSpec;
     dialect.prepareConnectProperties(copy, protocol, finalHostSpec);
 
-    final HikariDataSource ds = (HikariDataSource) HikariPoolsHolder.databasePools.computeIfAbsent(
-        Pair.create(hostSpec.getUrl(), getPoolKey(finalHostSpec, copy)),
-        (lambdaPoolKey) -> createHikariDataSource(protocol, finalHostSpec, copy, targetDriverDialect),
-        poolExpirationCheckNanos
-    );
+    final HikariDataSource ds;
+    try {
+      ds = (HikariDataSource) HikariPoolsHolder.databasePools.computeIfAbsent(
+          Pair.create(hostSpec.getUrl(), getPoolKey(finalHostSpec, copy)),
+          (lambdaPoolKey) -> createHikariDataSource(protocol, finalHostSpec, copy, targetDriverDialect),
+          poolExpirationCheckNanos
+      );
+    } catch (final HikariPool.PoolInitializationException e) {
+      // Hikari's fail-fast pool initialization throws a RuntimeException when the initial
+      // connection attempt fails. Wrap it as a SQLException so that callers relying on the
+      // declared 'throws SQLException' contract (e.g. the failover retry loop in RetryUtil)
+      // treat it as a recoverable connection failure instead of aborting.
+      throw new SQLException(
+          Messages.get("HikariPooledConnectionProvider.poolInitializationError",
+              new Object[] {finalHostSpec.getHostAndPort(), e.getMessage()}),
+          e);
+    }
 
     ds.setPassword(copy.getProperty(PropertyDefinition.PASSWORD.name));
 

--- a/wrapper/src/main/resources/aws_advanced_jdbc_wrapper_messages.properties
+++ b/wrapper/src/main/resources/aws_advanced_jdbc_wrapper_messages.properties
@@ -278,6 +278,8 @@ GlobalAuroraTopologyMonitor.initialHostNotInAccessibleRegion=Initial host ''{0}'
 GlobalAuroraTopologyUtils.globalClusterInstanceHostPatternsRequired=Parameter 'globalClusterInstanceHostPatterns' is required for Aurora Global Database.
 GlobalAuroraTopologyUtils.detectedGdbPatterns=Detected GDB instance template patterns:\n{0}
 
+HikariPooledConnectionProvider.poolInitializationError=Failed to initialize the internal connection pool for host ''{0}'': {1}
+
 HostAvailabilityStrategy.invalidMaxRetries=Invalid value of {0} for configuration parameter `hostAvailabilityStrategyMaxRetries`. It must be an integer greater than 1.
 HostAvailabilityStrategy.invalidInitialBackoffTime=Invalid value of {0}  for configuration parameter `hostAvailabilityStrategyInitialBackoffTime`. It must be an integer greater than 1.
 


### PR DESCRIPTION
## Summary

`HikariPooledConnectionProvider.connect(...)` is declared `throws SQLException`, so callers assume connection failures arrive as a `SQLException`. However, Hikari's fail-fast pool initialization (`new HikariDataSource(config)`) throws `com.zaxxer.hikari.pool.HikariPool.PoolInitializationException`, which extends `RuntimeException`, when the initial connection attempt fails.

During an in-transaction failover, this `RuntimeException` escaped `RetryUtil.getAllowedConnection`, whose retry loop only catches `SQLException`. As a result the exception bypassed the "remove host / retry other hosts until timeout" logic, aborted the failover, and surfaced the raw `HikariPool.PoolInitializationException` instead of the expected `TransactionStateUnknownSQLException`.

## Change

- Catch `HikariPool.PoolInitializationException` in `HikariPooledConnectionProvider.connect` and rethrow it as a `SQLException` (original exception preserved as the cause), honoring the method's declared `throws SQLException` contract.
- Add the `HikariPooledConnectionProvider.poolInitializationError` message to the resource bundle.

With this change, a pool-init failure during failover is treated as a recoverable connection failure: the failover retry loop catches it, refreshes topology, and retries until a reachable writer appears, after which the in-transaction case correctly ends in `TransactionStateUnknownSQLException`.

## Root cause context

Observed as an intermittent failure of `AutoSimpleReadWriteSplittingTests > test_pooledConnection_failoverInTransaction` (pg-aurora integration job):

```
org.opentest4j.AssertionFailedError: Unexpected exception type thrown,
  expected: <...TransactionStateUnknownSQLException>
  but was:  <com.zaxxer.hikari.pool.HikariPool.PoolInitializationException>
Caused by: HikariPool$PoolInitializationException: Failed to initialize pool: The connection attempt failed.
```

It presents intermittently because it only manifests when the writer candidate is still unreachable at connect time (Hikari's `initializationFailTimeout` fires before topology settles); the underlying contract violation is deterministic.

## Testing

- `:aws-advanced-jdbc-wrapper:compileJava` passes.
- The affected integration test requires an Aurora PG cluster with the proxy/network-outage harness and is validated by re-running the pg-aurora workflow.
