### PR TITLE
fix: pin connection when autocommit state is unknown

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/DefaultConnectionPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/DefaultConnectionPlugin.java
@@ -18,8 +18,6 @@ package software.amazon.jdbc.plugin;
 
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashSet;
@@ -28,7 +26,6 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import software.amazon.jdbc.ConnectionInfo;
@@ -299,21 +296,6 @@ public final class DefaultConnectionPlugin implements ConnectionPlugin {
   @Override
   public void notifyNodeListChanged(final Map<String, EnumSet<NodeChangeOptions>> changes) {
     // do nothing
-  }
-
-  List<String> parseMultiStatementQueries(String query) {
-    if (query == null || query.isEmpty()) {
-      return new ArrayList<>();
-    }
-
-    query = query.replaceAll("\\s+", " ");
-
-    // Check to see if string only has blank spaces.
-    if (query.trim().isEmpty()) {
-      return new ArrayList<>();
-    }
-
-    return Arrays.stream(query.split(";")).collect(Collectors.toList());
   }
 
   @Override

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/gate/TransactionAwareGate.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/gate/TransactionAwareGate.java
@@ -34,7 +34,10 @@ import software.amazon.jdbc.util.Messages;
  *   <li>an explicit {@code /*@keep* /} routing hint (when {@code honorKeepHint});</li>
  *   <li>a transaction is in progress;</li>
  *   <li>autocommit is explicitly disabled (when {@code pinOnAutoCommitOff}) — the next statement
- *       would implicitly start a transaction.</li>
+ *       would implicitly start a transaction;</li>
+ *   <li>the autocommit state cannot be read at all (when {@code pinOnAutoCommitOff}) — an unknown
+ *       state is treated like a disabled one, since the gate cannot rule out an implicit
+ *       transaction.</li>
  * </ul>
  *
  * <p>The legacy {@code setReadOnly(false)}-in-transaction throw is role-specific (it depends on
@@ -91,9 +94,15 @@ public class TransactionAwareGate implements SwitchGate {
         if (autoCommit.isPresent() && !autoCommit.get()) {
           return false;
         }
+        // An empty value means autocommit was never explicitly set, so the JDBC default (on)
+        // applies and there is no implicit transaction to protect.
       } catch (final SQLException e) {
-        // If autocommit state cannot be determined, fall back to allowing the switch.
-        return true;
+        // The autocommit state could not be read, so it is unknown whether the next statement
+        // would join an implicit transaction. Pin rather than switch: the cost is a missed routing
+        // opportunity on a connection whose session state cannot even be queried, while switching
+        // on a wrong guess can split one transaction across two physical connections.
+        LOGGER.fine(() -> Messages.get("ReadWriteSplittingPlugin.stayedOnConnectionForUnknownAutoCommit"));
+        return false;
       }
     }
 

--- a/wrapper/src/main/resources/aws_advanced_jdbc_wrapper_messages.properties
+++ b/wrapper/src/main/resources/aws_advanced_jdbc_wrapper_messages.properties
@@ -405,6 +405,7 @@ ReadWriteSplittingPlugin.setReaderConnection=Reader connection set to ''{0}''
 ReadWriteSplittingPlugin.setWriterConnection=Writer connection set to ''{0}''
 ReadWriteSplittingPlugin.setReadOnlyFalseInTransaction=setReadOnly(false) was called on a read-only connection inside a transaction. Please complete the transaction before calling setReadOnly(false).
 ReadWriteSplittingPlugin.stayedOnConnectionForXaTransaction=An XA transaction is active on the current connection, so the connection was not switched. Read/write splitting is skipped for the duration of the XA transaction.
+ReadWriteSplittingPlugin.stayedOnConnectionForUnknownAutoCommit=The autocommit state of the current connection could not be determined, so the connection was not switched. Read/write splitting is skipped until the session state can be read again.
 ReadWriteSplittingPlugin.switchedFromWriterToReader=Switched from a writer to a reader host. New reader host: ''{0}''
 ReadWriteSplittingPlugin.switchedFromReaderToWriter=Switched from a reader to a writer host. New writer host: ''{0}''
 ReadWriteSplittingPlugin.settingCurrentConnection=Setting the current connection to ''{0}''

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/DefaultConnectionPluginTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/DefaultConnectionPluginTest.java
@@ -33,18 +33,12 @@ import static org.mockito.Mockito.when;
 
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
-import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import software.amazon.jdbc.ConnectionInfo;
@@ -113,13 +107,6 @@ class DefaultConnectionPluginTest {
     closeable.close();
   }
 
-  @ParameterizedTest
-  @MethodSource("multiStatementQueries")
-  void testParseMultiStatementQueries(final String sql, final List<String> expected) {
-    final List<String> actual = plugin.parseMultiStatementQueries(sql);
-    assertEquals(expected, actual);
-  }
-
   @Test
   void testExecute_closeCurrentConnection() throws SQLException {
     when(this.pluginService.getCurrentConnection()).thenReturn(conn);
@@ -179,13 +166,4 @@ class DefaultConnectionPluginTest {
     verify(mockConnectionProviderManager, never()).acceptsStrategy(any(), anyString());
   }
 
-  private static Stream<Arguments> multiStatementQueries() {
-    return Stream.of(
-        Arguments.of("", new ArrayList<String>()),
-        Arguments.of(null, new ArrayList<String>()),
-        Arguments.of("  ", new ArrayList<String>()),
-        Arguments.of("some  \t  \r  \n   query;", Collections.singletonList("some query")),
-        Arguments.of("some\t\t\r\n query;query2", Arrays.asList("some query", "query2"))
-    );
-  }
 }

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/readwritesplitting/gate/TransactionAwareGateTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/readwritesplitting/gate/TransactionAwareGateTest.java
@@ -145,13 +145,25 @@ public class TransactionAwareGateTest {
   }
 
   @Test
-  void autoCommitIndeterminate_fallsBackToAllowingSwitch() throws SQLException {
+  void autoCommitIndeterminate_pins() throws SQLException {
+    // An unreadable autocommit state cannot rule out an implicit transaction, so the gate pins
+    // instead of guessing. Switching on a wrong guess would split a transaction across two
+    // physical connections.
     when(pluginService.isInTransaction()).thenReturn(false);
     when(pluginService.getCallContext()).thenReturn(callContext);
     when(pluginService.getSessionStateService()).thenReturn(sessionStateService);
     when(sessionStateService.getAutoCommit()).thenThrow(new SQLException("indeterminate"));
 
     final TransactionAwareGate gate = new TransactionAwareGate(true, true);
+    assertFalse(gate.canSwitch(ctx, TargetRole.READER));
+  }
+
+  @Test
+  void autoCommitIndeterminate_ignoredWhenNotConfigured() throws SQLException {
+    // The classic gate does not consult autocommit at all, so it must not be affected.
+    when(pluginService.isInTransaction()).thenReturn(false);
+
+    final TransactionAwareGate gate = new TransactionAwareGate();
     assertTrue(gate.canSwitch(ctx, TargetRole.READER));
   }
 


### PR DESCRIPTION
Follow-ups from the review that produced #2056. Independent of that PR - no overlapping files, branched from `main`.

## 1. `TransactionAwareGate`: pin when the autocommit state cannot be read

The gate refuses to move to another physical connection while a transaction is in progress, and (for `autoReadWriteSplitting`, via `pinOnAutoCommitOff`) while autocommit is explicitly disabled, because the next statement would join an implicit transaction. If reading the autocommit state threw, it fell back to allowing the switch:

```java
} catch (final SQLException e) {
  // If autocommit state cannot be determined, fall back to allowing the switch.
  return true;
}
```

That is the wrong default for the one input the gate cannot verify. An unknown autocommit state cannot rule out an implicit transaction, and switching on a wrong guess moves later statements to a different connection while the transaction stays open on the original one. Pinning instead costs a missed routing opportunity on a connection whose session state cannot even be queried - a bounded, recoverable cost against an unbounded correctness one.

Unchanged on purpose:

- An empty (never explicitly set) autocommit value still allows the switch. Empty means the JDBC default is in effect, so there is no implicit transaction to protect. Pinning there would disable read/write splitting for the common case.
- The classic gate (`new TransactionAwareGate()`, used by `readWriteSplitting`) does not consult autocommit at all and is unaffected. A test now covers that.

The existing `autoCommitIndeterminate_fallsBackToAllowingSwitch` test asserted the old behavior; it is renamed and inverted, since the assertion itself is the decision being changed. A `FINE` log line and a message bundle entry were added so the pinning is visible when diagnosing why splitting stopped.

## 2. Remove `DefaultConnectionPlugin.parseMultiStatementQueries()`

A package-private copy of the helper in `SqlMethodAnalyzer` with no production callers - the only reference was its own unit test. Package-private visibility also rules out external callers. Removed along with that test and the imports it needed.

Keeping a second copy of statement splitting invites the two from drifting apart, which is exactly what happened around comment handling (see #2056).

## Tests

Verified locally: full wrapper unit suite passes (1302 completed, 0 failed, 81 skipped - skips pre-existing), plus `checkstyleMain` and `checkstyleTest`. The count drops because the five parameterized cases for the removed dead method are gone; one gate test was added.

## Considered and not done

The review also floated having `SqlMethodAnalyzer` report an explicit "unknown" for SQL it cannot classify, with the gate refusing to switch on unknown. On closer reading that does not pay for itself: statements that are not transaction control are the overwhelmingly common case and are indistinguishable from genuinely unclassifiable text at that layer, so an "unknown means pin" rule would pin nearly every connection and effectively disable read/write splitting.

One genuine gap did surface while looking at this, and it is deliberately left for separate work: only the *first* statement of a multi-statement query is analyzed, so `SELECT 1; BEGIN` opens a transaction that goes undetected, and `SELECT 1; COMMIT` closes one that is never cleared. Fixing it means folding over every statement in the query, which first requires the `;` split to become quote-aware - otherwise a literal such as `INSERT INTO t VALUES ('a; commit')` would produce a bogus second statement and report a commit that never happened. That is a behavior change to transaction tracking and deserves its own PR.
