### PR TITLE
fix: strip SQL line comments in transaction detection

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/DefaultConnectionPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/DefaultConnectionPlugin.java
@@ -18,8 +18,6 @@ package software.amazon.jdbc.plugin;
 
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashSet;
@@ -28,7 +26,6 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import software.amazon.jdbc.ConnectionInfo;
@@ -299,21 +296,6 @@ public final class DefaultConnectionPlugin implements ConnectionPlugin {
   @Override
   public void notifyNodeListChanged(final Map<String, EnumSet<NodeChangeOptions>> changes) {
     // do nothing
-  }
-
-  List<String> parseMultiStatementQueries(String query) {
-    if (query == null || query.isEmpty()) {
-      return new ArrayList<>();
-    }
-
-    query = query.replaceAll("\\s+", " ");
-
-    // Check to see if string only has blank spaces.
-    if (query.trim().isEmpty()) {
-      return new ArrayList<>();
-    }
-
-    return Arrays.stream(query.split(";")).collect(Collectors.toList());
   }
 
   @Override

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/gate/TransactionAwareGate.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/gate/TransactionAwareGate.java
@@ -34,7 +34,10 @@ import software.amazon.jdbc.util.Messages;
  *   <li>an explicit {@code /*@keep* /} routing hint (when {@code honorKeepHint});</li>
  *   <li>a transaction is in progress;</li>
  *   <li>autocommit is explicitly disabled (when {@code pinOnAutoCommitOff}) — the next statement
- *       would implicitly start a transaction.</li>
+ *       would implicitly start a transaction;</li>
+ *   <li>the autocommit state cannot be read at all (when {@code pinOnAutoCommitOff}) — an unknown
+ *       state is treated like a disabled one, since the gate cannot rule out an implicit
+ *       transaction.</li>
  * </ul>
  *
  * <p>The legacy {@code setReadOnly(false)}-in-transaction throw is role-specific (it depends on
@@ -91,9 +94,15 @@ public class TransactionAwareGate implements SwitchGate {
         if (autoCommit.isPresent() && !autoCommit.get()) {
           return false;
         }
+        // An empty value means autocommit was never explicitly set, so the JDBC default (on)
+        // applies and there is no implicit transaction to protect.
       } catch (final SQLException e) {
-        // If autocommit state cannot be determined, fall back to allowing the switch.
-        return true;
+        // The autocommit state could not be read, so it is unknown whether the next statement
+        // would join an implicit transaction. Pin rather than switch: the cost is a missed routing
+        // opportunity on a connection whose session state cannot even be queried, while switching
+        // on a wrong guess can split one transaction across two physical connections.
+        LOGGER.fine(() -> Messages.get("ReadWriteSplittingPlugin.stayedOnConnectionForUnknownAutoCommit"));
+        return false;
       }
     }
 

--- a/wrapper/src/main/java/software/amazon/jdbc/util/SqlMethodAnalyzer.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/SqlMethodAnalyzer.java
@@ -83,14 +83,116 @@ public class SqlMethodAnalyzer {
   }
 
   private String getFirstSqlStatement(final String sql) {
-    List<String> statementList = parseMultiStatementQueries(sql);
+    // Comments are removed before the query is normalized and split. Both steps depend on it:
+    // parseMultiStatementQueries collapses every whitespace run (including the newline that
+    // terminates a line comment) into a single space, and a ";" inside a comment must not be
+    // treated as a statement separator.
+    List<String> statementList = parseMultiStatementQueries(stripComments(sql));
     if (statementList.isEmpty()) {
       return sql;
     }
     String statement = statementList.get(0);
     statement = statement.toUpperCase();
-    statement = statement.replaceAll("\\s*/\\*(.*?)\\*/\\s*", " ").trim();
-    return statement;
+    return statement.trim();
+  }
+
+  /**
+   * Removes SQL comments from a query so that the leading keyword of a statement can be matched
+   * reliably.
+   *
+   * <p>Line comments have to be removed before whitespace is collapsed: once the terminating
+   * newline is gone, the comment and the statement on the following line become indistinguishable,
+   * so {@code "-- note\nBEGIN"} would look like {@code "-- NOTE BEGIN"} and no longer start with
+   * {@code BEGIN}, even though the database opens a transaction for it.
+   *
+   * <p>Dialect notes: PostgreSQL treats {@code --} as a comment through the end of the line
+   * unconditionally, while MySQL requires whitespace (or a control character) after {@code --} and
+   * additionally supports {@code #} line comments. The most permissive reading is applied here
+   * ({@code --} and {@code #} always begin a comment), because failing to recognize a comment is
+   * the harmful direction: it hides a transaction-control statement from the caller. The opposite
+   * risk is benign, since every caller only compares the leading keyword of a statement, so
+   * truncating a MySQL {@code 1--2} expression or a PostgreSQL {@code #} operator cannot change the
+   * outcome.
+   *
+   * <p>Quoted sections are preserved so a comment marker inside a string literal or a quoted
+   * identifier is not mistaken for a comment. Backslash escapes and PostgreSQL dollar quoting are
+   * not interpreted; for the same reason as above, that cannot change which keyword a statement
+   * starts with. An unterminated block comment is left in place, as before.
+   *
+   * <p>Each comment is replaced by a single space so that adjacent tokens do not merge, matching
+   * the behavior of the block-comment handling this replaces.
+   */
+  private static String stripComments(final String sql) {
+    if (sql == null || sql.isEmpty()) {
+      return sql;
+    }
+
+    final int length = sql.length();
+    final StringBuilder result = new StringBuilder(length);
+    int i = 0;
+
+    while (i < length) {
+      final char c = sql.charAt(i);
+
+      if (c == '\'' || c == '"' || c == '`') {
+        final int end = skipQuoted(sql, i);
+        result.append(sql, i, end);
+        i = end;
+      } else if (c == '#' || (c == '-' && i + 1 < length && sql.charAt(i + 1) == '-')) {
+        // Line comment: drop everything up to, but not including, the line terminator. Keeping the
+        // terminator leaves a whitespace boundary between the comment and the next statement.
+        i = skipToEndOfLine(sql, i);
+        result.append(' ');
+      } else if (c == '/' && i + 1 < length && sql.charAt(i + 1) == '*') {
+        final int end = sql.indexOf("*/", i + 2);
+        if (end < 0) {
+          result.append(sql, i, length);
+          i = length;
+        } else {
+          i = end + 2;
+          result.append(' ');
+        }
+      } else {
+        result.append(c);
+        i++;
+      }
+    }
+
+    return result.toString();
+  }
+
+  /**
+   * Returns the index just past the quoted section that starts at {@code start}. A doubled quote
+   * character escapes itself. An unterminated section extends to the end of the query.
+   */
+  private static int skipQuoted(final String sql, final int start) {
+    final char quote = sql.charAt(start);
+    final int length = sql.length();
+    int i = start + 1;
+
+    while (i < length) {
+      if (sql.charAt(i) == quote) {
+        if (i + 1 < length && sql.charAt(i + 1) == quote) {
+          i += 2;
+          continue;
+        }
+        return i + 1;
+      }
+      i++;
+    }
+
+    return length;
+  }
+
+  /** Returns the index of the line terminator ending the current line, or the end of the query. */
+  private static int skipToEndOfLine(final String sql, final int start) {
+    for (int i = start; i < sql.length(); i++) {
+      final char c = sql.charAt(i);
+      if (c == '\n' || c == '\r') {
+        return i;
+      }
+    }
+    return sql.length();
   }
 
   private List<String> parseMultiStatementQueries(String query) {

--- a/wrapper/src/main/resources/aws_advanced_jdbc_wrapper_messages.properties
+++ b/wrapper/src/main/resources/aws_advanced_jdbc_wrapper_messages.properties
@@ -408,6 +408,7 @@ ReadWriteSplittingPlugin.setReaderConnection=Reader connection set to ''{0}''
 ReadWriteSplittingPlugin.setWriterConnection=Writer connection set to ''{0}''
 ReadWriteSplittingPlugin.setReadOnlyFalseInTransaction=setReadOnly(false) was called on a read-only connection inside a transaction. Please complete the transaction before calling setReadOnly(false).
 ReadWriteSplittingPlugin.stayedOnConnectionForXaTransaction=An XA transaction is active on the current connection, so the connection was not switched. Read/write splitting is skipped for the duration of the XA transaction.
+ReadWriteSplittingPlugin.stayedOnConnectionForUnknownAutoCommit=The autocommit state of the current connection could not be determined, so the connection was not switched. Read/write splitting is skipped until the session state can be read again.
 ReadWriteSplittingPlugin.switchedFromWriterToReader=Switched from a writer to a reader host. New reader host: ''{0}''
 ReadWriteSplittingPlugin.switchedFromReaderToWriter=Switched from a reader to a writer host. New writer host: ''{0}''
 ReadWriteSplittingPlugin.settingCurrentConnection=Setting the current connection to ''{0}''

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/DefaultConnectionPluginTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/DefaultConnectionPluginTest.java
@@ -33,18 +33,12 @@ import static org.mockito.Mockito.when;
 
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
-import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import software.amazon.jdbc.ConnectionInfo;
@@ -113,13 +107,6 @@ class DefaultConnectionPluginTest {
     closeable.close();
   }
 
-  @ParameterizedTest
-  @MethodSource("multiStatementQueries")
-  void testParseMultiStatementQueries(final String sql, final List<String> expected) {
-    final List<String> actual = plugin.parseMultiStatementQueries(sql);
-    assertEquals(expected, actual);
-  }
-
   @Test
   void testExecute_closeCurrentConnection() throws SQLException {
     when(this.pluginService.getCurrentConnection()).thenReturn(conn);
@@ -179,13 +166,4 @@ class DefaultConnectionPluginTest {
     verify(mockConnectionProviderManager, never()).acceptsStrategy(any(), anyString());
   }
 
-  private static Stream<Arguments> multiStatementQueries() {
-    return Stream.of(
-        Arguments.of("", new ArrayList<String>()),
-        Arguments.of(null, new ArrayList<String>()),
-        Arguments.of("  ", new ArrayList<String>()),
-        Arguments.of("some  \t  \r  \n   query;", Collections.singletonList("some query")),
-        Arguments.of("some\t\t\r\n query;query2", Arrays.asList("some query", "query2"))
-    );
-  }
 }

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/readwritesplitting/gate/TransactionAwareGateTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/readwritesplitting/gate/TransactionAwareGateTest.java
@@ -145,13 +145,25 @@ public class TransactionAwareGateTest {
   }
 
   @Test
-  void autoCommitIndeterminate_fallsBackToAllowingSwitch() throws SQLException {
+  void autoCommitIndeterminate_pins() throws SQLException {
+    // An unreadable autocommit state cannot rule out an implicit transaction, so the gate pins
+    // instead of guessing. Switching on a wrong guess would split a transaction across two
+    // physical connections.
     when(pluginService.isInTransaction()).thenReturn(false);
     when(pluginService.getCallContext()).thenReturn(callContext);
     when(pluginService.getSessionStateService()).thenReturn(sessionStateService);
     when(sessionStateService.getAutoCommit()).thenThrow(new SQLException("indeterminate"));
 
     final TransactionAwareGate gate = new TransactionAwareGate(true, true);
+    assertFalse(gate.canSwitch(ctx, TargetRole.READER));
+  }
+
+  @Test
+  void autoCommitIndeterminate_ignoredWhenNotConfigured() throws SQLException {
+    // The classic gate does not consult autocommit at all, so it must not be affected.
+    when(pluginService.isInTransaction()).thenReturn(false);
+
+    final TransactionAwareGate gate = new TransactionAwareGate();
     assertTrue(gate.canSwitch(ctx, TargetRole.READER));
   }
 

--- a/wrapper/src/test/java/software/amazon/jdbc/util/SqlMethodAnalyzerTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/util/SqlMethodAnalyzerTest.java
@@ -180,6 +180,23 @@ class SqlMethodAnalyzerTest {
         Arguments.of("Statement.executeUpdate", " /*COMMENT*/ START   /*COMMENT*/TRANSACTION;",
             true, true),
         Arguments.of("Statement.executeUpdate", " /*COMMENT*/ begin", true, true),
+        // Line comments on their own line: the database honors the statement that follows them.
+        Arguments.of("Statement.execute", "-- COMMENT\nBEGIN", true, true),
+        Arguments.of("Statement.execute", "--COMMENT\nSTART TRANSACTION;", true, true),
+        Arguments.of("Statement.execute", "-- COMMENT\r\nbegin", true, true),
+        Arguments.of("Statement.execute", "# COMMENT\nbegin", true, true),
+        Arguments.of("Statement.execute", "/*COMMENT*/ -- COMMENT\n begin", true, true),
+        Arguments.of("Statement.execute", "BEGIN -- COMMENT", true, true),
+        Arguments.of("Statement.execute", "-- COMMENT; MORE\nBEGIN", true, true),
+        // A keyword on the same line as a line comment stays commented out for the database too.
+        Arguments.of("Statement.execute", "-- COMMENT BEGIN", true, false),
+        Arguments.of("Statement.execute", "-- BEGIN\nSELECT 1", true, false),
+        // A leading line comment must not hide the SET/SHOW/USE exemption in isStatementDml.
+        Arguments.of("Statement.execute", "-- COMMENT\nset autocommit = 1", false, false),
+        Arguments.of("Statement.execute", "-- COMMENT\nSHOW TABLES", false, false),
+        Arguments.of("Statement.execute", "-- COMMENT\nSELECT 1", false, true),
+        Arguments.of("Statement.executeUpdate", "INSERT INTO test_table VALUES ('-- 1')", false,
+            true),
         Arguments.of("Statement.executeUpdate", "commit", false, false),
         Arguments.of("Statement.executeQuery", " select 1", true, false),
         Arguments.of("Statement.executeQuery", " SELECT 1", false, true),
@@ -202,6 +219,18 @@ class SqlMethodAnalyzerTest {
         Arguments.of("Statement.execute", "ROLLBACK PREPARED 'gid-1'", true),
         // "PREPARE <name> AS ..." is a prepared statement, not transaction control.
         Arguments.of("Statement.execute", "PREPARE myplan AS SELECT 1", false),
+        // Line comments on their own line: the database honors the statement that follows them.
+        Arguments.of("Statement.execute", "-- COMMENT\ncommit;", true),
+        Arguments.of("Statement.execute", "--COMMENT\nROLLBACK", true),
+        Arguments.of("Statement.execute", "-- COMMENT\r\nend", true),
+        Arguments.of("Statement.execute", "# COMMENT\nabort", true),
+        Arguments.of("Statement.execute", "/*COMMENT*/ -- COMMENT\n commit", true),
+        // A ";" inside a line comment is not a statement separator.
+        Arguments.of("Statement.execute", "-- COMMENT; MORE\nCOMMIT", true),
+        Arguments.of("Statement.execute", "-- COMMENT\nPREPARE TRANSACTION 'gid-1'", true),
+        // A keyword on the same line as a line comment stays commented out for the database too.
+        Arguments.of("Statement.execute", "-- COMMENT COMMIT", false),
+        Arguments.of("Statement.execute", "-- COMMIT\nSELECT 1", false),
         Arguments.of("Statement.execute", "select 1", false),
         Arguments.of("Statement.close", null, false),
         Arguments.of("Statement.isClosed", null, false),
@@ -217,7 +246,9 @@ class SqlMethodAnalyzerTest {
         Arguments.of("Connection.commit", null, false),
         Arguments.of("Statement.execute", " START  TRANSACTION   READ  ONLY", false),
         Arguments.of("Statement.execute", "  set  autocommit = 1 ; ", true),
-        Arguments.of("Statement.executeUpdate", "SET AUTOCOMMIT TO OFF ;  ", true)
+        Arguments.of("Statement.executeUpdate", "SET AUTOCOMMIT TO OFF ;  ", true),
+        Arguments.of("Statement.execute", "-- COMMENT\nset autocommit = 1", true),
+        Arguments.of("Statement.execute", "-- COMMENT set autocommit = 1", false)
     );
   }
 
@@ -230,7 +261,9 @@ class SqlMethodAnalyzerTest {
         Arguments.of("SET AUTOCOMMIT to 0", false),
         Arguments.of("set autoCOMMIT = on", true),
         Arguments.of("set autoCOMMIT TO trUE", true),
-        Arguments.of("  SeT  aUtOcommIT  = 1", true)
+        Arguments.of("  SeT  aUtOcommIT  = 1", true),
+        Arguments.of("-- COMMENT\nSET AUTOCOMMIT = 1 -- COMMENT", true),
+        Arguments.of("SET AUTOCOMMIT = 0 # COMMENT", false)
     );
   }
 


### PR DESCRIPTION
Three related fixes to how the wrapper decides whether a transaction is open, and to what the read/write splitting gate does with that answer.

## 1. Line comments hid transaction control from `SqlMethodAnalyzer`

`SqlMethodAnalyzer` decides whether a raw SQL statement opens or closes a transaction, which is what backs `PluginService.isInTransaction()`. It stripped `/* ... */` block comments before matching `BEGIN`, `START TRANSACTION`, `COMMIT`, `ROLLBACK`, `END`, `ABORT` and `PREPARE TRANSACTION`, but never handled `--` (or MySQL `#`) line comments.

The root cause is ordering rather than a missing pattern. `parseMultiStatementQueries()` runs first and collapses every whitespace run into a single space:

```java
query = query.replaceAll("\\s+", " ");
```

Once that has run, the newline terminating a line comment is gone and the comment is welded onto the next line. So:

```sql
-- trace-id: abc
BEGIN
```

becomes `-- TRACE-ID: ABC BEGIN`, which does not start with `BEGIN`. PostgreSQL and MySQL open a transaction here; the wrapper reported none, and `isInTransaction()` stayed `false`.

That flag is what the read/write splitting and failover plugins consult before moving to a different physical connection (`TransactionAwareGate.canSwitch()` returns `false` while a transaction is in progress). With the flag wrongly `false`, a following statement classified as read-only could be routed to another connection while the transaction stayed open and orphaned on the original one, holding any locks it had acquired until that connection was closed or evicted.

The reverse direction had the same gap: a `COMMIT`/`ROLLBACK` behind a line comment was not recognized, leaving the flag stuck at `true` and pinning the connection to the writer.

Note that a comment and a keyword on the *same* line (`-- note BEGIN`) is not affected - the engines comment out the keyword too, so reporting no transaction is correct. Only a comment on its own line diverges. Transactions driven through `setAutoCommit(false)`/`commit()`/`rollback()` are matched by method name and were never affected.

### Changes

- `SqlMethodAnalyzer.getFirstSqlStatement()` now strips comments before the query is normalized and split on `;`. Doing it first is required for the newline boundary to still exist, and it also stops a `;` inside a comment from splitting the statement.
- The block-comment regex is replaced by a small scanner that handles `--` and `#` line comments as well as `/* ... */`, replacing each comment with a single space. Quoted sections (`'`, `"`, backtick, with doubled-quote escaping) are walked so a comment marker inside a string literal or quoted identifier is preserved. An unterminated block comment is still left in place.
- `--` and `#` are treated as comment starts unconditionally. PostgreSQL always ends a line at `--`; MySQL additionally requires following whitespace and supports `#`. The permissive reading is deliberate: failing to recognize a comment hides transaction control, while over-stripping can only truncate the tail of a statement whose leading keyword has already been read. Dialect caveats and the untracked PostgreSQL dollar-quoting case are documented on the method.
- Fixes a false positive in the same code path: a leading line comment defeated the `SET `/`USE `/`SHOW ` exemption in `isStatementDml()`, so those statements flipped `isInTransaction` to `true` when autocommit was off.

## 2. `TransactionAwareGate`: pin when the autocommit state cannot be read

The gate refuses to move to another physical connection while a transaction is in progress, and (for `autoReadWriteSplitting`, via `pinOnAutoCommitOff`) while autocommit is explicitly disabled, because the next statement would join an implicit transaction. If reading the autocommit state threw, it fell back to allowing the switch:

```java
} catch (final SQLException e) {
  // If autocommit state cannot be determined, fall back to allowing the switch.
  return true;
}
```

That is the wrong default for the one input the gate cannot verify. An unknown autocommit state cannot rule out an implicit transaction, and switching on a wrong guess moves later statements to a different connection while the transaction stays open on the original one. Pinning instead costs a missed routing opportunity on a connection whose session state cannot even be queried - a bounded, recoverable cost against an unbounded correctness one.

Unchanged on purpose:

- An empty (never explicitly set) autocommit value still allows the switch. Empty means the JDBC default is in effect, so there is no implicit transaction to protect. Pinning there would disable read/write splitting for the common case.
- The classic gate (`new TransactionAwareGate()`, used by `readWriteSplitting`) does not consult autocommit at all and is unaffected. A test now covers that.

The existing `autoCommitIndeterminate_fallsBackToAllowingSwitch` test asserted the old behavior; it is renamed and inverted, since the assertion itself is the decision being changed. A `FINE` log line and a message bundle entry were added so the pinning is visible when diagnosing why splitting stopped.

## 3. Remove `DefaultConnectionPlugin.parseMultiStatementQueries()`

A package-private copy of the helper in `SqlMethodAnalyzer` with no production callers - the only reference was its own unit test. Package-private visibility also rules out external callers. Removed along with that test and the imports it needed.

Keeping a second copy of statement splitting invites the two from drifting apart, which is exactly what happened around comment handling in item 1.

## Tests

Cases added to the existing parameterized sources in `SqlMethodAnalyzerTest`:

- multi-line `--`, `#`, `\r\n` and no-space-after-dashes forms of `BEGIN`, `START TRANSACTION`, `COMMIT`, `ROLLBACK`, `END`, `ABORT`, `PREPARE TRANSACTION`
- a `;` inside a line comment, and a block comment followed by a line comment
- same-line `-- COMMENT BEGIN` and `-- COMMENT COMMIT` pinned to `false`, matching engine behavior
- the `SET`/`SHOW` false positive, and a quoted `--` inside an `INSERT`
- line-comment forms for `isStatementSettingAutoCommit` and `getAutoCommitValueFromSqlStatement`

`TransactionAwareGateTest` covers the inverted indeterminate case and the classic gate's indifference to autocommit.

Verified locally: full wrapper unit suite passes (1328 tests, 0 failures, 81 skipped - skips pre-existing), plus `checkstyleMain` and `checkstyleTest`.

Not covered: no integration test against a live PostgreSQL or MySQL asserting the engine-side transaction state. The premise that a line comment followed by `BEGIN` on the next line opens a real transaction rests on documented engine behavior.

