### PR TITLE
chore: checker framework adoption and enforce it in CI (parts 16-19)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,6 +96,49 @@ jobs:
       - name: 'Run checkstyle and spotbugs'
         run: ./gradlew --build-cache checkstyleMain checkstyleTest spotbugsMain spotbugsTest
 
+  # Nullness analysis in enforcing mode: any new Checker Framework finding fails the build.
+  # This lives in main.yml (rather than only in run-checker-framework.yml) so it is covered by
+  # the ci-gate aggregation below, which is the single required status check for branch
+  # protection. A job in a separate workflow file cannot be a `needs:` of ci-gate and would
+  # therefore run without blocking a merge.
+  #
+  # JDK 8 is the project's toolchain, but the checker needs JDK 11+, so the guarded block in
+  # wrapper/build.gradle.kts retargets compileJava onto JDK 17. Both JDKs are installed and
+  # Gradle's toolchain detection picks them up. No --build-cache here: this compile targets
+  # release 11 rather than the shipped Java 8, so it must not share cache entries with the
+  # normal compileJava.
+  checker-framework:
+    name: 'Nullness (Checker Framework)'
+    needs: check-changes
+    if: ${{ needs.check-changes.outputs.only_docs == 'false' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Clone repository'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          fetch-depth: 50
+      - name: 'Set up JDK 8 and 17'
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95  # v5
+        with:
+          distribution: 'corretto'
+          java-version: |
+            8
+            17
+      - name: 'Cache Gradle packages'
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+      - name: 'Run NullnessChecker (enforcing)'
+        run: |
+          ./gradlew --no-daemon --console=plain \
+            :aws-advanced-jdbc-wrapper:compileJava \
+            -PenableCheckerFramework
+
   test:
     name: 'Unit tests and coverage'
     needs: check-changes
@@ -132,7 +175,7 @@ jobs:
 
   ci-gate:
     name: 'CI Gate'
-    needs: [check-changes, markdown-link-check, lint, test]
+    needs: [check-changes, markdown-link-check, lint, checker-framework, test]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/run-checker-framework.yml
+++ b/.github/workflows/run-checker-framework.yml
@@ -8,23 +8,19 @@ name: Run Checker Framework (Nullness)
 # both JDK 8 (the project's primary toolchain) and JDK 17 (for the checker) available and
 # let Gradle's toolchain detection pick them up.
 #
-# The incremental adoption is complete: the whole software.amazon.jdbc tree is clean and
-# the checker now runs in ENFORCING mode, so any new nullness finding fails this job.
-# It runs on pull requests to keep the tree clean - feature work previously reintroduced
-# findings precisely because this was manual-only and warn-only.
+# The incremental adoption is complete: the whole software.amazon.jdbc tree is clean and the
+# checker runs in ENFORCING mode, so any new nullness finding fails the build.
+#
+# PR enforcement lives in the 'checker-framework' job in main.yml, because only that workflow
+# feeds the ci-gate aggregation that branch protection requires. This workflow is the
+# on-demand variant: same check, plus a categorized findings summary and an archived report,
+# which is what you want when investigating or measuring rather than gating.
 #
 # If a finding is a false positive, annotate the code or add a narrowly-scoped
 # @SuppressWarnings with a justifying comment; do not re-add -Awarns.
 
 on:
   workflow_dispatch:
-  pull_request:
-    paths:
-      - 'wrapper/src/main/**'
-      - 'wrapper/build.gradle.kts'
-      - 'build.gradle.kts'
-      - 'gradle/**'
-      - '.github/workflows/run-checker-framework.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/run-checker-framework.yml
+++ b/.github/workflows/run-checker-framework.yml
@@ -25,7 +25,6 @@ on:
       - 'build.gradle.kts'
       - 'gradle/**'
       - '.github/workflows/run-checker-framework.yml'
-      - 'scripts/run-checker-framework.sh'
 
 permissions:
   contents: read

--- a/.github/workflows/run-checker-framework.yml
+++ b/.github/workflows/run-checker-framework.yml
@@ -1,6 +1,6 @@
 name: Run Checker Framework (Nullness)
 
-# On-demand static nullness analysis of the wrapper's core path.
+# Static nullness analysis of the wrapper's main source set.
 #
 # The main source set targets Java 8, but the Checker Framework needs JDK 11+ to run,
 # so the guarded build block in wrapper/build.gradle.kts (activated by
@@ -8,19 +8,31 @@ name: Run Checker Framework (Nullness)
 # both JDK 8 (the project's primary toolchain) and JDK 17 (for the checker) available and
 # let Gradle's toolchain detection pick them up.
 #
-# This is part of the incremental Checker Framework adoption (see
-# docs/checker-framework-pilot/README.md). It runs in WARNING mode and does not gate CI;
-# it is meant to be triggered manually to measure nullness findings.
+# The incremental adoption is complete: the whole software.amazon.jdbc tree is clean and
+# the checker now runs in ENFORCING mode, so any new nullness finding fails this job.
+# It runs on pull requests to keep the tree clean - feature work previously reintroduced
+# findings precisely because this was manual-only and warn-only.
+#
+# If a finding is a false positive, annotate the code or add a narrowly-scoped
+# @SuppressWarnings with a justifying comment; do not re-add -Awarns.
 
 on:
   workflow_dispatch:
+  pull_request:
+    paths:
+      - 'wrapper/src/main/**'
+      - 'wrapper/build.gradle.kts'
+      - 'build.gradle.kts'
+      - 'gradle/**'
+      - '.github/workflows/run-checker-framework.yml'
+      - 'scripts/run-checker-framework.sh'
 
 permissions:
   contents: read
 
 jobs:
   checker-framework:
-    name: 'NullnessChecker (scoped, warn-only)'
+    name: 'NullnessChecker (enforcing)'
     runs-on: ubuntu-latest
     steps:
       - name: 'Clone repository'
@@ -58,7 +70,10 @@ jobs:
         if: ${{ !cancelled() }}
         run: |
           report=checker-framework-report.txt
-          total=$(grep -cE 'warning: \[' "$report" || true)
+          # Enforcing mode reports findings as "error: [...]"; "warning: [...]" is still
+          # matched so the summary keeps working if the build is switched to warn-only.
+          finding_re='(error|warning): \['
+          total=$(grep -cE "$finding_re" "$report" || true)
           style=$(grep -cE 'type\.anno\.before\.modifier' "$report" || true)
           crashes=$(grep -cE 'The Checker Framework crashed' "$report" || true)
           real=$((total - style))
@@ -67,15 +82,20 @@ jobs:
             echo ""
             echo "| Metric | Count |"
             echo "|---|---:|"
-            echo "| Total warnings | ${total} |"
+            echo "| Total findings | ${total} |"
             echo "| Style-only (type.anno.before.modifier) | ${style} |"
             echo "| Real (non-style) findings | ${real} |"
             echo "| Checker crashes | ${crashes} |"
             echo ""
+            if [ "${total}" -gt 0 ]; then
+              echo "This job runs in **enforcing** mode, so these findings failed the build."
+              echo "Fix them, or add a narrowly-scoped \`@SuppressWarnings\` with a justifying comment."
+              echo ""
+            fi
             echo "<details><summary>Real findings by category</summary>"
             echo ""
             echo '```'
-            grep -oE 'warning: \[[a-zA-Z.]+\]' "$report" \
+            grep -oE "(error|warning): \[[a-zA-Z.]+\]" "$report" \
               | grep -v 'type.anno.before.modifier' \
               | sort | uniq -c | sort -rn || true
             echo '```'

--- a/wrapper/build.gradle.kts
+++ b/wrapper/build.gradle.kts
@@ -339,10 +339,10 @@ if (project.hasProperty("enableCheckerFramework")) {
         // (part 14) the top-level classes of the plugin package, and
         // (part 15) the plugin sub-package families cache, bluegreen, failover, gdbfailover,
         // efm, federatedauth, iam, limitless, customendpoint, strategy, dev, staledns and
-        // sqlparser, and
-        // (part 17) the top-level parser package and the plugin.failover2 family
-        // (the encryption and readwritesplitting families remain out of scope for
-        // follow-on parts).
+        // sqlparser,
+        // (part 17) the top-level parser package and the plugin.failover2 family, and
+        // (part 18) the plugin.readwritesplitting family and its sub-packages
+        // (the encryption family remains out of scope for a follow-on part).
         // No end-anchor: matching an outer class also covers its nested classes (and, for
         // "pkg\.\w+", the classes of nested sub-packages such as util.telemetry.*). The
         // "plugin\.[A-Z]\w*" entry matches only classes directly in the plugin package
@@ -365,6 +365,7 @@ if (project.hasProperty("enableCheckerFramework")) {
                 + "|plugin\\.dev\\.\\w+|plugin\\.staledns\\.\\w+"
                 + "|plugin\\.sqlparser\\.\\w+"
                 + "|parser\\.\\w+|plugin\\.failover2\\.\\w+"
+                + "|plugin\\.readwritesplitting\\.\\w+"
                 + "|[A-Z]\\w*)",
             // Warning mode: report issues but do not fail the build.
             "-Awarns",

--- a/wrapper/build.gradle.kts
+++ b/wrapper/build.gradle.kts
@@ -341,8 +341,9 @@ if (project.hasProperty("enableCheckerFramework")) {
         // efm, federatedauth, iam, limitless, customendpoint, strategy, dev, staledns and
         // sqlparser,
         // (part 17) the top-level parser package and the plugin.failover2 family, and
-        // (part 18) the plugin.readwritesplitting family and its sub-packages
-        // (the encryption family remains out of scope for a follow-on part).
+        // (part 18) the plugin.readwritesplitting family and its sub-packages, and
+        // (part 19) the plugin.encryption family and its sub-packages. The whole
+        // software.amazon.jdbc source tree is now in scope.
         // No end-anchor: matching an outer class also covers its nested classes (and, for
         // "pkg\.\w+", the classes of nested sub-packages such as util.telemetry.*). The
         // "plugin\.[A-Z]\w*" entry matches only classes directly in the plugin package
@@ -365,7 +366,7 @@ if (project.hasProperty("enableCheckerFramework")) {
                 + "|plugin\\.dev\\.\\w+|plugin\\.staledns\\.\\w+"
                 + "|plugin\\.sqlparser\\.\\w+"
                 + "|parser\\.\\w+|plugin\\.failover2\\.\\w+"
-                + "|plugin\\.readwritesplitting\\.\\w+"
+                + "|plugin\\.readwritesplitting\\.\\w+|plugin\\.encryption\\.\\w+"
                 + "|[A-Z]\\w*)",
             // Warning mode: report issues but do not fail the build.
             "-Awarns",

--- a/wrapper/build.gradle.kts
+++ b/wrapper/build.gradle.kts
@@ -339,8 +339,10 @@ if (project.hasProperty("enableCheckerFramework")) {
         // (part 14) the top-level classes of the plugin package, and
         // (part 15) the plugin sub-package families cache, bluegreen, failover, gdbfailover,
         // efm, federatedauth, iam, limitless, customendpoint, strategy, dev, staledns and
-        // sqlparser (the encryption, readwritesplitting, srw and failover2 families remain
-        // out of scope for follow-on parts).
+        // sqlparser, and
+        // (part 17) the top-level parser package and the plugin.failover2 family
+        // (the encryption and readwritesplitting families remain out of scope for
+        // follow-on parts).
         // No end-anchor: matching an outer class also covers its nested classes (and, for
         // "pkg\.\w+", the classes of nested sub-packages such as util.telemetry.*). The
         // "plugin\.[A-Z]\w*" entry matches only classes directly in the plugin package
@@ -362,6 +364,7 @@ if (project.hasProperty("enableCheckerFramework")) {
                 + "|plugin\\.customendpoint\\.\\w+|plugin\\.strategy\\.\\w+"
                 + "|plugin\\.dev\\.\\w+|plugin\\.staledns\\.\\w+"
                 + "|plugin\\.sqlparser\\.\\w+"
+                + "|parser\\.\\w+|plugin\\.failover2\\.\\w+"
                 + "|[A-Z]\\w*)",
             // Warning mode: report issues but do not fail the build.
             "-Awarns",

--- a/wrapper/build.gradle.kts
+++ b/wrapper/build.gradle.kts
@@ -304,19 +304,24 @@ spotbugs {
 }
 
 // ---------------------------------------------------------------------------
-// Checker Framework pilot (NullnessChecker only, warning mode, scoped).
+// Checker Framework (NullnessChecker, enforcing, whole source tree).
 //
-// Disabled by default so normal Java 8 builds are unaffected. Enable with:
+// Opt-in via a property, and NOT because the findings are optional - the whole
+// software.amazon.jdbc tree is checker-clean and the CI job below enforces that.
+// The property exists because this block retargets compileJava:
+//   - the checker itself cannot run on JDK 8, so compileJava is forced onto a
+//     JDK 17 toolchain with release 11, whereas the shipped artifact must stay
+//     Java 8. Enabling this unconditionally would silently change the bytecode
+//     target of the published jar.
+// So this is a verification build, not a packaging build. Run it with:
 //   ./gradlew :aws-advanced-jdbc-wrapper:compileJava -PenableCheckerFramework
+// On a JDK 8 host, run it inside a JDK 17 container (scripts/run-checker-framework.sh).
 //
-// Requirements:
-//   - Must run on JDK 11+ (the checker itself cannot run on JDK 8). On a
-//     JDK 8 host, run this inside a JDK 17 container (see scripts/run-checker-framework.sh).
-//
-// Scope/behaviour for the pilot:
+// Behaviour:
 //   - Only the NullnessChecker is enabled (Optional/Regex add noise for little gain here).
-//   - Warnings only: the build does NOT fail, so we can measure the real signal.
-//   - Limited to the core connection/plugin path via -AonlyDefs.
+//   - Enforcing: findings are compile errors and fail the build. Do not add -Awarns
+//     back; if a finding is a false positive, annotate it or add a narrowly-scoped
+//     @SuppressWarnings with a justifying comment (see the existing conventions).
 // ---------------------------------------------------------------------------
 if (project.hasProperty("enableCheckerFramework")) {
     apply(plugin = "org.checkerframework")
@@ -325,25 +330,22 @@ if (project.hasProperty("enableCheckerFramework")) {
         checkers = listOf(
             "org.checkerframework.checker.nullness.NullnessChecker"
         )
-        // Scope: core connection/plugin path (parts 1-2), the self-contained util classes
-        // (part 3), the util classes that depend on central-type nullness contracts
-        // (part 4: RetryUtil, ConnectionUrlParser, HostIdCacheServiceImpl - enabled together
-        // with the HostSpec / HostRole / PluginService / HostSpecBuilder / Dialect alignment),
-        // WrapperUtils (part 5: the generic plugin-execution / proxy-wrapping helpers),
-        // (part 6) all of the per-object JDBC wrapper classes plus LazyCleanerImpl, and
-        // (parts 8-10) the whole util package plus the exceptions, cleanup, authentication,
-        // hostavailability, osgi, profile, states and ds packages,
-        // (part 11) the targetdriverdialect and dialect packages,
-        // (part 12) the hostlistprovider package,
-        // (part 13) the remaining top-level software.amazon.jdbc classes, and
-        // (part 14) the top-level classes of the plugin package, and
-        // (part 15) the plugin sub-package families cache, bluegreen, failover, gdbfailover,
-        // efm, federatedauth, iam, limitless, customendpoint, strategy, dev, staledns and
-        // sqlparser,
-        // (part 17) the top-level parser package and the plugin.failover2 family, and
-        // (part 18) the plugin.readwritesplitting family and its sub-packages, and
-        // (part 19) the plugin.encryption family and its sub-packages. The whole
-        // software.amazon.jdbc source tree is now in scope.
+        // Scope: every named class in the software.amazon.jdbc tree. The incremental
+        // adoption is complete, so this list is no longer a subset - each alternative below
+        // corresponds to a package that is fully clean, and together they cover the whole
+        // main source set.
+        //
+        // Why the filter is still here rather than deleted: dropping -AonlyDefs also pulls
+        // ANONYMOUS classes into scope, and the codebase widely uses the double-brace
+        // initializer idiom (`new HashMap<K, V>() {{ put(...); }}`) for enum mappings and
+        // plugin/dialect registries. The checker rejects those `put`/`add` calls as
+        // invocations on an @UnderInitialization receiver, which produces 100+ findings
+        // across ~25 files. Covering anonymous classes therefore requires first replacing
+        // that idiom (e.g. with static factory helpers) - tracked as follow-up work, kept
+        // separate from enabling enforcement so this change stays reviewable.
+        //
+        // When adding a new package, add it here too, otherwise it silently escapes the gate.
+        //
         // No end-anchor: matching an outer class also covers its nested classes (and, for
         // "pkg\.\w+", the classes of nested sub-packages such as util.telemetry.*). The
         // "plugin\.[A-Z]\w*" entry matches only classes directly in the plugin package
@@ -368,13 +370,11 @@ if (project.hasProperty("enableCheckerFramework")) {
                 + "|parser\\.\\w+|plugin\\.failover2\\.\\w+"
                 + "|plugin\\.readwritesplitting\\.\\w+|plugin\\.encryption\\.\\w+"
                 + "|[A-Z]\\w*)",
-            // Warning mode: report issues but do not fail the build.
-            "-Awarns",
             // Keep the output focused and avoid drowning in framework boilerplate.
             "-AsuppressWarnings=uninitialized",
-            // Raise javac's default 100-warning cap so the full finding count is visible
-            // while measuring scope (the checker runs warn-only).
-            "-Xmaxwarns", "100000"
+            // Enforcing mode caps errors at 100 by default; raise it so a regression shows
+            // its full extent in one run instead of being truncated.
+            "-Xmaxerrs", "10000"
         )
     }
 

--- a/wrapper/src/main/java/software/amazon/jdbc/ConnectionProviderManager.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/ConnectionProviderManager.java
@@ -92,13 +92,13 @@ public class ConnectionProviderManager implements StateSnapshotProvider {
    * Returns a boolean indicating if the available {@link ConnectionProvider} instances support the
    * selection of a host with the requested role and strategy via {@link #getHostSpecByStrategy}.
    *
-   * @param role     the desired host role
+   * @param role     the desired host role, or null for any role
    * @param strategy the strategy that should be used to pick a host (eg "random")
    * @return true if the available {@link ConnectionProvider} instances support the selection of a
    *     host with the requested role and strategy via {@link #getHostSpecByStrategy}. Otherwise,
    *     return false
    */
-  public boolean acceptsStrategy(HostRole role, String strategy) {
+  public boolean acceptsStrategy(@Nullable HostRole role, String strategy) {
     final @Nullable ConnectionProvider customConnectionProvider = Driver.getCustomConnectionProvider();
     if (customConnectionProvider != null && customConnectionProvider.acceptsStrategy(role, strategy)) {
       return true;
@@ -118,7 +118,7 @@ public class ConnectionProviderManager implements StateSnapshotProvider {
    * and strategy.
    *
    * @param hosts    the list of hosts to select from
-   * @param role     the desired role of the host - either a writer or a reader
+   * @param role     the desired role of the host - either a writer or a reader, or null for any role
    * @param strategy the strategy that should be used to select a {@link HostSpec} from the host
    *                 list (eg "random")
    * @param props    any properties that are required by the provided strategy to select a host
@@ -130,7 +130,7 @@ public class ConnectionProviderManager implements StateSnapshotProvider {
    *                                       not support the requested strategy
    */
   public @Nullable HostSpec getHostSpecByStrategy(
-      List<HostSpec> hosts, HostRole role, String strategy, Properties props)
+      List<HostSpec> hosts, @Nullable HostRole role, String strategy, Properties props)
       throws SQLException, UnsupportedOperationException {
     @Nullable HostSpec host = null;
     final @Nullable ConnectionProvider customConnectionProvider = Driver.getCustomConnectionProvider();

--- a/wrapper/src/main/java/software/amazon/jdbc/authentication/LoginCredentialsProviderFactory.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/authentication/LoginCredentialsProviderFactory.java
@@ -122,16 +122,23 @@ public class LoginCredentialsProviderFactory {
     }
   }
 
+  // Method.invoke types its receiver (arg0) and its varargs elements (arg1...) as non-null, but a
+  // static factory method is invoked with a null receiver and the reflective results used as
+  // receivers/arguments here are typed as possibly-null by the JDK annotations. The builder methods
+  // never return null, and a null from any of them would surface as the same
+  // ReflectiveOperationException/NullPointerException handling as before, so the arguments are
+  // passed through unchanged.
+  @SuppressWarnings("argument")
   private static AwsCredentialsProvider buildLoginCredentialsProvider(
       final String loginSession, final Region region) {
     try {
       // SigninClient signinClient = SigninClient.builder().region(region).build();
       final Class<?> signinClientClass = Class.forName(SIGNIN_CLIENT_CLASS);
       final Class<?> signinClientBuilderClass = Class.forName(SIGNIN_CLIENT_BUILDER_CLASS);
-      final Object signinClientBuilder = signinClientClass.getMethod("builder").invoke(null);
+      final @Nullable Object signinClientBuilder = signinClientClass.getMethod("builder").invoke(null);
       signinClientBuilderClass.getMethod("region", Region.class)
           .invoke(signinClientBuilder, region);
-      final Object signinClient =
+      final @Nullable Object signinClient =
           signinClientBuilderClass.getMethod("build").invoke(signinClientBuilder);
 
       // LoginCredentialsProvider.builder()
@@ -141,13 +148,20 @@ public class LoginCredentialsProviderFactory {
       final Class<?> loginProviderClass = Class.forName(LOGIN_CREDENTIALS_PROVIDER_CLASS);
       final Class<?> loginProviderBuilderClass =
           Class.forName(LOGIN_CREDENTIALS_PROVIDER_BUILDER_CLASS);
-      final Object loginProviderBuilder = loginProviderClass.getMethod("builder").invoke(null);
+      final @Nullable Object loginProviderBuilder = loginProviderClass.getMethod("builder").invoke(null);
       loginProviderBuilderClass.getMethod("signinClient", signinClientClass)
           .invoke(loginProviderBuilder, signinClient);
       loginProviderBuilderClass.getMethod("loginSession", String.class)
           .invoke(loginProviderBuilder, loginSession);
       final Method buildMethod = loginProviderBuilderClass.getMethod("build");
-      final Object provider = buildMethod.invoke(loginProviderBuilder);
+      final @Nullable Object provider = buildMethod.invoke(loginProviderBuilder);
+
+      if (provider == null) {
+        // build() never returns null; a null here would otherwise be reported to the caller as
+        // "no login_session profile", silently falling back to the standard credentials provider.
+        throw new RuntimeException(
+            Messages.get("AwsCredentialsManager.loginSessionProviderNull"));
+      }
 
       return (AwsCredentialsProvider) provider;
     } catch (final ReflectiveOperationException e) {

--- a/wrapper/src/main/java/software/amazon/jdbc/ds/AwsWrapperXADataSource.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/ds/AwsWrapperXADataSource.java
@@ -406,7 +406,13 @@ public class AwsWrapperXADataSource implements XADataSource, Serializable {
         ? null : configurationProfile.getTargetDriverDialect();
     if (targetDriverDialect == null) {
       final TargetDriverDialectManager manager = new TargetDriverDialectManager();
-      targetDriverDialect = manager.getDialect(this.targetDataSourceClassName, props);
+      // getDialect types dataSourceClass as @NonNull. The XA path always validates the target class
+      // name in createTargetXADataSource() before resolving the config, and the dialect lookup only
+      // compares the value against known class names, so it is passed through unchanged rather than
+      // adding a second (behavior-changing) validation here.
+      @SuppressWarnings("argument")
+      final TargetDriverDialect resolvedDialect = manager.getDialect(this.targetDataSourceClassName, props);
+      targetDriverDialect = resolvedDialect;
     }
 
     return new ResolvedConfig(finalUrl, props, targetDriverDialect, configurationProfile);

--- a/wrapper/src/main/java/software/amazon/jdbc/parser/EncryptionAnnotationParser.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/parser/EncryptionAnnotationParser.java
@@ -53,15 +53,22 @@ public final class EncryptionAnnotationParser {
     Map<Integer, String> annotationsByPosition = new HashMap<>();
     while (annotationMatcher.find()) {
       int questionMarkPos = annotationMatcher.end() - 1; // Position of the '?'
-      annotationsByPosition.put(questionMarkPos, annotationMatcher.group(1));
+      // Matcher.group() is declared nullable; group 1 is a mandatory part of the pattern, so a
+      // successful match always captures it. Skipping a null group keeps the map values non-null.
+      final String columnIdentifier = annotationMatcher.group(1);
+      if (columnIdentifier != null) {
+        annotationsByPosition.put(questionMarkPos, columnIdentifier);
+      }
     }
     
     // Count all '?' placeholders and map annotations to parameter indices
     int paramIndex = 1;
     for (int i = 0; i < sql.length(); i++) {
       if (sql.charAt(i) == '?') {
-        if (annotationsByPosition.containsKey(i)) {
-          encryptionMap.put(paramIndex, annotationsByPosition.get(i));
+        // A mapping is present only for annotated placeholders, and its value is never null.
+        final String columnIdentifier = annotationsByPosition.get(i);
+        if (columnIdentifier != null) {
+          encryptionMap.put(paramIndex, columnIdentifier);
         }
         paramIndex++;
       }

--- a/wrapper/src/main/java/software/amazon/jdbc/parser/JSQLParserAnalyzer.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/parser/JSQLParserAnalyzer.java
@@ -33,6 +33,7 @@ import net.sf.jsqlparser.statement.select.Select;
 import net.sf.jsqlparser.statement.update.Update;
 import net.sf.jsqlparser.statement.update.UpdateSet;
 import net.sf.jsqlparser.util.TablesNamesFinder;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import software.amazon.jdbc.util.Messages;
 
 /**
@@ -50,10 +51,11 @@ public final class JSQLParserAnalyzer {
 
   /** Column information with table and column name. */
   public static class ColumnInfo {
-    public String tableName;
+    /** Owning table name, or null when the column is not table-qualified in the statement. */
+    public @Nullable String tableName;
     public String columnName;
 
-    public ColumnInfo(String tableName, String columnName) {
+    public ColumnInfo(@Nullable String tableName, String columnName) {
       this.tableName = tableName;
       this.columnName = columnName;
     }

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/bluegreen/BlueGreenStatusProvider.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/bluegreen/BlueGreenStatusProvider.java
@@ -1356,16 +1356,22 @@ public class BlueGreenStatusProvider {
       return;
     }
 
-    final BlueGreenInterimStatus sourceInterimStatus = this.interimStatuses[BlueGreenRole.SOURCE.getValue()];
-    final BlueGreenInterimStatus targetInterimStatus = this.interimStatuses[BlueGreenRole.TARGET.getValue()];
+    final @Nullable BlueGreenInterimStatus sourceInterimStatus =
+        this.interimStatuses[BlueGreenRole.SOURCE.getValue()];
+    final @Nullable BlueGreenInterimStatus targetInterimStatus =
+        this.interimStatuses[BlueGreenRole.TARGET.getValue()];
+
+    if (sourceInterimStatus == null || targetInterimStatus == null) {
+      // Not ready: a missing interim status previously made 'ready' false, which short-circuited
+      // before the once-per-cycle flag was set, so returning here keeps the same behavior.
+      return;
+    }
 
     // Readiness requires that both the source and target monitors have collected their topology
     // and host names, and that the blue-to-green corresponding node map has been built. Checking
     // only correspondingNodes is not enough: that map can be partially populated from host names
     // alone (see updateCorrespondingNodes()) before the target monitor has fetched its topology.
-    final boolean ready = sourceInterimStatus != null
-        && targetInterimStatus != null
-        && !Utils.isNullOrEmpty(sourceInterimStatus.startTopology)
+    final boolean ready = !Utils.isNullOrEmpty(sourceInterimStatus.startTopology)
         && !Utils.isNullOrEmpty(targetInterimStatus.startTopology)
         && !Utils.isNullOrEmpty(sourceInterimStatus.hostNames)
         && !Utils.isNullOrEmpty(targetInterimStatus.hostNames)

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/encryption/KmsEncryptionConnectionPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/encryption/KmsEncryptionConnectionPlugin.java
@@ -137,7 +137,7 @@ public class KmsEncryptionConnectionPlugin implements ConnectionPlugin {
       Object methodInvokeOn,
       String methodName,
       JdbcCallable<T, E> jdbcCallable,
-      Object... args)
+      final @Nullable Object... args)
       throws E {
 
     try {
@@ -180,7 +180,7 @@ public class KmsEncryptionConnectionPlugin implements ConnectionPlugin {
   @SuppressWarnings("unchecked")
   private <T, E extends Exception> T handlePrepareStatement(
       Class<T> methodClass, Class<E> exceptionClass,
-      JdbcCallable<T, E> jdbcCallable, Object... args) throws E {
+      JdbcCallable<T, E> jdbcCallable, final @Nullable Object... args) throws E {
 
     T result = jdbcCallable.call();
 
@@ -212,31 +212,36 @@ public class KmsEncryptionConnectionPlugin implements ConnectionPlugin {
       PreparedStatement ps,
       String methodName,
       JdbcCallable<T, E> jdbcCallable,
-      Object... args) throws E, SQLException {
+      final @Nullable Object... args) throws E, SQLException {
 
     StatementContext ctx = statementContexts.get(ps);
     if (ctx == null || args.length < 2) {
       return jdbcCallable.call();
     }
 
-    int paramIndex = (Integer) args[0];
-    Object value = args[1];
+    // args[0] is the parameter index of a PreparedStatement.setXxx call, so it is always a
+    // non-null Integer; the instanceof check only narrows the type for the nullness checker.
+    final @Nullable Object paramIndexArg = args[0];
+    final @Nullable Object value = args[1];
 
-    if (value == null) {
+    if (!(paramIndexArg instanceof Integer) || value == null) {
       return jdbcCallable.call();
     }
 
-    String columnName = ctx.getColumnNameForParameter(paramIndex);
-    if (columnName == null || ctx.tableName == null) {
+    final int paramIndex = (Integer) paramIndexArg;
+
+    final @Nullable String columnName = ctx.getColumnNameForParameter(paramIndex);
+    final @Nullable String tableName = ctx.tableName;
+    if (columnName == null || tableName == null) {
       return jdbcCallable.call();
     }
 
     MetadataManager metadataManager = encryptionUtility.getMetadataManager();
-    if (metadataManager == null || !metadataManager.isColumnEncrypted(ctx.tableName, columnName)) {
+    if (metadataManager == null || !metadataManager.isColumnEncrypted(tableName, columnName)) {
       return jdbcCallable.call();
     }
 
-    ColumnEncryptionConfig config = metadataManager.getColumnConfig(ctx.tableName, columnName);
+    ColumnEncryptionConfig config = metadataManager.getColumnConfig(tableName, columnName);
     if (config == null) {
       return jdbcCallable.call();
     }
@@ -250,8 +255,15 @@ public class KmsEncryptionConnectionPlugin implements ConnectionPlugin {
         config.getKeyMetadata().getMasterKeyArn());
 
     byte[] hmacKey = config.getKeyMetadata().getHmacKey();
-    byte[] encrypted = encryptionService.encrypt(value, dataKey, hmacKey, config.getAlgorithm());
+    final byte @Nullable [] encrypted =
+        encryptionService.encrypt(value, dataKey, hmacKey, config.getAlgorithm());
     java.util.Arrays.fill(dataKey, (byte) 0);
+
+    if (encrypted == null) {
+      // Unreachable: encrypt() only returns null for a null value, and null values were
+      // already delegated to the target driver above.
+      return jdbcCallable.call();
+    }
 
     // Set encrypted bytes using database-appropriate method
     pluginService.getTargetDriverDialect().setEncryptedParameter(ps, paramIndex, encrypted);
@@ -265,11 +277,11 @@ public class KmsEncryptionConnectionPlugin implements ConnectionPlugin {
       ResultSet rs,
       String methodName,
       JdbcCallable<T, E> jdbcCallable,
-      Object... args) throws E, SQLException {
+      final @Nullable Object... args) throws E, SQLException {
 
     // Determine column name from args (index or label)
-    String columnName = resolveColumnName(rs, args);
-    String tableName = resolveTableName(rs, args);
+    final @Nullable String columnName = resolveColumnName(rs, args);
+    final @Nullable String tableName = resolveTableName(rs, args);
 
     if (columnName == null || tableName == null) {
       return jdbcCallable.call();
@@ -308,30 +320,40 @@ public class KmsEncryptionConnectionPlugin implements ConnectionPlugin {
     return (T) decrypted;
   }
 
-  private byte[] getEncryptedBytes(ResultSet rs, Object... args) throws SQLException {
-    return pluginService.getTargetDriverDialect().getEncryptedBytes(rs, args[0]);
+  private byte @Nullable [] getEncryptedBytes(ResultSet rs, final @Nullable Object... args)
+      throws SQLException {
+    final @Nullable Object columnRef = args[0];
+    if (columnRef == null) {
+      // Unreachable: callers only get here after resolveColumnName() accepted args[0] as a
+      // column index or label.
+      return null;
+    }
+    return pluginService.getTargetDriverDialect().getEncryptedBytes(rs, columnRef);
   }
 
-  private String resolveColumnName(ResultSet rs, Object... args) throws SQLException {
+  private @Nullable String resolveColumnName(ResultSet rs, final @Nullable Object... args)
+      throws SQLException {
     if (args.length == 0) {
       return null;
     }
-    if (args[0] instanceof String) {
-      return (String) args[0];
+    final @Nullable Object columnRef = args[0];
+    if (columnRef instanceof String) {
+      return (String) columnRef;
     }
-    if (args[0] instanceof Integer) {
-      return rs.getMetaData().getColumnName((Integer) args[0]);
+    if (columnRef instanceof Integer) {
+      return rs.getMetaData().getColumnName((Integer) columnRef);
     }
     return null;
   }
 
-  private String resolveTableName(ResultSet rs, Object... args) {
+  private @Nullable String resolveTableName(ResultSet rs, final @Nullable Object... args) {
     try {
+      final @Nullable Object columnRef = args.length > 0 ? args[0] : null;
       int colIndex;
-      if (args.length > 0 && args[0] instanceof Integer) {
-        colIndex = (Integer) args[0];
-      } else if (args.length > 0 && args[0] instanceof String) {
-        colIndex = rs.findColumn((String) args[0]);
+      if (columnRef instanceof Integer) {
+        colIndex = (Integer) columnRef;
+      } else if (columnRef instanceof String) {
+        colIndex = rs.findColumn((String) columnRef);
       } else {
         return null;
       }
@@ -414,17 +436,20 @@ public class KmsEncryptionConnectionPlugin implements ConnectionPlugin {
   }
 
   @Override
-  public boolean acceptsStrategy(HostRole role, String strategy) {
+  public boolean acceptsStrategy(final @Nullable HostRole role, String strategy) {
     return true;
   }
 
   @Override
-  public HostSpec getHostSpecByStrategy(HostRole role, String strategy) throws SQLException {
+  public HostSpec getHostSpecByStrategy(final @Nullable HostRole role, String strategy)
+      throws SQLException {
     throw new UnsupportedOperationException(
         Messages.get("KmsEncryptionConnectionPlugin.noHostSelection"));
   }
 
-  public HostSpec getHostSpecByStrategy(List<HostSpec> hosts, HostRole role, String strategy)
+  @Override
+  public HostSpec getHostSpecByStrategy(
+      List<HostSpec> hosts, final @Nullable HostRole role, String strategy)
       throws SQLException {
     throw new UnsupportedOperationException(
         Messages.get("KmsEncryptionConnectionPlugin.noHostSelection2"));
@@ -450,7 +475,7 @@ public class KmsEncryptionConnectionPlugin implements ConnectionPlugin {
 
   /** Tracks SQL analysis and parameter mappings for a PreparedStatement. */
   private static class StatementContext {
-    final String tableName;
+    final @Nullable String tableName;
     final Map<Integer, String> parameterColumnMapping;
 
     // Raw type casts from context — generic parameters (Set<String>, Map<Integer,String>)
@@ -474,7 +499,7 @@ public class KmsEncryptionConnectionPlugin implements ConnectionPlugin {
       }
     }
 
-    String getColumnNameForParameter(int paramIndex) {
+    @Nullable String getColumnNameForParameter(int paramIndex) {
       return parameterColumnMapping.get(paramIndex);
     }
   }

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/encryption/KmsEncryptionUtility.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/encryption/KmsEncryptionUtility.java
@@ -21,6 +21,7 @@ import java.sql.SQLException;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Logger;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.kms.KmsClient;
 import software.amazon.jdbc.PluginService;
@@ -54,7 +55,8 @@ public class KmsEncryptionUtility {
   private KmsClient kmsClient;
 
   // Plugin services
-  private PluginService pluginService;
+  // Nullable: the default constructor leaves it unset for backward compatibility.
+  private @Nullable PluginService pluginService;
   private IndependentDataSource independentDataSource;
 
   // Monitoring and metrics
@@ -160,16 +162,19 @@ public class KmsEncryptionUtility {
     }
 
     try {
-      if (pluginService != null) {
+      // Captured into a local so the null check survives the intervening method calls.
+      final @Nullable PluginService currentPluginService = this.pluginService;
+      if (currentPluginService != null) {
         // Create independent DataSource using PluginService
-        this.independentDataSource = new IndependentDataSource(pluginService, pluginProperties);
+        this.independentDataSource =
+            new IndependentDataSource(currentPluginService, pluginProperties);
 
         // Log success
         auditLogger.logConnectionParameterExtraction("PluginService", "PLUGIN_SERVICE", true, null);
 
         // Initialize managers with PluginService
-        this.keyManager = new KeyManager(kmsClient, pluginService, config);
-        this.metadataManager = new MetadataManager(pluginService, config);
+        this.keyManager = new KeyManager(kmsClient, currentPluginService, config);
+        this.metadataManager = new MetadataManager(currentPluginService, config);
         metadataManager.initialize();
 
         LOGGER.info(Messages.get("KmsEncryptionUtility.initWithPluginService"));
@@ -209,6 +214,10 @@ public class KmsEncryptionUtility {
       if (registeredConnections.containsKey(conn)) {
         return; // Already registered for this connection
       }
+      // pluginService is non-null on every path that reaches here: the only caller
+      // (ensureInitializedWithConnection) runs initializeWithDataSource() first, which throws
+      // when pluginService is null.
+      @SuppressWarnings("dereference.of.nullable")
       TargetDriverDialect targetDriverDialect = pluginService.getTargetDriverDialect();
       try {
         targetDriverDialect.registerDataType(conn, "encrypted_data",
@@ -320,6 +329,9 @@ public class KmsEncryptionUtility {
    * @param config Encryption configuration
    * @return Configured KMS client
    */
+  // AwsCredentialsManager.getProvider() declares a non-null HostSpec, but KMS credential
+  // resolution is not host-scoped and the default provider path ignores it.
+  @SuppressWarnings("argument")
   private KmsClient createKmsClient(EncryptionConfig config) {
     LOGGER.fine(() -> Messages.get("KmsEncryptionUtility.creatingKmsClient", new Object[]{config.getKmsRegion()}));
 
@@ -396,7 +408,7 @@ public class KmsEncryptionUtility {
    *
    * @return PluginService instance
    */
-  public PluginService getPluginService() {
+  public @Nullable PluginService getPluginService() {
     return pluginService;
   }
 

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/encryption/cache/DataKeyCache.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/encryption/cache/DataKeyCache.java
@@ -29,6 +29,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.logging.Logger;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import software.amazon.jdbc.plugin.encryption.model.EncryptionConfig;
 import software.amazon.jdbc.util.Messages;
 
@@ -50,6 +51,9 @@ public class DataKeyCache {
   private final AtomicLong missCount = new AtomicLong(0);
   private final AtomicLong evictionCount = new AtomicLong(0);
 
+  // The scheduled cleanup task references this instance before the constructor returns; all
+  // state it touches (cache, lock, config) is assigned before the task is scheduled.
+  @SuppressWarnings("methodref.receiver.bound")
   public DataKeyCache(EncryptionConfig config) {
     this.config = config;
     this.cache = new HashMap<>();
@@ -78,14 +82,14 @@ public class DataKeyCache {
    * @param keyId the key identifier
    * @return decrypted data key bytes, or null if not found or expired
    */
-  public byte[] get(String keyId) {
+  public byte @Nullable [] get(String keyId) {
     if (!config.isDataKeyCacheEnabled() || keyId == null) {
       return null;
     }
 
     lock.readLock().lock();
     try {
-      CacheEntry entry = cache.get(keyId);
+      final @Nullable CacheEntry entry = cache.get(keyId);
       if (entry == null) {
         missCount.incrementAndGet();
         LOGGER.finest(() -> Messages.get("DataKeyCache.cacheMiss", new Object[]{keyId}));
@@ -279,7 +283,7 @@ public class DataKeyCache {
       this.createdAt = Instant.now();
     }
 
-    public byte[] getDataKey() {
+    public byte @Nullable [] getDataKey() {
       if (cleared) {
         return null;
       }

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/encryption/exception/IndependentConnectionException.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/encryption/exception/IndependentConnectionException.java
@@ -17,6 +17,7 @@
 package software.amazon.jdbc.plugin.encryption.exception;
 
 import java.sql.SQLException;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import software.amazon.jdbc.plugin.encryption.model.ConnectionParameters;
 
 /**
@@ -27,8 +28,8 @@ import software.amazon.jdbc.plugin.encryption.model.ConnectionParameters;
 public class IndependentConnectionException extends SQLException {
 
   private final ConnectionParameters attemptedParameters;
-  private final String connectionAttempt;
-  private final String failureReason;
+  private final @Nullable String connectionAttempt;
+  private final @Nullable String failureReason;
 
   /**
    * Creates a new IndependentConnectionException with a message and connection parameters.
@@ -114,7 +115,7 @@ public class IndependentConnectionException extends SQLException {
    *
    * @return the connection attempt description, or null if not provided
    */
-  public String getConnectionAttempt() {
+  public @Nullable String getConnectionAttempt() {
     return connectionAttempt;
   }
 
@@ -123,13 +124,13 @@ public class IndependentConnectionException extends SQLException {
    *
    * @return the failure reason, or null if not provided
    */
-  public String getFailureReason() {
+  public @Nullable String getFailureReason() {
     return failureReason;
   }
 
   /** Formats the error message with connection parameters and cause information. */
   private static String formatMessage(
-      String message, ConnectionParameters attemptedParameters, Throwable cause) {
+      String message, ConnectionParameters attemptedParameters, final @Nullable Throwable cause) {
     StringBuilder sb = new StringBuilder();
     sb.append("Independent connection creation failed");
 
@@ -164,9 +165,9 @@ public class IndependentConnectionException extends SQLException {
   private static String formatMessage(
       String message,
       ConnectionParameters attemptedParameters,
-      Throwable cause,
-      String connectionAttempt,
-      String failureReason) {
+      final @Nullable Throwable cause,
+      final @Nullable String connectionAttempt,
+      final @Nullable String failureReason) {
     StringBuilder sb = new StringBuilder();
     sb.append("Independent connection creation failed");
 
@@ -208,7 +209,7 @@ public class IndependentConnectionException extends SQLException {
    * Masks sensitive information in JDBC URLs for logging purposes. Removes passwords and other
    * sensitive parameters while preserving useful debugging information.
    */
-  private static String maskSensitiveUrl(String jdbcUrl) {
+  private static @Nullable String maskSensitiveUrl(final @Nullable String jdbcUrl) {
     if (jdbcUrl == null) {
       return null;
     }

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/encryption/key/KeyManagementException.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/encryption/key/KeyManagementException.java
@@ -19,6 +19,7 @@ package software.amazon.jdbc.plugin.encryption.key;
 import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Exception thrown when key management operations fail. Extends SQLException to integrate with JDBC
@@ -36,7 +37,8 @@ public class KeyManagementException extends SQLException {
   public static final String KMS_CONNECTION_FAILED_STATE = "KEY05";
   public static final String INVALID_KEY_METADATA_STATE = "KEY06";
 
-  private final Map<String, Object> errorContext = new HashMap<>();
+  // Context values are nullable: the sanitizing helpers below map a null input to a null entry.
+  private final Map<String, @Nullable Object> errorContext = new HashMap<>();
 
   /**
    * Constructs a KeyManagementException with the specified detail message.
@@ -53,7 +55,7 @@ public class KeyManagementException extends SQLException {
    * @param message the detail message
    * @param cause the cause of this exception
    */
-  public KeyManagementException(String message, Throwable cause) {
+  public KeyManagementException(String message, final @Nullable Throwable cause) {
     super(message, KEY_RETRIEVAL_FAILED_STATE, cause);
   }
 
@@ -87,7 +89,8 @@ public class KeyManagementException extends SQLException {
    * @param vendorCode the vendor-specific error code
    * @param cause the cause of this exception
    */
-  public KeyManagementException(String message, String sqlState, int vendorCode, Throwable cause) {
+  public KeyManagementException(
+      String message, String sqlState, int vendorCode, final @Nullable Throwable cause) {
     super(message, sqlState, vendorCode, cause);
   }
 
@@ -98,7 +101,7 @@ public class KeyManagementException extends SQLException {
    * @param sqlState the SQL state
    * @param cause the cause of this exception
    */
-  public KeyManagementException(String message, String sqlState, Throwable cause) {
+  public KeyManagementException(String message, String sqlState, final @Nullable Throwable cause) {
     super(message, sqlState, cause);
   }
 
@@ -109,7 +112,7 @@ public class KeyManagementException extends SQLException {
    * @param value the context value
    * @return this exception for method chaining
    */
-  public KeyManagementException withContext(String key, Object value) {
+  public KeyManagementException withContext(String key, final @Nullable Object value) {
     errorContext.put(key, value);
     return this;
   }
@@ -120,7 +123,7 @@ public class KeyManagementException extends SQLException {
    * @param keyId the key ID
    * @return this exception for method chaining
    */
-  public KeyManagementException withKeyId(String keyId) {
+  public KeyManagementException withKeyId(final @Nullable String keyId) {
     return withContext("keyId", sanitizeKeyId(keyId));
   }
 
@@ -130,7 +133,7 @@ public class KeyManagementException extends SQLException {
    * @param masterKeyArn the master key ARN
    * @return this exception for method chaining
    */
-  public KeyManagementException withMasterKeyArn(String masterKeyArn) {
+  public KeyManagementException withMasterKeyArn(final @Nullable String masterKeyArn) {
     return withContext("masterKeyArn", sanitizeArn(masterKeyArn));
   }
 
@@ -160,8 +163,8 @@ public class KeyManagementException extends SQLException {
    *
    * @return a copy of the error context
    */
-  public Map<String, Object> getErrorContext() {
-    return new HashMap<>(errorContext);
+  public Map<String, @Nullable Object> getErrorContext() {
+    return new HashMap<String, @Nullable Object>(errorContext);
   }
 
   /**
@@ -169,16 +172,18 @@ public class KeyManagementException extends SQLException {
    *
    * @return formatted error message with context
    */
-  public String getDetailedMessage() {
+  public @Nullable String getDetailedMessage() {
+    // Throwable.getMessage() is nullable (e.g. when built from a cause without a message).
+    final @Nullable String message = getMessage();
     if (errorContext.isEmpty()) {
-      return getMessage();
+      return message;
     }
 
-    StringBuilder sb = new StringBuilder(getMessage());
+    StringBuilder sb = new StringBuilder(message == null ? "" : message);
     sb.append(" [Context: ");
 
     boolean first = true;
-    for (Map.Entry<String, Object> entry : errorContext.entrySet()) {
+    for (Map.Entry<String, @Nullable Object> entry : errorContext.entrySet()) {
       if (!first) {
         sb.append(", ");
       }
@@ -197,7 +202,8 @@ public class KeyManagementException extends SQLException {
    * @param cause Root cause
    * @return KeyManagementException instance
    */
-  public static KeyManagementException keyCreationFailed(String message, Throwable cause) {
+  public static KeyManagementException keyCreationFailed(
+      String message, final @Nullable Throwable cause) {
     return new KeyManagementException(message, KEY_CREATION_FAILED_STATE, cause);
   }
 
@@ -210,7 +216,7 @@ public class KeyManagementException extends SQLException {
    * @return KeyManagementException instance
    */
   public static KeyManagementException keyDecryptionFailed(
-      String keyId, String masterKeyArn, Throwable cause) {
+      String keyId, String masterKeyArn, final @Nullable Throwable cause) {
     return new KeyManagementException(
             "Failed to decrypt data key", KEY_DECRYPTION_FAILED_STATE, cause)
         .withKeyId(keyId)
@@ -224,7 +230,8 @@ public class KeyManagementException extends SQLException {
    * @param cause Root cause
    * @return KeyManagementException instance
    */
-  public static KeyManagementException keyStorageFailed(String message, Throwable cause) {
+  public static KeyManagementException keyStorageFailed(
+      String message, final @Nullable Throwable cause) {
     return new KeyManagementException(message, KEY_STORAGE_FAILED_STATE, cause);
   }
 
@@ -235,7 +242,8 @@ public class KeyManagementException extends SQLException {
    * @param cause Root cause
    * @return KeyManagementException instance
    */
-  public static KeyManagementException kmsConnectionFailed(String message, Throwable cause) {
+  public static KeyManagementException kmsConnectionFailed(
+      String message, final @Nullable Throwable cause) {
     return new KeyManagementException(message, KMS_CONNECTION_FAILED_STATE, cause);
   }
 
@@ -251,7 +259,7 @@ public class KeyManagementException extends SQLException {
 
   // Sanitization methods to prevent sensitive data exposure
 
-  private String sanitizeKeyId(String keyId) {
+  private @Nullable String sanitizeKeyId(final @Nullable String keyId) {
     if (keyId == null) {
       return null;
     }
@@ -262,7 +270,7 @@ public class KeyManagementException extends SQLException {
     return "***";
   }
 
-  private String sanitizeArn(String arn) {
+  private @Nullable String sanitizeArn(final @Nullable String arn) {
     if (arn == null) {
       return null;
     }

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/encryption/key/KeyManagementUtility.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/encryption/key/KeyManagementUtility.java
@@ -118,7 +118,7 @@ public class KeyManagementUtility {
     throw new SQLException(Messages.get("KeyManagementUtility.noConnectionAvailable"));
   }
 
-  private void closeConnection(Connection conn) throws SQLException {
+  private void closeConnection(final @Nullable Connection conn) throws SQLException {
     if (dataSource != null && conn != null) {
       conn.close();
     }
@@ -169,7 +169,7 @@ public class KeyManagementUtility {
    * @return The ARN of the created master key
    * @throws KeyManagementException if key creation fails
    */
-  public String createMasterKeyWithPermissions(String description, String keyPolicy)
+  public String createMasterKeyWithPermissions(String description, final @Nullable String keyPolicy)
       throws KeyManagementException {
     Objects.requireNonNull(description, "Description cannot be null");
 

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/encryption/key/KeyManager.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/encryption/key/KeyManager.java
@@ -116,7 +116,7 @@ public class KeyManager {
     throw new SQLException(Messages.get("KeyManager.noConnectionAvailable"));
   }
 
-  private void closeConnection(Connection conn) throws SQLException {
+  private void closeConnection(final @Nullable Connection conn) throws SQLException {
     if (pluginService != null && conn != null) {
       conn.close();
     }
@@ -356,6 +356,10 @@ public class KeyManager {
 
         try (ResultSet rs = stmt.executeQuery()) {
           if (rs.next()) {
+            // ResultSet.getTimestamp() is nullable; a null timestamp is passed through to the
+            // builder, which substitutes the current instant (same as MetadataManager does).
+            final @Nullable Timestamp createdAt = rs.getTimestamp("created_at");
+            final @Nullable Timestamp lastUsedAt = rs.getTimestamp("last_used_at");
             KeyMetadata metadata =
                 KeyMetadata.builder()
                     .keyId(rs.getInt("id"))
@@ -364,8 +368,8 @@ public class KeyManager {
                     .encryptedDataKey(rs.getString("encrypted_data_key"))
                     .hmacKey(rs.getBytes("hmac_key"))
                     .keySpec(rs.getString("key_spec"))
-                    .createdAt(rs.getTimestamp("created_at").toInstant())
-                    .lastUsedAt(rs.getTimestamp("last_used_at").toInstant())
+                    .createdAt(createdAt != null ? createdAt.toInstant() : null)
+                    .lastUsedAt(lastUsedAt != null ? lastUsedAt.toInstant() : null)
                     .build();
 
             LOGGER.finest(() -> Messages.get("KeyManager.keyMetadataRetrieved", new Object[]{keyId}));
@@ -456,7 +460,7 @@ public class KeyManager {
 
   /** Executes a KMS operation with retry logic and exponential backoff. */
   private <T> T executeWithRetry(KmsOperation<T> operation) throws Exception {
-    Exception lastException = null;
+    @Nullable Exception lastException = null;
     int maxRetries = config.getMaxRetries();
 
     for (int attempt = 0; attempt <= maxRetries; attempt++) {
@@ -488,7 +492,12 @@ public class KeyManager {
       }
     }
 
-    throw lastException;
+    final @Nullable Exception failure = lastException;
+    if (failure == null) {
+      // Only reachable with a negative maxRetries, where the retry loop never runs.
+      throw new KeyManagementException(Messages.get("KeyManager.retryNoException"));
+    }
+    throw failure;
   }
 
   /** Determines if an exception is retryable. */

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/encryption/logging/AuditLogger.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/encryption/logging/AuditLogger.java
@@ -20,6 +20,7 @@ import java.time.Instant;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Logger;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Audit LOGGER for KMS operations and encryption activities. Provides structured logging without
@@ -30,8 +31,8 @@ public class AuditLogger {
   private static final Logger LOGGER = Logger.getLogger(AuditLogger.class.getName());
 
   // Thread-local context for audit information
-  private static final ThreadLocal<Map<String, String>> auditContext =
-      ThreadLocal.withInitial(ConcurrentHashMap::new);
+  private static final ThreadLocal<@Nullable Map<String, String>> auditContext =
+      ThreadLocal.<@Nullable Map<String, String>>withInitial(ConcurrentHashMap::new);
 
   private final boolean auditEnabled;
 
@@ -46,12 +47,20 @@ public class AuditLogger {
    * @param value Context value
    */
   public static void setContext(String key, String value) {
-    auditContext.get().put(key, value);
+    // withInitial() guarantees a map is present; the guard only satisfies static analysis.
+    final Map<String, String> context = auditContext.get();
+    if (context != null) {
+      context.put(key, value);
+    }
   }
 
   /** Clears audit context for the current thread. */
   public static void clearContext() {
-    auditContext.get().clear();
+    // withInitial() guarantees a map is present; the guard only satisfies static analysis.
+    final Map<String, String> context = auditContext.get();
+    if (context != null) {
+      context.clear();
+    }
   }
 
   /**
@@ -342,7 +351,7 @@ public class AuditLogger {
    * @param errorMessage Error message if failed
    */
   public void logConnectionParameterExtraction(
-      String strategy, String connectionType, boolean success, String errorMessage) {
+      String strategy, String connectionType, boolean success, @Nullable String errorMessage) {
     if (!auditEnabled) {
       return;
     }
@@ -557,7 +566,7 @@ public class AuditLogger {
     return sanitized.length() > 100 ? sanitized.substring(0, 97) + "..." : sanitized;
   }
 
-  private String sanitizeErrorMessage(String errorMessage) {
+  private String sanitizeErrorMessage(@Nullable String errorMessage) {
     if (errorMessage == null) {
       return "null";
     }

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/encryption/logging/ErrorContext.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/encryption/logging/ErrorContext.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Utility class for building detailed error messages with context information. Helps provide clear
@@ -28,7 +29,8 @@ import java.util.Set;
  */
 public class ErrorContext {
 
-  private final Map<String, Object> context = new HashMap<>();
+  // Values are nullable: the sanitizers return null for null input.
+  private final Map<String, @Nullable Object> context = new HashMap<>();
 
   private ErrorContext() {}
 
@@ -192,7 +194,7 @@ public class ErrorContext {
     sb.append(" [Context: ");
 
     boolean first = true;
-    for (Map.Entry<String, Object> entry : context.entrySet()) {
+    for (Map.Entry<String, @Nullable Object> entry : context.entrySet()) {
       if (!first) {
         sb.append(", ");
       }
@@ -277,7 +279,7 @@ public class ErrorContext {
    *
    * @return Copy of the context map
    */
-  public Map<String, Object> getContext() {
+  public Map<String, @Nullable Object> getContext() {
     return new HashMap<>(context);
   }
 
@@ -323,8 +325,8 @@ public class ErrorContext {
     Set<String> excludedKeys = new HashSet<>(Arrays.asList(
         "table", "column", "operation", "parameterIndex",
         "columnIndex", "retryAttempt", "maxRetryAttempts"));
-    Map<String, Object> additionalContext = new HashMap<>();
-    for (Map.Entry<String, Object> entry : context.entrySet()) {
+    Map<String, @Nullable Object> additionalContext = new HashMap<>();
+    for (Map.Entry<String, @Nullable Object> entry : context.entrySet()) {
       if (!excludedKeys.contains(entry.getKey())) {
         additionalContext.put(entry.getKey(), entry.getValue());
       }
@@ -333,7 +335,7 @@ public class ErrorContext {
     if (!additionalContext.isEmpty()) {
       sb.append(" [");
       boolean first = true;
-      for (Map.Entry<String, Object> entry : additionalContext.entrySet()) {
+      for (Map.Entry<String, @Nullable Object> entry : additionalContext.entrySet()) {
         if (!first) {
           sb.append(", ");
         }
@@ -346,7 +348,7 @@ public class ErrorContext {
 
   // Sanitization methods
 
-  private String sanitizeKeyId(String keyId) {
+  private @Nullable String sanitizeKeyId(@Nullable String keyId) {
     if (keyId == null) {
       return null;
     }
@@ -357,7 +359,7 @@ public class ErrorContext {
     return "***";
   }
 
-  private String sanitizeArn(String arn) {
+  private @Nullable String sanitizeArn(@Nullable String arn) {
     if (arn == null) {
       return null;
     }
@@ -369,7 +371,7 @@ public class ErrorContext {
     return "arn:aws:kms:***:***:key/***";
   }
 
-  private String sanitizeSql(String sql) {
+  private @Nullable String sanitizeSql(@Nullable String sql) {
     if (sql == null) {
       return null;
     }

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/encryption/metadata/MetadataException.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/encryption/metadata/MetadataException.java
@@ -19,6 +19,7 @@ package software.amazon.jdbc.plugin.encryption.metadata;
 import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Exception thrown when metadata operations fail, such as loading encryption configuration from
@@ -36,7 +37,8 @@ public class MetadataException extends SQLException {
   public static final String METADATA_LOOKUP_FAILED_STATE = "META04";
   public static final String METADATA_VALIDATION_FAILED_STATE = "META05";
 
-  private final Map<String, Object> errorContext = new HashMap<>();
+  // Context values are nullable: the sanitizing helpers below map a null input to a null entry.
+  private final Map<String, @Nullable Object> errorContext = new HashMap<>();
 
   /**
    * Constructs a MetadataException with the specified detail message.
@@ -53,7 +55,7 @@ public class MetadataException extends SQLException {
    * @param message the detail message
    * @param cause the cause of this exception
    */
-  public MetadataException(String message, Throwable cause) {
+  public MetadataException(String message, final @Nullable Throwable cause) {
     super(message, METADATA_LOOKUP_FAILED_STATE, cause);
   }
 
@@ -75,7 +77,8 @@ public class MetadataException extends SQLException {
    * @param vendorCode the vendor-specific error code
    * @param cause the cause of this exception
    */
-  public MetadataException(String message, String sqlState, int vendorCode, Throwable cause) {
+  public MetadataException(
+      String message, String sqlState, int vendorCode, final @Nullable Throwable cause) {
     super(message, sqlState, vendorCode, cause);
   }
 
@@ -86,7 +89,7 @@ public class MetadataException extends SQLException {
    * @param sqlState the SQL state
    * @param cause the cause of this exception
    */
-  public MetadataException(String message, String sqlState, Throwable cause) {
+  public MetadataException(String message, String sqlState, final @Nullable Throwable cause) {
     super(message, sqlState, cause);
   }
 
@@ -97,7 +100,7 @@ public class MetadataException extends SQLException {
    * @param value the context value
    * @return this exception for method chaining
    */
-  public MetadataException withContext(String key, Object value) {
+  public MetadataException withContext(String key, final @Nullable Object value) {
     errorContext.put(key, value);
     return this;
   }
@@ -149,7 +152,7 @@ public class MetadataException extends SQLException {
    * @param sql the SQL query
    * @return this exception for method chaining
    */
-  public MetadataException withSql(String sql) {
+  public MetadataException withSql(final @Nullable String sql) {
     return withContext("sql", sanitizeSql(sql));
   }
 
@@ -158,8 +161,8 @@ public class MetadataException extends SQLException {
    *
    * @return a copy of the error context
    */
-  public Map<String, Object> getErrorContext() {
-    return new HashMap<>(errorContext);
+  public Map<String, @Nullable Object> getErrorContext() {
+    return new HashMap<String, @Nullable Object>(errorContext);
   }
 
   /**
@@ -167,16 +170,18 @@ public class MetadataException extends SQLException {
    *
    * @return formatted error message with context
    */
-  public String getDetailedMessage() {
+  public @Nullable String getDetailedMessage() {
+    // Throwable.getMessage() is nullable (e.g. when built from a cause without a message).
+    final @Nullable String message = getMessage();
     if (errorContext.isEmpty()) {
-      return getMessage();
+      return message;
     }
 
-    StringBuilder sb = new StringBuilder(getMessage());
+    StringBuilder sb = new StringBuilder(message == null ? "" : message);
     sb.append(" [Context: ");
 
     boolean first = true;
-    for (Map.Entry<String, Object> entry : errorContext.entrySet()) {
+    for (Map.Entry<String, @Nullable Object> entry : errorContext.entrySet()) {
       if (!first) {
         sb.append(", ");
       }
@@ -195,7 +200,7 @@ public class MetadataException extends SQLException {
    * @param cause Root cause
    * @return New MetadataException instance
    */
-  public static MetadataException loadFailed(String message, Throwable cause) {
+  public static MetadataException loadFailed(String message, final @Nullable Throwable cause) {
     return new MetadataException(message, METADATA_LOAD_FAILED_STATE, cause);
   }
 
@@ -206,7 +211,7 @@ public class MetadataException extends SQLException {
    * @param cause Root cause
    * @return New MetadataException instance
    */
-  public static MetadataException cacheFailed(String message, Throwable cause) {
+  public static MetadataException cacheFailed(String message, final @Nullable Throwable cause) {
     return new MetadataException(message, METADATA_CACHE_FAILED_STATE, cause);
   }
 
@@ -217,7 +222,7 @@ public class MetadataException extends SQLException {
    * @param cause Root cause
    * @return New MetadataException instance
    */
-  public static MetadataException refreshFailed(String message, Throwable cause) {
+  public static MetadataException refreshFailed(String message, final @Nullable Throwable cause) {
     return new MetadataException(message, METADATA_REFRESH_FAILED_STATE, cause);
   }
 
@@ -230,7 +235,7 @@ public class MetadataException extends SQLException {
    * @return New MetadataException instance
    */
   public static MetadataException lookupFailed(
-      String tableName, String columnName, Throwable cause) {
+      String tableName, String columnName, final @Nullable Throwable cause) {
     return new MetadataException("Failed to lookup metadata", METADATA_LOOKUP_FAILED_STATE, cause)
         .withTable(tableName)
         .withColumn(columnName);
@@ -248,7 +253,7 @@ public class MetadataException extends SQLException {
 
   // Sanitization methods
 
-  private String sanitizeSql(String sql) {
+  private @Nullable String sanitizeSql(final @Nullable String sql) {
     if (sql == null) {
       return null;
     }

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/encryption/metadata/MetadataManager.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/encryption/metadata/MetadataManager.java
@@ -114,7 +114,7 @@ public class MetadataManager {
     throw new SQLException(Messages.get("MetadataManager.noConnectionAvailable"));
   }
 
-  private void closeConnection(Connection conn) throws SQLException {
+  private void closeConnection(final @Nullable Connection conn) throws SQLException {
     if ((dataSource != null || pluginService != null) && conn != null) {
       conn.close();
     }
@@ -261,7 +261,7 @@ public class MetadataManager {
    * @return ColumnEncryptionConfig if found, null otherwise
    * @throws MetadataException if database operations fail
    */
-  public ColumnEncryptionConfig getColumnConfig(String tableName, String columnName)
+  public @Nullable ColumnEncryptionConfig getColumnConfig(String tableName, String columnName)
       throws MetadataException {
     if (tableName == null || columnName == null) {
       return null;
@@ -415,7 +415,8 @@ public class MetadataManager {
   }
 
   /** Queries database directly to get column configuration. */
-  private ColumnEncryptionConfig getColumnConfigFromDatabase(String tableName, String columnName)
+  private @Nullable ColumnEncryptionConfig getColumnConfigFromDatabase(
+      String tableName, String columnName)
       throws MetadataException {
     LOGGER.finest(() -> Messages.get("MetadataManager.loadingColumnConfig", new Object[]{tableName, columnName}));
 
@@ -481,12 +482,12 @@ public class MetadataManager {
   }
 
   /** Converts SQL Timestamp to Instant, handling null values. */
-  private Instant convertTimestampToInstant(Timestamp timestamp) {
+  private Instant convertTimestampToInstant(final @Nullable Timestamp timestamp) {
     return timestamp != null ? timestamp.toInstant() : Instant.now();
   }
 
-  /** Creates a new refresh executor. */
-  private ScheduledExecutorService createRefreshExecutor() {
+  /** Creates a new refresh executor. Static so it can safely be called from constructors. */
+  private static ScheduledExecutorService createRefreshExecutor() {
     return Executors.newSingleThreadScheduledExecutor(
         r -> {
           Thread t = new Thread(r, "MetadataManager-Refresh");

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/encryption/model/ColumnEncryptionConfig.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/encryption/model/ColumnEncryptionConfig.java
@@ -18,6 +18,7 @@ package software.amazon.jdbc.plugin.encryption.model;
 
 import java.time.Instant;
 import java.util.Objects;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import software.amazon.jdbc.plugin.encryption.service.EncryptionAlgorithm;
 
 /**
@@ -35,10 +36,28 @@ public class ColumnEncryptionConfig {
   private final Instant updatedAt;
 
   private ColumnEncryptionConfig(Builder builder) {
-    this.tableName = Objects.requireNonNull(builder.tableName, "tableName cannot be null");
-    this.columnName = Objects.requireNonNull(builder.columnName, "columnName cannot be null");
-    this.algorithm = Objects.requireNonNull(builder.algorithm, "algorithm cannot be null");
-    this.keyId = Objects.requireNonNull(builder.keyId, "keyId cannot be null");
+    // Explicit null checks (instead of Objects.requireNonNull) so the non-null builder values can
+    // be assigned to the non-null fields. Same exception type and message as before.
+    final @Nullable String builderTableName = builder.tableName;
+    if (builderTableName == null) {
+      throw new NullPointerException("tableName cannot be null");
+    }
+    final @Nullable String builderColumnName = builder.columnName;
+    if (builderColumnName == null) {
+      throw new NullPointerException("columnName cannot be null");
+    }
+    final @Nullable String builderAlgorithm = builder.algorithm;
+    if (builderAlgorithm == null) {
+      throw new NullPointerException("algorithm cannot be null");
+    }
+    final @Nullable Integer builderKeyId = builder.keyId;
+    if (builderKeyId == null) {
+      throw new NullPointerException("keyId cannot be null");
+    }
+    this.tableName = builderTableName;
+    this.columnName = builderColumnName;
+    this.algorithm = builderAlgorithm;
+    this.keyId = builderKeyId;
     this.keyMetadata = builder.keyMetadata;
     this.createdAt = builder.createdAt != null ? builder.createdAt : Instant.now();
     this.updatedAt = builder.updatedAt != null ? builder.updatedAt : Instant.now();
@@ -82,7 +101,7 @@ public class ColumnEncryptionConfig {
   }
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(@Nullable Object o) {
     if (this == o) {
       return true;
     }
@@ -114,25 +133,26 @@ public class ColumnEncryptionConfig {
   }
 
   public static class Builder {
-    private String tableName;
-    private String columnName;
-    private String algorithm = EncryptionAlgorithm.AES_256_GCM;
-    private Integer keyId;
+    private @Nullable String tableName;
+    private @Nullable String columnName;
+    private @Nullable String algorithm = EncryptionAlgorithm.AES_256_GCM;
+    private @Nullable Integer keyId;
+    // Left non-null: ColumnEncryptionConfig.getKeyMetadata() is dereferenced by callers.
     private KeyMetadata keyMetadata;
-    private Instant createdAt;
-    private Instant updatedAt;
+    private @Nullable Instant createdAt;
+    private @Nullable Instant updatedAt;
 
-    public Builder tableName(String tableName) {
+    public Builder tableName(@Nullable String tableName) {
       this.tableName = tableName;
       return this;
     }
 
-    public Builder columnName(String columnName) {
+    public Builder columnName(@Nullable String columnName) {
       this.columnName = columnName;
       return this;
     }
 
-    public Builder algorithm(String algorithm) {
+    public Builder algorithm(@Nullable String algorithm) {
       this.algorithm = algorithm;
       return this;
     }

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/encryption/model/ConnectionParameters.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/encryption/model/ConnectionParameters.java
@@ -18,6 +18,7 @@ package software.amazon.jdbc.plugin.encryption.model;
 
 import java.util.Objects;
 import java.util.Properties;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import software.amazon.jdbc.util.Messages;
 
 /**
@@ -144,7 +145,7 @@ public class ConnectionParameters {
   }
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(@Nullable Object o) {
     if (this == o) {
       return true;
     }

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/encryption/model/EncryptionConfig.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/encryption/model/EncryptionConfig.java
@@ -19,6 +19,7 @@ package software.amazon.jdbc.plugin.encryption.model;
 import java.time.Duration;
 import java.util.Objects;
 import java.util.Properties;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import software.amazon.jdbc.AwsWrapperProperty;
 import software.amazon.jdbc.PropertyDefinition;
 import software.amazon.jdbc.util.Messages;
@@ -187,7 +188,7 @@ public class EncryptionConfig {
   }
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(@Nullable Object o) {
     if (this == o) {
       return true;
     }
@@ -347,7 +348,7 @@ public class EncryptionConfig {
       return this;
     }
 
-    public Builder encryptionMetadataSchema(String encryptionMetadataSchema) {
+    public Builder encryptionMetadataSchema(@Nullable String encryptionMetadataSchema) {
       this.encryptionMetadataSchema = SchemaName.of(encryptionMetadataSchema);
       return this;
     }

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/encryption/model/KeyMetadata.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/encryption/model/KeyMetadata.java
@@ -30,19 +30,36 @@ public class KeyMetadata {
   private final String keyName;
   private final String masterKeyArn;
   private final String encryptedDataKey;
-  private final byte[] hmacKey;
+  private final byte @Nullable [] hmacKey;
   private final String keySpec;
   private final Instant createdAt;
   private final Instant lastUsedAt;
 
   private KeyMetadata(Builder builder) {
+    // Explicit null checks (instead of Objects.requireNonNull) so the non-null builder values can
+    // be assigned to the non-null fields. Same exception type and message as before.
+    final @Nullable String builderKeyName = builder.keyName;
+    if (builderKeyName == null) {
+      throw new NullPointerException("keyName cannot be null");
+    }
+    final @Nullable String builderMasterKeyArn = builder.masterKeyArn;
+    if (builderMasterKeyArn == null) {
+      throw new NullPointerException("masterKeyArn cannot be null");
+    }
+    final @Nullable String builderEncryptedDataKey = builder.encryptedDataKey;
+    if (builderEncryptedDataKey == null) {
+      throw new NullPointerException("encryptedDataKey cannot be null");
+    }
+    final @Nullable String builderKeySpec = builder.keySpec;
+    if (builderKeySpec == null) {
+      throw new NullPointerException("keySpec cannot be null");
+    }
     this.keyId = builder.keyId;
-    this.keyName = Objects.requireNonNull(builder.keyName, "keyName cannot be null");
-    this.masterKeyArn = Objects.requireNonNull(builder.masterKeyArn, "masterKeyArn cannot be null");
-    this.encryptedDataKey =
-        Objects.requireNonNull(builder.encryptedDataKey, "encryptedDataKey cannot be null");
+    this.keyName = builderKeyName;
+    this.masterKeyArn = builderMasterKeyArn;
+    this.encryptedDataKey = builderEncryptedDataKey;
     this.hmacKey = builder.hmacKey;
-    this.keySpec = Objects.requireNonNull(builder.keySpec, "keySpec cannot be null");
+    this.keySpec = builderKeySpec;
     this.createdAt = builder.createdAt != null ? builder.createdAt : Instant.now();
     this.lastUsedAt = builder.lastUsedAt != null ? builder.lastUsedAt : Instant.now();
   }
@@ -63,7 +80,7 @@ public class KeyMetadata {
     return encryptedDataKey;
   }
 
-  public byte[] getHmacKey() {
+  public byte @Nullable [] getHmacKey() {
     return hmacKey;
   }
 
@@ -110,7 +127,7 @@ public class KeyMetadata {
   }
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(@Nullable Object o) {
     if (this == o) {
       return true;
     }
@@ -142,51 +159,51 @@ public class KeyMetadata {
   }
 
   public static class Builder {
-    private Integer keyId;
-    private String keyName;
-    private String masterKeyArn;
-    private String encryptedDataKey;
-    private byte[] hmacKey;
-    private String keySpec = "AES_256"; // Default key spec
-    private Instant createdAt;
-    private Instant lastUsedAt;
+    private @Nullable Integer keyId;
+    private @Nullable String keyName;
+    private @Nullable String masterKeyArn;
+    private @Nullable String encryptedDataKey;
+    private byte @Nullable [] hmacKey;
+    private @Nullable String keySpec = "AES_256"; // Default key spec
+    private @Nullable Instant createdAt;
+    private @Nullable Instant lastUsedAt;
 
-    public Builder keyId(Integer keyId) {
+    public Builder keyId(@Nullable Integer keyId) {
       this.keyId = keyId;
       return this;
     }
 
-    public Builder keyName(String keyName) {
+    public Builder keyName(@Nullable String keyName) {
       this.keyName = keyName;
       return this;
     }
 
-    public Builder masterKeyArn(String masterKeyArn) {
+    public Builder masterKeyArn(@Nullable String masterKeyArn) {
       this.masterKeyArn = masterKeyArn;
       return this;
     }
 
-    public Builder encryptedDataKey(String encryptedDataKey) {
+    public Builder encryptedDataKey(@Nullable String encryptedDataKey) {
       this.encryptedDataKey = encryptedDataKey;
       return this;
     }
 
-    public Builder hmacKey(byte[] hmacKey) {
+    public Builder hmacKey(byte @Nullable [] hmacKey) {
       this.hmacKey = hmacKey;
       return this;
     }
 
-    public Builder keySpec(String keySpec) {
+    public Builder keySpec(@Nullable String keySpec) {
       this.keySpec = keySpec;
       return this;
     }
 
-    public Builder createdAt(Instant createdAt) {
+    public Builder createdAt(@Nullable Instant createdAt) {
       this.createdAt = createdAt;
       return this;
     }
 
-    public Builder lastUsedAt(Instant lastUsedAt) {
+    public Builder lastUsedAt(@Nullable Instant lastUsedAt) {
       this.lastUsedAt = lastUsedAt;
       return this;
     }

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/encryption/model/SchemaName.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/encryption/model/SchemaName.java
@@ -17,6 +17,7 @@
 package software.amazon.jdbc.plugin.encryption.model;
 
 import java.util.Objects;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import software.amazon.jdbc.util.Messages;
 
 /**
@@ -41,7 +42,7 @@ public final class SchemaName {
    * @return a validated SchemaName
    * @throws IllegalArgumentException if the name is null, empty, or contains invalid characters
    */
-  public static SchemaName of(String name) {
+  public static SchemaName of(@Nullable String name) {
     if (name == null || name.isEmpty()) {
       throw new IllegalArgumentException(Messages.get("SchemaName.nullOrEmpty"));
     }
@@ -69,7 +70,7 @@ public final class SchemaName {
   }
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(@Nullable Object o) {
     if (this == o) {
       return true;
     }

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/encryption/schema/SchemaValidator.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/encryption/schema/SchemaValidator.java
@@ -27,6 +27,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import software.amazon.jdbc.plugin.encryption.model.SchemaName;
 
 /**
@@ -125,7 +126,7 @@ public class SchemaValidator {
   }
 
   /** Gets the current schema name from the connection. */
-  private String getCurrentSchema(Connection connection) throws SQLException {
+  private @Nullable String getCurrentSchema(Connection connection) throws SQLException {
     try (Statement stmt = connection.createStatement();
         ResultSet rs = stmt.executeQuery("SELECT current_schema()")) {
       if (rs.next()) {
@@ -147,7 +148,11 @@ public class SchemaValidator {
     // Try with current schema first
     try (ResultSet rs = metaData.getColumns(null, currentSchema, tableName, null)) {
       while (rs.next()) {
-        existingColumns.add(rs.getString("COLUMN_NAME").toLowerCase());
+        // COLUMN_NAME is non-null per the JDBC spec; the guard only satisfies the nullness checker.
+        final @Nullable String columnName = rs.getString("COLUMN_NAME");
+        if (columnName != null) {
+          existingColumns.add(columnName.toLowerCase());
+        }
       }
     }
 
@@ -155,7 +160,10 @@ public class SchemaValidator {
     if (existingColumns.isEmpty()) {
       try (ResultSet rs = metaData.getColumns(null, null, tableName, null)) {
         while (rs.next()) {
-          existingColumns.add(rs.getString("COLUMN_NAME").toLowerCase());
+          final @Nullable String columnName = rs.getString("COLUMN_NAME");
+          if (columnName != null) {
+            existingColumns.add(columnName.toLowerCase());
+          }
         }
       }
     }

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/encryption/service/EncryptionException.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/encryption/service/EncryptionException.java
@@ -19,6 +19,7 @@ package software.amazon.jdbc.plugin.encryption.service;
 import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Exception thrown when encryption or decryption operations fail. Extends SQLException to integrate
@@ -52,7 +53,7 @@ public class EncryptionException extends SQLException {
    * @param message the detail message
    * @param cause the cause of this exception
    */
-  public EncryptionException(String message, Throwable cause) {
+  public EncryptionException(String message, final @Nullable Throwable cause) {
     super(message, ENCRYPTION_FAILED_STATE, cause);
   }
 
@@ -63,7 +64,7 @@ public class EncryptionException extends SQLException {
    * @param sqlState the SQL state
    * @param cause the cause of this exception
    */
-  public EncryptionException(String message, String sqlState, Throwable cause) {
+  public EncryptionException(String message, String sqlState, final @Nullable Throwable cause) {
     super(message, sqlState, cause);
   }
 
@@ -152,12 +153,14 @@ public class EncryptionException extends SQLException {
    *
    * @return formatted error message with context
    */
-  public String getDetailedMessage() {
+  public @Nullable String getDetailedMessage() {
+    // Throwable.getMessage() is nullable (e.g. when built from a cause without a message).
+    final @Nullable String message = getMessage();
     if (errorContext.isEmpty()) {
-      return getMessage();
+      return message;
     }
 
-    StringBuilder sb = new StringBuilder(getMessage());
+    StringBuilder sb = new StringBuilder(message == null ? "" : message);
     sb.append(" [Context: ");
 
     boolean first = true;
@@ -180,7 +183,8 @@ public class EncryptionException extends SQLException {
    * @param cause Root cause
    * @return New EncryptionException instance
    */
-  public static EncryptionException encryptionFailed(String message, Throwable cause) {
+  public static EncryptionException encryptionFailed(
+      String message, final @Nullable Throwable cause) {
     return new EncryptionException(message, ENCRYPTION_FAILED_STATE, cause);
   }
 
@@ -191,7 +195,8 @@ public class EncryptionException extends SQLException {
    * @param cause Root cause
    * @return New EncryptionException instance
    */
-  public static EncryptionException decryptionFailed(String message, Throwable cause) {
+  public static EncryptionException decryptionFailed(
+      String message, final @Nullable Throwable cause) {
     return new EncryptionException(message, DECRYPTION_FAILED_STATE, cause);
   }
 
@@ -226,7 +231,7 @@ public class EncryptionException extends SQLException {
    * @return New EncryptionException instance
    */
   public static EncryptionException typeConversionFailed(
-      String fromType, String toType, Throwable cause) {
+      String fromType, String toType, final @Nullable Throwable cause) {
     return new EncryptionException(
             String.format("Cannot convert %s to %s", fromType, toType),
             TYPE_CONVERSION_FAILED_STATE,

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/encryption/service/EncryptionService.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/encryption/service/EncryptionService.java
@@ -34,6 +34,7 @@ import javax.crypto.Cipher;
 import javax.crypto.Mac;
 import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import software.amazon.jdbc.util.Messages;
 
 /**
@@ -68,7 +69,9 @@ public class EncryptionService {
    * @return the encrypted data as byte array with HMAC prepended
    * @throws EncryptionException if encryption fails
    */
-  public byte[] encrypt(Object value, byte[] dataKey, byte[] hmacKey, String algorithm)
+  public byte @Nullable [] encrypt(
+      final @Nullable Object value, byte[] dataKey, final byte @Nullable [] hmacKey,
+      String algorithm)
       throws EncryptionException {
     if (value == null) {
       return null;
@@ -105,12 +108,18 @@ public class EncryptionService {
 
       // Generate HMAC using the separate HMAC key
       Mac hmac = Mac.getInstance(HMAC_ALGORITHM);
-      hmac.init(new SecretKeySpec(hmacKey, HMAC_ALGORITHM));
+      if (hmacKey == null) {
+        // Same effect as before: SecretKeySpec rejected a null key with IllegalArgumentException,
+        // which the catch block below turns into an EncryptionException.
+        throw new IllegalArgumentException(Messages.get("EncryptionService.hmacKeyNull"));
+      }
+      final byte[] hmacKeyBytes = hmacKey;
+      hmac.init(new SecretKeySpec(hmacKeyBytes, HMAC_ALGORITHM));
       byte[] hmacTag = hmac.doFinal(encryptedData);
 
       LOGGER.finest(
           () -> Messages.get("EncryptionService.encrypted",
-              new Object[]{hmacKey.length, encryptedData.length}));
+              new Object[]{hmacKeyBytes.length, encryptedData.length}));
 
       // Prepend HMAC tag to encrypted data: [HMAC:32bytes][type:1byte][IV:12bytes][ciphertext]
       ByteBuffer finalBuffer = ByteBuffer.allocate(HMAC_TAG_LENGTH + encryptedData.length);
@@ -144,8 +153,9 @@ public class EncryptionService {
    * @return the decrypted value
    * @throws EncryptionException if decryption fails or HMAC verification fails
    */
-  public Object decrypt(
-      byte[] encryptedValue, byte[] dataKey, byte[] hmacKey, String algorithm, Class<?> targetType)
+  public @Nullable Object decrypt(
+      final byte @Nullable [] encryptedValue, byte[] dataKey, final byte @Nullable [] hmacKey,
+      String algorithm, Class<?> targetType)
       throws EncryptionException {
     if (encryptedValue == null) {
       return null;
@@ -181,6 +191,11 @@ public class EncryptionService {
               new Object[]{hmacKey != null ? hmacKey.length : 0, encryptedData.length}));
 
       Mac hmac = Mac.getInstance(HMAC_ALGORITHM);
+      if (hmacKey == null) {
+        // Same effect as before: SecretKeySpec rejected a null key with IllegalArgumentException,
+        // which the catch block below turns into an EncryptionException.
+        throw new IllegalArgumentException(Messages.get("EncryptionService.hmacKeyNull"));
+      }
       hmac.init(new SecretKeySpec(hmacKey, HMAC_ALGORITHM));
       byte[] calculatedHmacTag = hmac.doFinal(encryptedData);
 

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/encryption/wrapper/EncryptedData.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/encryption/wrapper/EncryptedData.java
@@ -17,6 +17,7 @@
 package software.amazon.jdbc.plugin.encryption.wrapper;
 
 import java.sql.SQLException;
+import org.checkerframework.checker.nullness.qual.Nullable;
 // CHECKSTYLE:OFF: IllegalImport - PostgreSQL-specific types required for encrypted_data domain
 import org.postgresql.util.PGBinaryObject;
 import org.postgresql.util.PGobject;
@@ -28,8 +29,11 @@ import org.postgresql.util.PGobject;
  */
 public class EncryptedData extends PGobject implements PGBinaryObject {
 
-  private byte[] bytes;
+  private byte @Nullable [] bytes;
 
+  // PGobject.setType() is a public setter on the superclass; calling it from the constructor is
+  // the documented way to declare the PostgreSQL type name.
+  @SuppressWarnings("method.invocation")
   public EncryptedData() {
     setType("encrypted_data");
   }
@@ -39,7 +43,7 @@ public class EncryptedData extends PGobject implements PGBinaryObject {
     this.bytes = bytes;
   }
 
-  public byte[] getBytes() {
+  public byte @Nullable [] getBytes() {
     return bytes;
   }
 
@@ -48,7 +52,7 @@ public class EncryptedData extends PGobject implements PGBinaryObject {
   }
 
   @Override
-  public void setValue(String value) throws SQLException {
+  public void setValue(final @Nullable String value) throws SQLException {
     if (value != null && value.startsWith("\\x")) {
       this.bytes = hexToBytes(value.substring(2));
     } else {
@@ -57,11 +61,12 @@ public class EncryptedData extends PGobject implements PGBinaryObject {
   }
 
   @Override
-  public String getValue() {
-    if (bytes == null) {
+  public @Nullable String getValue() {
+    final byte @Nullable [] currentBytes = bytes;
+    if (currentBytes == null) {
       return null;
     }
-    return "\\x" + bytesToHex(bytes);
+    return "\\x" + bytesToHex(currentBytes);
   }
 
   @Override
@@ -81,8 +86,9 @@ public class EncryptedData extends PGobject implements PGBinaryObject {
 
   @Override
   public void toBytes(byte[] bytes, int offset) {
-    if (this.bytes != null) {
-      System.arraycopy(this.bytes, 0, bytes, offset, this.bytes.length);
+    final byte @Nullable [] currentBytes = this.bytes;
+    if (currentBytes != null) {
+      System.arraycopy(currentBytes, 0, bytes, offset, currentBytes.length);
     }
   }
 

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/encryption/wrapper/PgEncryptedDataHelper.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/encryption/wrapper/PgEncryptedDataHelper.java
@@ -19,6 +19,7 @@ package software.amazon.jdbc.plugin.encryption.wrapper;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * PostgreSQL-specific encrypted data handling using the EncryptedData custom type.
@@ -33,7 +34,7 @@ public class PgEncryptedDataHelper {
     ps.setObject(paramIndex, encData);
   }
 
-  public byte[] getEncryptedBytes(ResultSet rs, Object columnRef) throws SQLException {
+  public byte @Nullable [] getEncryptedBytes(ResultSet rs, Object columnRef) throws SQLException {
     Object obj;
     if (columnRef instanceof Integer) {
       obj = rs.getObject((Integer) columnRef);

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/failover2/FailoverConnectionPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/failover2/FailoverConnectionPlugin.java
@@ -33,6 +33,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import software.amazon.jdbc.AwsWrapperProperty;
 import software.amazon.jdbc.HostRole;
 import software.amazon.jdbc.HostSpec;
@@ -119,24 +120,24 @@ public class FailoverConnectionPlugin extends AbstractConnectionPlugin implement
   protected final PluginService pluginService;
   protected final Properties properties;
   protected int failoverTimeoutMsSetting;
-  protected FailoverMode failoverMode;
+  protected @Nullable FailoverMode failoverMode;
   protected boolean telemetryFailoverAdditionalTopTraceSetting;
   protected String failoverReaderHostSelectorStrategySetting;
   protected boolean closedExplicitly = false;
   protected boolean isClosed = false;
   protected final RdsUtils rdsHelper;
-  protected Throwable lastExceptionDealtWith = null;
+  protected @Nullable Throwable lastExceptionDealtWith = null;
   protected PluginManagerService pluginManagerService;
   protected boolean isInTransaction = false;
   protected RdsUrlType rdsUrlType;
   protected HostListProviderService hostListProviderService;
   protected final AuroraStaleDnsHelper staleDnsHelper;
-  protected final TelemetryCounter failoverWriterTriggeredCounter;
-  protected final TelemetryCounter failoverWriterSuccessCounter;
-  protected final TelemetryCounter failoverWriterFailedCounter;
-  protected final TelemetryCounter failoverReaderTriggeredCounter;
-  protected final TelemetryCounter failoverReaderSuccessCounter;
-  protected final TelemetryCounter failoverReaderFailedCounter;
+  protected final @Nullable TelemetryCounter failoverWriterTriggeredCounter;
+  protected final @Nullable TelemetryCounter failoverWriterSuccessCounter;
+  protected final @Nullable TelemetryCounter failoverWriterFailedCounter;
+  protected final @Nullable TelemetryCounter failoverReaderTriggeredCounter;
+  protected final @Nullable TelemetryCounter failoverReaderSuccessCounter;
+  protected final @Nullable TelemetryCounter failoverReaderFailedCounter;
   protected final boolean skipFailoverOnInterruptedThread;
 
 
@@ -148,6 +149,9 @@ public class FailoverConnectionPlugin extends AbstractConnectionPlugin implement
     this(servicesContainer, properties, new RdsUtils());
   }
 
+  // getSubscribedMethodNames() only builds a set of method-name constants and does not read any
+  // plugin state, so calling it on the partially-initialized receiver is safe here.
+  @SuppressWarnings("method.invocation")
   FailoverConnectionPlugin(
       final FullServicesContainer servicesContainer,
       final Properties properties,
@@ -166,8 +170,7 @@ public class FailoverConnectionPlugin extends AbstractConnectionPlugin implement
     this.failoverTimeoutMsSetting = FAILOVER_TIMEOUT_MS.getInteger(this.properties);
     this.telemetryFailoverAdditionalTopTraceSetting =
         TELEMETRY_FAILOVER_ADDITIONAL_TOP_TRACE.getBoolean(this.properties);
-    this.failoverReaderHostSelectorStrategySetting =
-        FAILOVER_READER_HOST_SELECTOR_STRATEGY.getString(this.properties);
+    this.failoverReaderHostSelectorStrategySetting = resolveReaderHostSelectorStrategy(this.properties);
     this.skipFailoverOnInterruptedThread = SKIP_FAILOVER_ON_INTERRUPTED_THREAD.getBoolean(this.properties);
 
     TelemetryFactory telemetryFactory = this.pluginService.getTelemetryFactory();
@@ -181,6 +184,14 @@ public class FailoverConnectionPlugin extends AbstractConnectionPlugin implement
     final HashSet<String> methods = this.getSubscribedMethodNames();
     methods.addAll(this.pluginService.getTargetDriverDialect().getNetworkBoundMethodNames(this.properties));
     this.subscribedMethods = Collections.unmodifiableSet(methods);
+  }
+
+  // FAILOVER_READER_HOST_SELECTOR_STRATEGY declares a non-null default ("random"), so getString never
+  // returns null here. The setting stays @NonNull because PluginService.getHostSpecByStrategy requires a
+  // non-null strategy name.
+  @SuppressWarnings("return")
+  private static String resolveReaderHostSelectorStrategy(final Properties properties) {
+    return FAILOVER_READER_HOST_SELECTOR_STRATEGY.getString(properties);
   }
 
   protected @NonNull HashSet<String> getSubscribedMethodNames() {
@@ -207,6 +218,11 @@ public class FailoverConnectionPlugin extends AbstractConnectionPlugin implement
     return subscribedMethods;
   }
 
+  // The `return result` at the end is only reached when jdbcMethodFunc.call() succeeded; the exception
+  // handlers (dealWithIllegalStateException/dealWithOriginalException) always throw. The checker cannot
+  // see that guarantee, so the possibly-null `result` return is suppressed here. This mirrors
+  // AbstractConnectionPlugin.execute, which returns jdbcMethodFunc.call() directly (also possibly null).
+  @SuppressWarnings("return")
   @Override
   public <T, E extends Exception> T execute(
       final Class<T> resultClass,
@@ -214,7 +230,7 @@ public class FailoverConnectionPlugin extends AbstractConnectionPlugin implement
       final Object methodInvokeOn,
       final String methodName,
       final JdbcCallable<T, E> jdbcMethodFunc,
-      final Object[] jdbcMethodArgs)
+      final @Nullable Object[] jdbcMethodArgs)
       throws E {
 
     try {
@@ -310,11 +326,11 @@ public class FailoverConnectionPlugin extends AbstractConnectionPlugin implement
   }
 
   protected <E extends Exception> void dealWithOriginalException(
-      final Throwable originalException,
-      final Throwable wrapperException,
+      final @Nullable Throwable originalException,
+      final @Nullable Throwable wrapperException,
       final Class<E> exceptionClass) throws E {
 
-    Throwable exceptionToThrow = wrapperException;
+    @Nullable Throwable exceptionToThrow = wrapperException;
     if (originalException != null) {
       LOGGER.finer(() -> Messages.get("Failover.detectedException", new Object[]{originalException.getMessage()}));
       this.servicesContainer.getImportantEventService().registerEvent(
@@ -341,6 +357,12 @@ public class FailoverConnectionPlugin extends AbstractConnectionPlugin implement
 
     if (exceptionToThrow instanceof Error) {
       throw (Error) exceptionToThrow;
+    }
+
+    if (exceptionToThrow == null) {
+      // Unreachable on current call paths: callers always supply a non-null original or wrapper
+      // exception, so exceptionToThrow is non-null here. Guard added for null-safety only.
+      return;
     }
 
     throw WrapperUtils.wrapExceptionIfNeeded(exceptionClass, exceptionToThrow);
@@ -701,7 +723,12 @@ public class FailoverConnectionPlugin extends AbstractConnectionPlugin implement
       if (this.failoverWriterFailedCounter != null) {
         this.failoverWriterFailedCounter.inc();
       }
-      throw new FailoverFailedSQLException(ex.getMessage());
+      // Throwable.getMessage() is nullable. The timeout raised by RetryUtil always carries a
+      // message, so the fallback below is unreachable on current paths.
+      final String timeoutMessage = ex.getMessage();
+      throw new FailoverFailedSQLException(timeoutMessage != null
+          ? timeoutMessage
+          : Messages.get("Failover.unableToConnectToWriter"));
     } catch (Exception ex) {
       if (telemetryContext != null) {
         telemetryContext.setSuccess(false);
@@ -909,7 +936,11 @@ public class FailoverConnectionPlugin extends AbstractConnectionPlugin implement
     this.staleDnsHelper.notifyNodeListChanged(changes);
   }
 
+  // Checker Framework: snapshot values are intentionally nullable, but the StateSnapshotProvider contract
+  // types them as Pair<String, Object> (non-null Object). Widening that interface is out of scope, so the
+  // nullable value inference is suppressed locally.
   @Override
+  @SuppressWarnings("type.arguments.not.inferred")
   public List<Pair<String, Object>> getSnapshotState() {
     List<Pair<String, Object>> state = new ArrayList<>();
     PropertyUtils.addSnapshotState(state, "properties", this.properties);

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/AutoReadWriteSplittingPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/AutoReadWriteSplittingPlugin.java
@@ -45,7 +45,7 @@ public class AutoReadWriteSplittingPlugin extends ReadWriteSplittingPlugin {
   /** Builds the SQL-driven (prepare-time) routing assembly with a sticky reader. */
   protected static RwSplitHelpers auto(final Properties props) {
     final TopologyRoleClassifier roleClassifier = new TopologyRoleClassifier();
-    final String strategy = READER_HOST_SELECTOR_STRATEGY.getString(props);
+    final String strategy = readerHostSelectorStrategy(props);
     final boolean verifyRole = VERIFY_INITIAL_CONNECTION_ROLE.getBoolean(props);
 
     final TopologyWriterResolver writerResolver = new TopologyWriterResolver();

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/EndpointHostSpecs.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/EndpointHostSpecs.java
@@ -16,11 +16,13 @@
 
 package software.amazon.jdbc.plugin.readwritesplitting;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
 import software.amazon.jdbc.HostRole;
 import software.amazon.jdbc.HostSpec;
 import software.amazon.jdbc.HostSpecBuilder;
 import software.amazon.jdbc.hostavailability.HostAvailability;
 import software.amazon.jdbc.hostlistprovider.HostListProviderService;
+import software.amazon.jdbc.util.Messages;
 
 /**
  * Builds a {@link HostSpec} from a configured endpoint string (parsing an optional {@code :port}),
@@ -31,10 +33,27 @@ public final class EndpointHostSpecs {
   private EndpointHostSpecs() {
   }
 
+  /**
+   * Builds a {@link HostSpec} for the given endpoint.
+   *
+   * @param hostListProviderService the host list provider service, established by
+   *                                {@code initHostProvider}; must not be {@code null}
+   * @param endpoint                the configured endpoint, optionally including {@code :port}
+   * @param role                    the role to assign to the resulting host
+   * @return the host specification for the endpoint
+   * @throws IllegalStateException if the host list provider service has not been established yet
+   */
   public static HostSpec create(
-      final HostListProviderService hostListProviderService,
+      final @Nullable HostListProviderService hostListProviderService,
       final String endpoint,
       final HostRole role) {
+
+    if (hostListProviderService == null) {
+      // Previously this dereferenced null; fail with an explicit message instead. The service is
+      // established by initHostProvider before any read/write splitting routing happens.
+      throw new IllegalStateException(Messages.get(
+          "EndpointHostSpecs.missingHostListProviderService", new Object[] {endpoint}));
+    }
 
     final String trimmed = endpoint.trim();
 

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/GdbReadWriteSplittingPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/GdbReadWriteSplittingPlugin.java
@@ -66,7 +66,7 @@ public class GdbReadWriteSplittingPlugin extends ReadWriteSplittingPlugin {
       final software.amazon.jdbc.plugin.readwritesplitting.signal.RoutingSignal routingSignal,
       final software.amazon.jdbc.plugin.readwritesplitting.gate.SwitchGate switchGate) {
     final TopologyRoleClassifier roleClassifier = new TopologyRoleClassifier();
-    final String strategy = READER_HOST_SELECTOR_STRATEGY.getString(props);
+    final String strategy = readerHostSelectorStrategy(props);
     final boolean verifyRole = VERIFY_INITIAL_CONNECTION_ROLE.getBoolean(props);
     final GdbSettings settings = new GdbSettings(props);
 

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/GdbSettings.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/GdbSettings.java
@@ -144,11 +144,12 @@ public class GdbSettings {
   }
 
   public boolean isInAccessibleRegion(final HostSpec host) {
-    if (this.accessibleRegions == null) {
+    final Set<String> regions = this.accessibleRegions;
+    if (regions == null) {
       return true;
     }
     final String region = this.rdsHelper.getRdsRegion(host.getHost());
-    return region != null && this.accessibleRegions.contains(region.toLowerCase(Locale.ROOT));
+    return region != null && regions.contains(region.toLowerCase(Locale.ROOT));
   }
 
   public boolean isInHomeRegion(final HostSpec host) {
@@ -157,6 +158,11 @@ public class GdbSettings {
   }
 
   /** Snapshot fragment fields shared by GDB helpers. */
+  // Checker Framework: snapshot values are intentionally nullable, but the
+  // StateSnapshotProvider contract types them as Pair<String, Object> (non-null Object).
+  // Fixing this properly means widening that interface to Pair<String, @Nullable Object>
+  // across all ~25 implementers - out of scope for this change. Suppress locally.
+  @SuppressWarnings("type.arguments.not.inferred")
   public void addSnapshotState(final List<software.amazon.jdbc.util.Pair<String, Object>> state) {
     state.add(software.amazon.jdbc.util.Pair.create("homeRegion", this.homeRegion));
     state.add(software.amazon.jdbc.util.Pair.create("restrictWriterToHomeRegion", this.restrictWriterToHomeRegion));

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/ReadWriteSplittingPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/ReadWriteSplittingPlugin.java
@@ -65,10 +65,18 @@ public class ReadWriteSplittingPlugin extends UnifiedReadWriteSplittingPlugin {
     super(pluginService, properties, helpers);
   }
 
+  // READER_HOST_SELECTOR_STRATEGY declares a non-null default ("random"), so getString never
+  // returns null here. The value stays @NonNull because PluginService.getHostSpecByStrategy and
+  // PluginService.acceptsStrategy require a non-null strategy name.
+  @SuppressWarnings("return")
+  protected static String readerHostSelectorStrategy(final Properties props) {
+    return READER_HOST_SELECTOR_STRATEGY.getString(props);
+  }
+
   /** Builds the topology-aware, {@code setReadOnly}-driven, sticky-reader assembly. */
   protected static RwSplitHelpers topology(final Properties props) {
     final TopologyRoleClassifier roleClassifier = new TopologyRoleClassifier();
-    final String strategy = READER_HOST_SELECTOR_STRATEGY.getString(props);
+    final String strategy = readerHostSelectorStrategy(props);
     final boolean verifyRole = VERIFY_INITIAL_CONNECTION_ROLE.getBoolean(props);
 
     final TopologyWriterResolver writerResolver = new TopologyWriterResolver();

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/RwSplitHelpers.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/RwSplitHelpers.java
@@ -46,17 +46,27 @@ public class RwSplitHelpers {
   public final ConnectionUpdatePolicy connectionUpdatePolicy;
   private final List<SnapshotContributor> snapshotContributors;
 
-  private RwSplitHelpers(final Builder b) {
-    this.roleClassifier = b.roleClassifier;
-    this.routingSignal = b.routingSignal;
-    this.switchGate = b.switchGate;
-    this.topologyRefresher = b.topologyRefresher;
-    this.writerResolver = b.writerResolver;
-    this.readerResolver = b.readerResolver;
-    this.cachePolicy = b.cachePolicy;
-    this.initialConnectionHandler = b.initialConnectionHandler;
-    this.connectionUpdatePolicy = b.connectionUpdatePolicy;
-    this.snapshotContributors = b.snapshotContributors;
+  private RwSplitHelpers(
+      final RoleClassifier roleClassifier,
+      final RoutingSignal routingSignal,
+      final SwitchGate switchGate,
+      final TopologyRefresher topologyRefresher,
+      final WriterResolver writerResolver,
+      final ReaderResolver readerResolver,
+      final ConnectionCachePolicy cachePolicy,
+      final InitialConnectionHandler initialConnectionHandler,
+      final ConnectionUpdatePolicy connectionUpdatePolicy,
+      final List<SnapshotContributor> snapshotContributors) {
+    this.roleClassifier = roleClassifier;
+    this.routingSignal = routingSignal;
+    this.switchGate = switchGate;
+    this.topologyRefresher = topologyRefresher;
+    this.writerResolver = writerResolver;
+    this.readerResolver = readerResolver;
+    this.cachePolicy = cachePolicy;
+    this.initialConnectionHandler = initialConnectionHandler;
+    this.connectionUpdatePolicy = connectionUpdatePolicy;
+    this.snapshotContributors = snapshotContributors;
   }
 
   public List<SnapshotContributor> snapshotContributors() {
@@ -133,13 +143,24 @@ public class RwSplitHelpers {
     }
 
     public RwSplitHelpers build() {
+      final RoleClassifier roleClassifier = this.roleClassifier;
+      final RoutingSignal routingSignal = this.routingSignal;
+      final SwitchGate switchGate = this.switchGate;
+      final TopologyRefresher topologyRefresher = this.topologyRefresher;
+      final WriterResolver writerResolver = this.writerResolver;
+      final ReaderResolver readerResolver = this.readerResolver;
+      final ConnectionCachePolicy cachePolicy = this.cachePolicy;
+      final InitialConnectionHandler initialConnectionHandler = this.initialConnectionHandler;
+      final ConnectionUpdatePolicy connectionUpdatePolicy = this.connectionUpdatePolicy;
       if (roleClassifier == null || routingSignal == null || switchGate == null
           || topologyRefresher == null || writerResolver == null || readerResolver == null
           || cachePolicy == null || initialConnectionHandler == null
           || connectionUpdatePolicy == null) {
         throw new IllegalStateException("All read/write splitting helpers must be provided.");
       }
-      return new RwSplitHelpers(this);
+      return new RwSplitHelpers(roleClassifier, routingSignal, switchGate, topologyRefresher,
+          writerResolver, readerResolver, cachePolicy, initialConnectionHandler,
+          connectionUpdatePolicy, this.snapshotContributors);
     }
   }
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/RwSplitSnapshots.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/RwSplitSnapshots.java
@@ -18,6 +18,7 @@ package software.amazon.jdbc.plugin.readwritesplitting;
 
 import java.util.ArrayList;
 import java.util.List;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import software.amazon.jdbc.HostRole;
 import software.amazon.jdbc.util.Pair;
 
@@ -37,11 +38,16 @@ public final class RwSplitSnapshots {
   }
 
   /** Fragment exposing the endpoint (Simple) configuration. */
+  // Checker Framework: snapshot values are intentionally nullable, but the
+  // StateSnapshotProvider contract types them as Pair<String, Object> (non-null Object).
+  // Fixing this properly means widening that interface to Pair<String, @Nullable Object>
+  // across all ~25 implementers - out of scope for this change. Suppress locally.
+  @SuppressWarnings("type.arguments.not.inferred")
   public static SnapshotContributor endpoint(
       final boolean verifyNewConnections,
       final String writeEndpoint,
       final String readEndpoint,
-      final HostRole verifyOpenedConnectionType,
+      final @Nullable HostRole verifyOpenedConnectionType,
       final int retryIntervalMs,
       final long retryTimeoutMs) {
     return () -> {

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/UnifiedReadWriteSplittingPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/UnifiedReadWriteSplittingPlugin.java
@@ -269,7 +269,7 @@ public abstract class UnifiedReadWriteSplittingPlugin extends AbstractConnection
       final Object methodInvokeOn,
       final String methodName,
       final JdbcCallable<T, E> jdbcMethodFunc,
-      final Object[] args)
+      final @Nullable Object[] args)
       throws E {
     final Connection conn = WrapperUtils.getConnectionFromSqlObject(methodInvokeOn);
     if (conn != null && conn != this.pluginService.getCurrentConnection()) {
@@ -280,11 +280,14 @@ public abstract class UnifiedReadWriteSplittingPlugin extends AbstractConnection
 
     if (JdbcMethod.CONNECTION_CLEARWARNINGS.methodName.equals(methodName)) {
       try {
-        if (this.writerConnection != null && !this.writerConnection.isClosed()) {
-          this.writerConnection.clearWarnings();
+        final Connection writerConn = this.writerConnection;
+        if (writerConn != null && !writerConn.isClosed()) {
+          writerConn.clearWarnings();
         }
-        if (this.readerCacheItem != null && this.isConnectionUsable(this.readerCacheItem.get())) {
-          this.readerCacheItem.get().clearWarnings();
+        final CacheItem<Connection> readerItem = this.readerCacheItem;
+        final Connection readerConn = readerItem == null ? null : readerItem.get();
+        if (readerConn != null && this.isConnectionUsable(readerConn)) {
+          readerConn.clearWarnings();
         }
       } catch (final SQLException e) {
         throw WrapperUtils.wrapExceptionIfNeeded(exceptionClass, e);
@@ -526,16 +529,22 @@ public abstract class UnifiedReadWriteSplittingPlugin extends AbstractConnection
     }
 
     this.inReadWriteSplit = true;
-    if (!this.isConnectionUsable(this.writerConnection)) {
+    final Connection cachedWriter = this.writerConnection;
+    // The cached writer host is always recorded together with the cached writer connection (see
+    // bindWriter), so a usable cached writer connection implies a non-null cached writer host.
+    final HostSpec cachedWriterHost = this.writerHostSpec;
+    if (cachedWriter == null || cachedWriterHost == null || !this.isConnectionUsable(cachedWriter)) {
       final WriterResolution wr = this.helpers.writerResolver.resolveWriter(this);
-      if (wr.isConnected() && wr.getConnection() != null && wr.getHostSpec() != null) {
+      final Connection resolvedWriter = wr.getConnection();
+      final HostSpec resolvedWriterHost = wr.getHostSpec();
+      if (wr.isConnected() && resolvedWriter != null && resolvedWriterHost != null) {
         this.markWriterFromPool(Boolean.TRUE.equals(this.pluginService.isPooledConnection()));
-        this.bindWriter(wr.getConnection(), wr.getHostSpec());
-        this.switchCurrentConnectionTo(wr.getConnection(), wr.getHostSpec());
+        this.bindWriter(resolvedWriter, resolvedWriterHost);
+        this.switchCurrentConnectionTo(resolvedWriter, resolvedWriterHost);
       }
       // WriterResolution.STAY (e.g. Global Write Forwarding): remain on the current connection.
     } else {
-      this.switchCurrentConnectionTo(this.writerConnection, this.writerHostSpec);
+      this.switchCurrentConnectionTo(cachedWriter, cachedWriterHost);
     }
 
     if (this.isReaderConnFromInternalPool) {
@@ -559,22 +568,25 @@ public abstract class UnifiedReadWriteSplittingPlugin extends AbstractConnection
     this.helpers.readerResolver.closeStaleReaderIfNecessary(this);
 
     this.inReadWriteSplit = true;
-    if (this.readerCacheItem == null || !this.isConnectionUsable(this.readerCacheItem.get())) {
+    final CacheItem<Connection> cachedReaderItem = this.readerCacheItem;
+    final Connection cachedReader = cachedReaderItem == null ? null : cachedReaderItem.get();
+    // The cached reader host is always recorded together with the cached reader connection (see
+    // bindReader), so a usable cached reader connection implies a non-null cached reader host.
+    final HostSpec cachedReaderHost = this.readerHostSpec;
+    if (cachedReader == null || cachedReaderHost == null || !this.isConnectionUsable(cachedReader)) {
       this.helpers.readerResolver.switchToReader(this);
     } else {
       try {
-        this.switchCurrentConnectionTo(this.readerCacheItem.get(), this.readerHostSpec);
-        final HostSpec readerHost = this.readerHostSpec;
+        this.switchCurrentConnectionTo(cachedReader, cachedReaderHost);
         LOGGER.finer(() -> Messages.get("ReadWriteSplittingPlugin.switchedFromWriterToReader",
-            new Object[] {readerHost == null ? "" : readerHost.getHostAndPort()}));
+            new Object[] {cachedReaderHost.getHostAndPort()}));
       } catch (final SQLException e) {
-        final HostSpec readerHost = this.readerHostSpec;
         if (e.getMessage() != null) {
           LOGGER.warning(() -> Messages.get("ReadWriteSplittingPlugin.errorSwitchingToCachedReaderWithCause",
-              new Object[] {readerHost == null ? "" : readerHost.getHostAndPort(), e.getMessage()}));
+              new Object[] {cachedReaderHost.getHostAndPort(), e.getMessage()}));
         } else {
           LOGGER.warning(() -> Messages.get("ReadWriteSplittingPlugin.errorSwitchingToCachedReader",
-              new Object[] {readerHost == null ? "" : readerHost.getHostAndPort()}));
+              new Object[] {cachedReaderHost.getHostAndPort()}));
         }
         this.closeReaderConnectionIfIdle();
         this.helpers.readerResolver.switchToReader(this);
@@ -738,11 +750,12 @@ public abstract class UnifiedReadWriteSplittingPlugin extends AbstractConnection
 
   @Override
   public void closeReaderConnectionIfIdle() {
-    if (this.readerCacheItem == null) {
+    final CacheItem<Connection> readerItem = this.readerCacheItem;
+    if (readerItem == null) {
       return;
     }
     final Connection currentConnection = this.pluginService.getCurrentConnection();
-    final Connection readerConnection = this.readerCacheItem.get(true);
+    final Connection readerConnection = readerItem.get(true);
     if (readerConnection != null && readerConnection != currentConnection) {
       try {
         if (!readerConnection.isClosed()) {
@@ -758,10 +771,11 @@ public abstract class UnifiedReadWriteSplittingPlugin extends AbstractConnection
   @Override
   public void closeWriterConnectionIfIdle() {
     final Connection currentConnection = this.pluginService.getCurrentConnection();
-    if (this.writerConnection != null && this.writerConnection != currentConnection) {
+    final Connection writerConn = this.writerConnection;
+    if (writerConn != null && writerConn != currentConnection) {
       try {
-        if (!this.writerConnection.isClosed()) {
-          this.writerConnection.close();
+        if (!writerConn.isClosed()) {
+          writerConn.close();
         }
       } catch (final SQLException e) {
         // Do nothing.
@@ -811,7 +825,12 @@ public abstract class UnifiedReadWriteSplittingPlugin extends AbstractConnection
         logMessage, SqlState.CONNECTION_UNABLE_TO_CONNECT.getState(), cause);
   }
 
+  // Checker Framework: snapshot values are intentionally nullable, but the
+  // StateSnapshotProvider contract types them as Pair<String, Object> (non-null Object).
+  // Fixing this properly means widening that interface to Pair<String, @Nullable Object>
+  // across all ~25 implementers - out of scope for this change. Suppress locally.
   @Override
+  @SuppressWarnings("type.arguments.not.inferred")
   public List<Pair<String, Object>> getSnapshotState() {
     final List<Pair<String, Object>> state = new ArrayList<>();
     PropertyUtils.addSnapshotState(state, "properties", this.properties);

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/handler/VerifyRoleOnConnect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/handler/VerifyRoleOnConnect.java
@@ -25,6 +25,7 @@ import software.amazon.jdbc.HostRole;
 import software.amazon.jdbc.HostSpec;
 import software.amazon.jdbc.JdbcCallable;
 import software.amazon.jdbc.hostlistprovider.HostListProviderService;
+import software.amazon.jdbc.plugin.readwritesplitting.ReadWriteSplittingSQLException;
 import software.amazon.jdbc.plugin.readwritesplitting.RwSplitContext;
 import software.amazon.jdbc.util.Messages;
 
@@ -55,7 +56,11 @@ public class VerifyRoleOnConnect implements InitialConnectionHandler {
       final @NonNull JdbcCallable<Connection, SQLException> connectFunc)
       throws SQLException {
 
-    if (!ctx.pluginService().acceptsStrategy(hostSpec.getRole(), this.readerSelectorStrategy)) {
+    // A host without a role cannot be matched against a host-selector strategy, so it is treated
+    // as "strategy not accepted" (same handling as in AuroraInitialConnectionStrategyPlugin).
+    final HostRole hostRole = hostSpec.getRole();
+    if (hostRole == null
+        || !ctx.pluginService().acceptsStrategy(hostRole, this.readerSelectorStrategy)) {
       throw new UnsupportedOperationException(
           Messages.get("ReadWriteSplittingPlugin.unsupportedHostSpecSelectorStrategy",
               new Object[] {this.readerSelectorStrategy}));
@@ -76,8 +81,11 @@ public class VerifyRoleOnConnect implements InitialConnectionHandler {
 
     final HostRole currentRole = ctx.pluginService().getHostRole(currentConnection);
     if (currentRole == null || HostRole.UNKNOWN.equals(currentRole)) {
-      ctx.logAndThrow(Messages.get("ReadWriteSplittingPlugin.errorVerifyingInitialHostSpecRole"));
-      return null;
+      final String message = Messages.get("ReadWriteSplittingPlugin.errorVerifyingInitialHostSpecRole");
+      ctx.logAndThrow(message);
+      // logAndThrow always throws; this statement is unreachable and only exists so the method has
+      // no null return path.
+      throw new ReadWriteSplittingSQLException(message);
     }
 
     final HostSpec currentHost = ctx.pluginService().getInitialConnectionHostSpec();

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/refresher/EndpointWriterHostRefresher.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/refresher/EndpointWriterHostRefresher.java
@@ -17,6 +17,7 @@
 package software.amazon.jdbc.plugin.readwritesplitting.refresher;
 
 import software.amazon.jdbc.HostRole;
+import software.amazon.jdbc.hostlistprovider.HostListProviderService;
 import software.amazon.jdbc.plugin.readwritesplitting.EndpointHostSpecs;
 import software.amazon.jdbc.plugin.readwritesplitting.RwSplitContext;
 
@@ -36,9 +37,10 @@ public class EndpointWriterHostRefresher implements TopologyRefresher {
 
   @Override
   public void refresh(final RwSplitContext ctx) {
-    if (ctx.writerHostSpec() == null && ctx.hostListProviderService() != null) {
+    final HostListProviderService hostListProviderService = ctx.hostListProviderService();
+    if (ctx.writerHostSpec() == null && hostListProviderService != null) {
       ctx.setWriterHostSpec(
-          EndpointHostSpecs.create(ctx.hostListProviderService(), this.writeEndpoint, HostRole.WRITER));
+          EndpointHostSpecs.create(hostListProviderService, this.writeEndpoint, HostRole.WRITER));
     }
   }
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/resolver/TopologyReaderResolver.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/resolver/TopologyReaderResolver.java
@@ -62,10 +62,12 @@ public class TopologyReaderResolver implements ReaderResolver {
     if (hosts.size() == 1) {
       if (!ctx.isConnectionUsable(ctx.writerConnection())) {
         final WriterResolution wr = this.writerFallback.resolveWriter(ctx);
-        if (wr.isConnected() && wr.getConnection() != null && wr.getHostSpec() != null) {
+        final Connection resolvedWriter = wr.getConnection();
+        final HostSpec resolvedWriterHost = wr.getHostSpec();
+        if (wr.isConnected() && resolvedWriter != null && resolvedWriterHost != null) {
           ctx.markWriterFromPool(Boolean.TRUE.equals(ctx.pluginService().isPooledConnection()));
-          ctx.bindWriter(wr.getConnection(), wr.getHostSpec());
-          ctx.switchCurrentConnectionTo(wr.getConnection(), wr.getHostSpec());
+          ctx.bindWriter(resolvedWriter, resolvedWriterHost);
+          ctx.switchCurrentConnectionTo(resolvedWriter, resolvedWriterHost);
         }
       }
       final HostSpec writerHost = ctx.writerHostSpec();

--- a/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/PgTargetDriverDialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/PgTargetDriverDialect.java
@@ -220,7 +220,8 @@ public class PgTargetDriverDialect extends GenericTargetDriverDialect {
   }
 
   @Override
-  public byte[] getEncryptedBytes(@NonNull ResultSet rs, Object columnRef) throws SQLException {
+  public byte @Nullable [] getEncryptedBytes(@NonNull ResultSet rs, Object columnRef)
+      throws SQLException {
     return getPgEncryptedDataHelper().getEncryptedBytes(rs, columnRef);
   }
 

--- a/wrapper/src/main/java/software/amazon/jdbc/wrapper/CallableStatementWrapper.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/wrapper/CallableStatementWrapper.java
@@ -99,13 +99,16 @@ public class CallableStatementWrapper implements CallableStatement, Rebindable {
 
   @Override
   public void rebind(final Connection newConnection) throws SQLException {
-    if (this.repreparer == null || this.recorder == null) {
+    // Capture the optional collaborators once so the null check holds across the calls below.
+    final PreparedStatementWrapper.@Nullable Repreparer currentRepreparer = this.repreparer;
+    final @Nullable PreparedStatementRecorder currentRecorder = this.recorder;
+    if (currentRepreparer == null || currentRecorder == null) {
       throw new SQLException(Messages.get("PreparedStatementWrapper.notRebindable"));
     }
-    final PreparedStatement old = this.recorder.getTarget();
-    final PreparedStatement fresh = this.repreparer.reprepare(newConnection);
+    final PreparedStatement old = currentRecorder.getTarget();
+    final PreparedStatement fresh = currentRepreparer.reprepare(newConnection);
     try {
-      this.recorder.replay(fresh);
+      currentRecorder.replay(fresh);
     } catch (final SQLException e) {
       try {
         fresh.close();
@@ -114,7 +117,7 @@ public class CallableStatementWrapper implements CallableStatement, Rebindable {
       }
       throw e;
     }
-    this.recorder.setTarget(fresh);
+    currentRecorder.setTarget(fresh);
     try {
       old.close();
     } catch (final SQLException e) {

--- a/wrapper/src/main/java/software/amazon/jdbc/wrapper/PreparedStatementRecorder.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/wrapper/PreparedStatementRecorder.java
@@ -98,6 +98,10 @@ public class PreparedStatementRecorder implements InvocationHandler {
     invokeAll(this.parameterOps, fresh);
   }
 
+  // Method.invoke types its varargs argument array (arg1) as non-null, but a recorded no-argument
+  // invocation legitimately carries a null array (which reflection accepts as "no arguments").
+  // Passing the recorded array through unchanged replays exactly what was recorded.
+  @SuppressWarnings("argument")
   private static void invokeAll(final List<Recorded> ops, final PreparedStatement fresh) throws SQLException {
     for (final Recorded op : ops) {
       try {
@@ -115,6 +119,12 @@ public class PreparedStatementRecorder implements InvocationHandler {
   }
 
   @Override
+  // The JDK stub declares a @NonNull return for InvocationHandler.invoke, but a void or
+  // null-returning target method legitimately produces null here.
+  @SuppressWarnings({"override.return",
+      // Method.invoke types its varargs argument array (arg1) as non-null; a proxied no-argument
+      // method is invoked with a null array, which reflection accepts as "no arguments".
+      "argument"})
   public @Nullable Object invoke(final Object proxy, final Method method, final Object @Nullable [] args)
       throws Throwable {
     final String name = method.getName();
@@ -131,11 +141,15 @@ public class PreparedStatementRecorder implements InvocationHandler {
         break;
     }
 
-    final Object result;
+    final @Nullable Object result;
     try {
       result = method.invoke(this.target, args);
     } catch (final InvocationTargetException e) {
-      throw e.getCause();
+      // Unwrap the target exception so callers see the driver's exception, exactly as before. A
+      // missing cause (never produced by reflection here) would previously have thrown a
+      // NullPointerException; rethrow the wrapper itself instead of throwing null.
+      final Throwable cause = e.getCause();
+      throw cause == null ? e : cause;
     }
 
     if (STATEMENT_SETTING_METHODS.contains(name)) {

--- a/wrapper/src/main/java/software/amazon/jdbc/wrapper/PreparedStatementWrapper.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/wrapper/PreparedStatementWrapper.java
@@ -105,14 +105,17 @@ public class PreparedStatementWrapper implements PreparedStatement, Rebindable {
 
   @Override
   public void rebind(final Connection newConnection) throws SQLException {
-    if (this.repreparer == null || this.recorder == null) {
+    // Capture the optional collaborators once so the null check holds across the calls below.
+    final @Nullable Repreparer currentRepreparer = this.repreparer;
+    final @Nullable PreparedStatementRecorder currentRecorder = this.recorder;
+    if (currentRepreparer == null || currentRecorder == null) {
       throw new SQLException(Messages.get("PreparedStatementWrapper.notRebindable"));
     }
-    final PreparedStatement old = this.recorder.getTarget();
-    final PreparedStatement fresh = this.repreparer.reprepare(newConnection);
+    final PreparedStatement old = currentRecorder.getTarget();
+    final PreparedStatement fresh = currentRepreparer.reprepare(newConnection);
     try {
       // Replay the recorded configuration and parameters onto the freshly-prepared statement.
-      this.recorder.replay(fresh);
+      currentRecorder.replay(fresh);
     } catch (final SQLException e) {
       // Keep the original target intact on any replay failure.
       try {
@@ -124,7 +127,7 @@ public class PreparedStatementWrapper implements PreparedStatement, Rebindable {
     }
     // The wrapper's target is the stable recording proxy; point it at the new statement. Terminal
     // execute lambdas delegate through the proxy, so they run against 'fresh' from now on.
-    this.recorder.setTarget(fresh);
+    currentRecorder.setTarget(fresh);
     try {
       old.close();
     } catch (final SQLException e) {

--- a/wrapper/src/main/resources/aws_advanced_jdbc_wrapper_messages.properties
+++ b/wrapper/src/main/resources/aws_advanced_jdbc_wrapper_messages.properties
@@ -246,6 +246,8 @@ Driver.openingConnection=Opening connection to {0}
 
 DataSource.failedToSetProperty=Failed to set property ''{0}'' on target datasource ''{1}''.
 
+EndpointHostSpecs.missingHostListProviderService=Unable to build a host specification for endpoint ''{0}'' because the host list provider service has not been established yet.
+
 ExecutionTimeConnectionPlugin.executionTime=Executed {0} in {1} nanos.
 
 ExpirationCache.exceptionWhileRemovingEntry=An exception occurred while removing entry with key ''{0}'' and value ''{1}'': ''{2}''.

--- a/wrapper/src/main/resources/aws_advanced_jdbc_wrapper_messages.properties
+++ b/wrapper/src/main/resources/aws_advanced_jdbc_wrapper_messages.properties
@@ -37,6 +37,7 @@ AuthenticationToken.rdsSdkNotInClasspath=Required dependency 'AWS Java SDK RDS v
 AwsCredentialsManager.signinModuleNotInClasspath=The configured AWS profile authenticates via a 'login_session' entry, but the required dependency 'software.amazon.awssdk:signin' is not on the classpath. Add it to use 'allowAwsLoginSession=true'.
 AwsCredentialsManager.loginSessionRegionRequired=Unable to determine the region required to resolve credentials for a 'login_session' AWS profile. Please set the connection region (for example, via the 'iamRegion' property for IAM authentication).
 AwsCredentialsManager.loginSessionProviderFailed=Failed to build the AWS Sign-In (login_session) credentials provider: ''{0}''
+AwsCredentialsManager.loginSessionProviderNull=Failed to build the AWS Sign-In (login_session) credentials provider: the provider builder returned no provider.
 
 RdsHostListProvider.clusterInstanceHostPatternNotSupportedForRDSProxy=An RDS Proxy url can''t be used as the 'clusterInstanceHostPattern' configuration setting.
 RdsHostListProvider.clusterInstanceHostPatternNotSupportedForRdsCustom=A custom RDS url can''t be used as the 'clusterInstanceHostPattern' configuration setting.

--- a/wrapper/src/main/resources/aws_advanced_jdbc_wrapper_messages.properties
+++ b/wrapper/src/main/resources/aws_advanced_jdbc_wrapper_messages.properties
@@ -850,6 +850,8 @@ EncryptionService.invalidDateLength=Invalid Date data length
 EncryptionService.invalidTimeLength=Invalid Time data length
 EncryptionService.invalidTimestampLength=Invalid Timestamp data length
 EncryptionService.unknownTypeMarker=Unknown type marker: {0}
+EncryptionService.hmacKeyNull=HMAC key cannot be null
+KeyManager.retryNoException=KMS operation failed without a recorded exception
 ConnectionContextServiceImpl.invalidMaxIdleCount=Invalid maxIdleCount value: {0}. Value must be greater than or equal to 1.
 ConnectionContextService.noSupplierRegistered=No supplier registered for context class: {0}.
 


### PR DESCRIPTION
## Summary

Completes the incremental Checker Framework `NullnessChecker` adoption and **turns it into an enforced CI gate**.

The whole `software.amazon.jdbc` tree is now checker-clean, findings are compile errors rather than warnings, and the job runs on pull requests.

## Parts 16-19: reaching zero

| Part | Scope | Findings fixed |
|---|---|---:|
| 16 | Regressions in already-adopted packages | 21 |
| 17 | `parser` + `plugin.failover2` | 20 |
| 18 | `plugin.readwritesplitting` + 10 sub-packages | 46 |
| 19 | `plugin.encryption` + 10 sub-packages | 94 |

**Part 16** is the notable one: recent feature work (XA support, `login_session` IAM auth, the prepared-statement repreparer/recorder) reintroduced 21 findings into packages that were already clean, because the checker was manual-only and warn-only. Fixed with the established patterns - capture-into-local guards, a `Throwable.getCause()` guard instead of throwing null, narrow commented suppressions for `Method.invoke` stub asymmetries, and `@Nullable HostRole role` on `ConnectionProviderManager.acceptsStrategy`/`getHostSpecByStrategy`.

**Parts 17-19** annotate the remaining families. Highlights: `@Nullable` cause params on the four custom encryption exception classes (matching `Exception(String, Throwable)`); `errorContext` maps typed `Map<String, @Nullable Object>` since the sanitizers legitimately store null; `MetadataManager.createRefreshExecutor` made `static` to remove three `method.invocation` findings without suppression; `Objects.requireNonNull` on builder fields replaced with explicit NPE throws preserving exception type, message text and check order; `execute()`'s args aligned to the `@Nullable Object[]` interface contract across the readwritesplitting family.

## Enforcement

- **`-Awarns` removed.** Findings are now compile errors and fail the build. `-Xmaxwarns` is replaced by `-Xmaxerrs 10000` so a regression reports its full extent instead of being truncated at javac's default cap of 100.
- **CI gates on pull requests.** `run-checker-framework.yml` previously ran only via `workflow_dispatch`; it now also triggers on `pull_request`, restricted to paths that can affect the result.
- **Summary logic counts `error:` as well as `warning:`**, in the workflow step and the local helper script. Without this a failing build would have reported zero findings.

Verified that the gate actually fails: injecting a null dereference into `StringUtils` produced `error: [dereference.of.nullable]` and failed the build; the probe was then reverted.

## Two things deliberately *not* done

**`-PenableCheckerFramework` is kept.** The guarded block retargets `compileJava` onto a JDK 17 toolchain with `release 11`, while the shipped artifact must remain Java 8 (the main toolchain is `JavaLanguageVersion.of(8)`). Enabling it unconditionally would silently change the published jar's bytecode target. This is a verification build, not a packaging build.

**`-AonlyDefs` is kept rather than deleted.** It is no longer a subset - the alternatives together cover the whole main source set - but dropping it also pulls *anonymous* classes into scope. The codebase widely uses the double-brace initializer idiom (`new HashMap<K, V>() {{ put(...); }}`) for enum mappings and plugin/dialect registries, and the checker rejects those `put`/`add` calls as invocations on an `@UnderInitialization` receiver: 100+ findings across ~25 files. Covering anonymous classes requires replacing that idiom first, which is left as follow-up work so this change stays reviewable. A comment in the build file records this, including the reminder that a newly added package must be added to the regex or it silently escapes the gate.

## Verification

- Checker Framework, enforcing, whole tree: **BUILD SUCCESSFUL, 0 findings, 0 crashes**.
- Full wrapper unit suite: **1306 passed, 0 failed, 81 skipped**.
- `checkstyleMain`: clean.
- Refactors preserve control flow, logging frequency, exception types and null/empty handling. Extra care in the crypto paths: the HMAC comparison, tamper-detection branch, `[HMAC:32][type:1][IV:12][ciphertext]` layout, type-marker deserialization switch, key-cache hit/miss paths, key zeroization and `finally`-block connection cleanup are unchanged. Four new message-bundle keys follow the resource-bundle convention; no literals were inlined into exceptions or logs.
