### PR TITLE
fix: forward wrapper settings to target XA data sources

### DIFF
--- a/docs/using-the-jdbc-driver/UsingXADataSource.md
+++ b/docs/using-the-jdbc-driver/UsingXADataSource.md
@@ -165,6 +165,14 @@ The read path keeps the headline switching features; the write path gets what XA
   supports XA by default.
 - `AwsWrapperXADataSource` requires a target `XADataSource`; a plain `DataSource` class name is
   rejected at `getXAConnection()` time.
+- **Timeouts:** the wrapper `connectTimeout` / `socketTimeout` / `tcpKeepAlive` properties are
+  forwarded to the target `XADataSource` in the unit each driver expects (seconds for PostgreSQL,
+  milliseconds for MySQL Connector/J, URL parameters for MariaDB). Setting a socket timeout is
+  recommended: without one, a network blackhole leaves the pinned XA session waiting indefinitely
+  instead of surfacing a connection failure.
+- **MariaDB Connector/J with a MySQL URL:** MariaDB rejects a `jdbc:mysql://` URL ("Wrong mariaDB
+  url") unless the URL itself carries `permitMysqlScheme`. When `org.mariadb.jdbc.MariaDbDataSource`
+  is the target XA datasource, the wrapper adds that parameter to the target URL automatically.
 - Because each `XAConnection.getConnection()` returns a fresh logical connection over the same
   physical session, the wrapper builds a fresh plugin pipeline per logical connection to keep plugin
   state isolated between checkouts.

--- a/docs/using-the-jdbc-driver/UsingXADataSource.md
+++ b/docs/using-the-jdbc-driver/UsingXADataSource.md
@@ -170,9 +170,11 @@ The read path keeps the headline switching features; the write path gets what XA
   milliseconds for MySQL Connector/J, URL parameters for MariaDB). Setting a socket timeout is
   recommended: without one, a network blackhole leaves the pinned XA session waiting indefinitely
   instead of surfacing a connection failure.
-- **MariaDB Connector/J with a MySQL URL:** MariaDB rejects a `jdbc:mysql://` URL ("Wrong mariaDB
-  url") unless the URL itself carries `permitMysqlScheme`. When `org.mariadb.jdbc.MariaDbDataSource`
-  is the target XA datasource, the wrapper adds that parameter to the target URL automatically.
+- **MariaDB Connector/J:** its data source accepts only `url`, `user`, `password` and `loginTimeout`
+  as bean properties, so the wrapper moves the other target-driver settings (for example
+  `allowPublicKeyRetrieval` or `sslMode`) into the target URL. MariaDB also rejects a `jdbc:mysql://`
+  URL ("Wrong mariaDB url") unless the URL itself carries `permitMysqlScheme`; the wrapper adds that
+  parameter automatically when `org.mariadb.jdbc.MariaDbDataSource` is the target XA datasource.
 - Because each `XAConnection.getConnection()` returns a fresh logical connection over the same
   physical session, the wrapper builds a fresh plugin pipeline per logical connection to keep plugin
   state isolated between checkouts.

--- a/wrapper/src/main/java/software/amazon/jdbc/ds/AwsWrapperXADataSource.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/ds/AwsWrapperXADataSource.java
@@ -329,7 +329,8 @@ public class AwsWrapperXADataSource implements XADataSource, Serializable {
    * parameters (e.g. {@code wrapperPlugins}) from leaking into the target driver's URL, which some
    * drivers reject as unknown parameters.
    */
-  void configureTargetXaDataSource(final XADataSource xaDataSource, final ResolvedConfig config) {
+  void configureTargetXaDataSource(final XADataSource xaDataSource, final ResolvedConfig config)
+      throws SQLException {
     final Properties targetProps = new Properties();
 
     if (this.targetDataSourceProperties != null) {
@@ -337,10 +338,13 @@ public class AwsWrapperXADataSource implements XADataSource, Serializable {
     }
 
     // A computed URL lets server/port/database flow to the target XADataSource that supports setUrl.
-    // Strip wrapper-specific query parameters so they are not passed to the target driver.
-    final String targetUrl = DataSourceConfigHelper.removeWrapperPropertiesFromUrl(config.finalUrl);
-    if (!StringUtils.isNullOrEmpty(targetUrl)) {
-      targetProps.put("url", targetUrl);
+    // Strip wrapper-specific query parameters so they are not passed to the target driver, then let
+    // the target driver dialect apply the wrapper settings the target can only receive through its
+    // own bean setters or URL parameters (connect/socket timeouts, MariaDB's permitMysqlScheme).
+    final String cleanUrl = DataSourceConfigHelper.removeWrapperPropertiesFromUrl(config.finalUrl);
+    if (!StringUtils.isNullOrEmpty(cleanUrl)) {
+      targetProps.put(
+          "url", config.targetDriverDialect.prepareTargetDataSource(xaDataSource, cleanUrl, config.props));
     }
     if (!StringUtils.isNullOrEmpty(this.user)) {
       targetProps.put(PropertyDefinition.USER.name, this.user);

--- a/wrapper/src/main/java/software/amazon/jdbc/ds/xa/XADataSourceConnectionProvider.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/ds/xa/XADataSourceConnectionProvider.java
@@ -145,7 +145,7 @@ public class XADataSourceConnectionProvider implements ConnectionProvider {
     // sets it as the password on these per-connect props; without applying them here the target
     // XADataSource would keep the static password configured at getXAConnection() time and IAM
     // authentication would fail.
-    final XAConnection xaConn = openXaConnection(props);
+    final XAConnection xaConn = openXaConnection(props, targetDriverDialect);
     return new ConnectionInfo(getOrCreateLogicalConnection(xaConn), false, xaConn);
   }
 
@@ -187,7 +187,7 @@ public class XADataSourceConnectionProvider implements ConnectionProvider {
    * @throws SQLException if the XA connection cannot be opened.
    */
   public @NonNull XAConnection getOrOpenXaConnection() throws SQLException {
-    return openXaConnection(null);
+    return openXaConnection(null, null);
   }
 
   /**
@@ -196,7 +196,9 @@ public class XADataSourceConnectionProvider implements ConnectionProvider {
    * is opened, so plugin-provided credentials (e.g. an IAM token) take effect. The physical session
    * is pinned for the lifetime of this provider, so credentials are only applied on the first open.
    */
-  private @NonNull XAConnection openXaConnection(final @Nullable Properties props) throws SQLException {
+  private @NonNull XAConnection openXaConnection(
+      final @Nullable Properties props,
+      final @Nullable TargetDriverDialect targetDriverDialect) throws SQLException {
     XAConnection xaConn = this.xaConnection;
     if (xaConn == null) {
       try (ResourceLock ignored = this.lock.obtain()) {
@@ -204,7 +206,7 @@ public class XADataSourceConnectionProvider implements ConnectionProvider {
         if (xaConn == null) {
           if (props != null) {
             applyCredentials(props);
-            applyCleanUrl();
+            applyCleanUrl(props, targetDriverDialect);
           }
           xaConn = this.xaDataSource.getXAConnection();
           if (xaConn == null) {
@@ -241,7 +243,9 @@ public class XADataSourceConnectionProvider implements ConnectionProvider {
    * {@code getXAConnection()} time may miss plugin-specific properties whose classes were not yet
    * loaded).
    */
-  private void applyCleanUrl() {
+  private void applyCleanUrl(
+      final @NonNull Properties props,
+      final @Nullable TargetDriverDialect targetDriverDialect) throws SQLException {
     if (StringUtils.isNullOrEmpty(this.resolvedUrl)) {
       return;
     }
@@ -249,8 +253,14 @@ public class XADataSourceConnectionProvider implements ConnectionProvider {
     if (StringUtils.isNullOrEmpty(cleanUrl)) {
       return;
     }
+    // Re-apply the target driver dialect adjustments (driver-specific URL parameters and settings
+    // that the target data source only accepts through its own bean setters) against the final
+    // per-connect properties, which may have been rewritten by the connect pipeline.
+    final String targetUrl = targetDriverDialect == null
+        ? cleanUrl
+        : targetDriverDialect.prepareTargetDataSource(this.xaDataSource, cleanUrl, props);
     final List<Method> methods = Arrays.asList(this.xaDataSource.getClass().getMethods());
-    PropertyUtils.setPropertyOnTarget(this.xaDataSource, "url", cleanUrl, methods);
+    PropertyUtils.setPropertyOnTarget(this.xaDataSource, "url", targetUrl, methods);
   }
 
   /**

--- a/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/MariadbTargetDriverDialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/MariadbTargetDriverDialect.java
@@ -19,10 +19,12 @@ package software.amazon.jdbc.targetdriverdialect;
 import java.sql.Driver;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Properties;
 import java.util.Set;
+import java.util.TreeSet;
 import javax.sql.CommonDataSource;
 import javax.sql.DataSource;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -36,6 +38,23 @@ public class MariadbTargetDriverDialect extends GenericTargetDriverDialect {
 
   private static final String PERMIT_MYSQL_SCHEME = "permitMysqlScheme";
   private static final String MYSQL_URL_PREFIX = "jdbc:mysql:";
+
+  /**
+   * Properties that must not be copied into the target URL by
+   * {@link #prepareTargetDataSource(CommonDataSource, String, Properties)}: the credentials and the
+   * login timeout have bean setters on the MariaDB data source, and the remaining ones are already
+   * expressed by the URL itself.
+   */
+  private static final Set<String> NON_URL_PROPERTY_NAMES = Collections.unmodifiableSet(
+      new HashSet<>(Arrays.asList(
+          PropertyDefinition.USER.name,
+          PropertyDefinition.PASSWORD.name,
+          PropertyDefinition.LOGIN_TIMEOUT.name,
+          PropertyDefinition.DATABASE.name,
+          "url",
+          "serverName",
+          "serverPort")));
+
   private static final String DRIVER_CLASS_NAME = "org.mariadb.jdbc.Driver";
   private static final String DS_CLASS_NAME = "org.mariadb.jdbc.MariaDbDataSource";
   private static final String CP_DS_CLASS_NAME = "org.mariadb.jdbc.MariaDbPoolDataSource";
@@ -156,17 +175,24 @@ public class MariadbTargetDriverDialect extends GenericTargetDriverDialect {
   }
 
   /**
-   * MariaDB Connector/J data sources accept only a URL (plus user/password/loginTimeout) as bean
-   * properties, so every other setting has to be expressed as a URL parameter.
+   * MariaDB Connector/J data sources accept only {@code url}, {@code user}, {@code password} and
+   * {@code loginTimeout} as bean properties, so every other setting has to be expressed as a URL
+   * parameter. Two adjustments are made:
    *
-   * <p>Two adjustments are made:
    * <ul>
    *   <li>{@code permitMysqlScheme} is added for a {@code jdbc:mysql://} URL. The driver rejects the
    *       MySQL scheme outright ("Wrong mariaDB url") unless the URL itself carries this parameter,
    *       and it cannot be set as a bean property.</li>
-   *   <li>The wrapper connect/socket timeouts are added (in milliseconds, the unit MariaDB uses) so
-   *       they are not silently dropped.</li>
+   *   <li>The target-driver settings are moved into the URL: the wrapper keep-alive and timeout
+   *       properties (whose names and millisecond unit match MariaDB's own options), plus every
+   *       property the wrapper does not recognize, which by definition belongs to the target driver
+   *       (for example {@code allowPublicKeyRetrieval} or {@code sslMode}). Without this they would
+   *       be dropped, because the data source has no bean setter for them. This mirrors what the
+   *       non-XA data source path does through the connection URL builder.</li>
    * </ul>
+   *
+   * <p>Credentials are deliberately kept out of the URL; they are applied through the
+   * {@code setUser} / {@code setPassword} bean setters.
    */
   @Override
   public String prepareTargetDataSource(
@@ -178,13 +204,18 @@ public class MariadbTargetDriverDialect extends GenericTargetDriverDialect {
     if (result.startsWith(MYSQL_URL_PREFIX)) {
       result = appendUrlParameter(result, PERMIT_MYSQL_SCHEME, null);
     }
-    final Integer connectTimeout = PropertyUtils.getIntegerPropertyValue(props, PropertyDefinition.CONNECT_TIMEOUT);
-    if (connectTimeout != null) {
-      result = appendUrlParameter(result, PropertyDefinition.CONNECT_TIMEOUT.name, connectTimeout.toString());
-    }
-    final Integer socketTimeout = PropertyUtils.getIntegerPropertyValue(props, PropertyDefinition.SOCKET_TIMEOUT);
-    if (socketTimeout != null) {
-      result = appendUrlParameter(result, PropertyDefinition.SOCKET_TIMEOUT.name, socketTimeout.toString());
+
+    final Properties urlProps = PropertyUtils.copyProperties(props);
+    PropertyDefinition.removeAllExcept(urlProps,
+        PropertyDefinition.TCP_KEEP_ALIVE.name,
+        PropertyDefinition.CONNECT_TIMEOUT.name,
+        PropertyDefinition.SOCKET_TIMEOUT.name);
+    // Either already part of the URL itself, or applied through a bean setter.
+    NON_URL_PROPERTY_NAMES.forEach(urlProps::remove);
+
+    // Sorted so that the resulting URL is deterministic.
+    for (final String name : new TreeSet<>(urlProps.stringPropertyNames())) {
+      result = appendUrlParameter(result, name, urlProps.getProperty(name));
     }
     return result;
   }

--- a/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/MariadbTargetDriverDialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/MariadbTargetDriverDialect.java
@@ -23,16 +23,19 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Properties;
 import java.util.Set;
+import javax.sql.CommonDataSource;
 import javax.sql.DataSource;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import software.amazon.jdbc.HostSpec;
 import software.amazon.jdbc.JdbcMethod;
 import software.amazon.jdbc.PropertyDefinition;
+import software.amazon.jdbc.util.PropertyUtils;
 
 public class MariadbTargetDriverDialect extends GenericTargetDriverDialect {
 
   private static final String PERMIT_MYSQL_SCHEME = "permitMysqlScheme";
+  private static final String MYSQL_URL_PREFIX = "jdbc:mysql:";
   private static final String DRIVER_CLASS_NAME = "org.mariadb.jdbc.Driver";
   private static final String DS_CLASS_NAME = "org.mariadb.jdbc.MariaDbDataSource";
   private static final String CP_DS_CLASS_NAME = "org.mariadb.jdbc.MariaDbPoolDataSource";
@@ -150,6 +153,65 @@ public class MariadbTargetDriverDialect extends GenericTargetDriverDialect {
     // direct reference to org.mariadb.jdbc.MariaDbDataSource
     final MariadbDriverHelper helper = new MariadbDriverHelper();
     helper.prepareDataSource(dataSource, protocol, hostSpec, props);
+  }
+
+  /**
+   * MariaDB Connector/J data sources accept only a URL (plus user/password/loginTimeout) as bean
+   * properties, so every other setting has to be expressed as a URL parameter.
+   *
+   * <p>Two adjustments are made:
+   * <ul>
+   *   <li>{@code permitMysqlScheme} is added for a {@code jdbc:mysql://} URL. The driver rejects the
+   *       MySQL scheme outright ("Wrong mariaDB url") unless the URL itself carries this parameter,
+   *       and it cannot be set as a bean property.</li>
+   *   <li>The wrapper connect/socket timeouts are added (in milliseconds, the unit MariaDB uses) so
+   *       they are not silently dropped.</li>
+   * </ul>
+   */
+  @Override
+  public String prepareTargetDataSource(
+      final @NonNull CommonDataSource dataSource,
+      final @NonNull String url,
+      final @NonNull Properties props) {
+
+    String result = url;
+    if (result.startsWith(MYSQL_URL_PREFIX)) {
+      result = appendUrlParameter(result, PERMIT_MYSQL_SCHEME, null);
+    }
+    final Integer connectTimeout = PropertyUtils.getIntegerPropertyValue(props, PropertyDefinition.CONNECT_TIMEOUT);
+    if (connectTimeout != null) {
+      result = appendUrlParameter(result, PropertyDefinition.CONNECT_TIMEOUT.name, connectTimeout.toString());
+    }
+    final Integer socketTimeout = PropertyUtils.getIntegerPropertyValue(props, PropertyDefinition.SOCKET_TIMEOUT);
+    if (socketTimeout != null) {
+      result = appendUrlParameter(result, PropertyDefinition.SOCKET_TIMEOUT.name, socketTimeout.toString());
+    }
+    return result;
+  }
+
+  /**
+   * Appends {@code name} (with {@code value}, or as a bare flag when {@code value} is null) to the
+   * query string of {@code url}, unless the parameter is already present.
+   */
+  private String appendUrlParameter(final String url, final String name, final @Nullable String value) {
+    final int queryStart = url.indexOf('?');
+    if (queryStart >= 0 && containsParameter(url.substring(queryStart + 1), name)) {
+      return url;
+    }
+    return url
+        + (queryStart >= 0 ? "&" : "?")
+        + name
+        + (value == null ? "" : "=" + value);
+  }
+
+  private boolean containsParameter(final String query, final String name) {
+    for (final String token : query.split("&")) {
+      final int eq = token.indexOf('=');
+      if (name.equals(eq < 0 ? token : token.substring(0, eq))) {
+        return true;
+      }
+    }
+    return false;
   }
 
   @Override

--- a/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/MysqlConnectorJDriverHelper.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/MysqlConnectorJDriverHelper.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
+import javax.sql.CommonDataSource;
 import javax.sql.DataSource;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import software.amazon.jdbc.HostSpec;
@@ -79,6 +80,45 @@ public class MysqlConnectorJDriverHelper {
         PropertyDefinition.CONNECT_TIMEOUT.name);
 
     PropertyUtils.applyProperties(dataSource, props);
+  }
+
+  /**
+   * Applies the AWS Wrapper TCP keep-alive and timeout properties to a MySQL Connector/J data source
+   * (including {@code MysqlXADataSource}). Connector/J expresses connect/socket timeouts in
+   * milliseconds, the same unit as the corresponding wrapper properties, so the values are passed
+   * through unchanged. Non-Connector/J data sources are left untouched.
+   *
+   * @param dataSource the target data source to configure.
+   * @param props      the connection properties.
+   * @throws SQLException if a setting cannot be applied to the data source.
+   */
+  public void prepareTargetDataSource(
+      final @NonNull CommonDataSource dataSource, final @NonNull Properties props) throws SQLException {
+
+    if (!(dataSource instanceof MysqlDataSource)) {
+      return;
+    }
+    final MysqlDataSource mysqlDataSource = (MysqlDataSource) dataSource;
+
+    final Boolean tcpKeepAlive = PropertyUtils.getBooleanPropertyValue(props, PropertyDefinition.TCP_KEEP_ALIVE);
+    if (tcpKeepAlive != null) {
+      mysqlDataSource.setTcpKeepAlive(tcpKeepAlive);
+    }
+
+    final Integer loginTimeout = PropertyUtils.getIntegerPropertyValue(props, PropertyDefinition.LOGIN_TIMEOUT);
+    if (loginTimeout != null) {
+      mysqlDataSource.setLoginTimeout((int) TimeUnit.MILLISECONDS.toSeconds(loginTimeout));
+    }
+
+    final Integer connectTimeout = PropertyUtils.getIntegerPropertyValue(props, PropertyDefinition.CONNECT_TIMEOUT);
+    if (connectTimeout != null) {
+      mysqlDataSource.setConnectTimeout(connectTimeout);
+    }
+
+    final Integer socketTimeout = PropertyUtils.getIntegerPropertyValue(props, PropertyDefinition.SOCKET_TIMEOUT);
+    if (socketTimeout != null) {
+      mysqlDataSource.setSocketTimeout(socketTimeout);
+    }
   }
 
   public boolean isDriverRegistered() throws SQLException {

--- a/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/MysqlConnectorJTargetDriverDialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/MysqlConnectorJTargetDriverDialect.java
@@ -26,6 +26,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Properties;
 import java.util.Set;
+import javax.sql.CommonDataSource;
 import javax.sql.DataSource;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -38,6 +39,7 @@ public class MysqlConnectorJTargetDriverDialect extends GenericTargetDriverDiale
   private static final String DRIVER_CLASS_NAME = "com.mysql.cj.jdbc.Driver";
   private static final String DS_CLASS_NAME = "com.mysql.cj.jdbc.MysqlDataSource";
   private static final String CP_DS_CLASS_NAME = "com.mysql.cj.jdbc.MysqlConnectionPoolDataSource";
+  private static final String XA_DS_CLASS_NAME = "com.mysql.cj.jdbc.MysqlXADataSource";
   private static final String PREPARED_STATEMENT_QUERY_HEADER = "PreparedStatement:";
 
   private static final Set<String> MYSQL_ALLOWED_ON_CLOSED_METHOD_NAMES = Collections.unmodifiableSet(
@@ -66,7 +68,8 @@ public class MysqlConnectorJTargetDriverDialect extends GenericTargetDriverDiale
   @Override
   public boolean isDialect(String dataSourceClass) {
     return DS_CLASS_NAME.equals(dataSourceClass)
-        || CP_DS_CLASS_NAME.equals(dataSourceClass);
+        || CP_DS_CLASS_NAME.equals(dataSourceClass)
+        || XA_DS_CLASS_NAME.equals(dataSourceClass);
   }
 
   @Override
@@ -103,6 +106,19 @@ public class MysqlConnectorJTargetDriverDialect extends GenericTargetDriverDiale
     // direct reference to com.mysql.cj.jdbc.MysqlDataSource
     final MysqlConnectorJDriverHelper helper = new MysqlConnectorJDriverHelper();
     helper.prepareDataSource(dataSource, hostSpec, props);
+  }
+
+  @Override
+  public String prepareTargetDataSource(
+      final @NonNull CommonDataSource dataSource,
+      final @NonNull String url,
+      final @NonNull Properties props) throws SQLException {
+
+    // The logic is isolated to a separated class since it uses
+    // direct reference to com.mysql.cj.jdbc.MysqlDataSource
+    final MysqlConnectorJDriverHelper helper = new MysqlConnectorJDriverHelper();
+    helper.prepareTargetDataSource(dataSource, props);
+    return url;
   }
 
   @Override

--- a/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/PgDriverHelper.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/PgDriverHelper.java
@@ -20,6 +20,7 @@ import java.sql.SQLException;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
+import javax.sql.CommonDataSource;
 import javax.sql.DataSource;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.postgresql.ds.common.BaseDataSource;
@@ -61,6 +62,32 @@ public class PgDriverHelper {
       baseDataSource.setPortNumbers(new int[] { hostSpec.getPort() });
     }
 
+    applyKeepAliveAndTimeouts(baseDataSource, props);
+
+    // keep unknown properties (the ones that don't belong to AWS Wrapper Driver)
+    // and try to apply them to data source
+    PropertyDefinition.removeAll(props);
+
+    PropertyUtils.applyProperties(dataSource, props);
+  }
+
+  /**
+   * Applies the AWS Wrapper TCP keep-alive and timeout properties to a PostgreSQL data source
+   * (including {@code PGXADataSource}, which is a {@link BaseDataSource} but not a
+   * {@link DataSource}). Non-PostgreSQL data sources are left untouched.
+   *
+   * @param dataSource the target data source to configure.
+   * @param props      the connection properties.
+   */
+  public void prepareTargetDataSource(
+      final @NonNull CommonDataSource dataSource, final @NonNull Properties props) {
+    if (!(dataSource instanceof BaseDataSource)) {
+      return;
+    }
+    applyKeepAliveAndTimeouts((BaseDataSource) dataSource, props);
+  }
+
+  private void applyKeepAliveAndTimeouts(final BaseDataSource baseDataSource, final Properties props) {
     final Boolean tcpKeepAlive = PropertyUtils.getBooleanPropertyValue(props, PropertyDefinition.TCP_KEEP_ALIVE);
     if (tcpKeepAlive != null) {
       baseDataSource.setTcpKeepAlive(tcpKeepAlive);
@@ -71,6 +98,7 @@ public class PgDriverHelper {
       baseDataSource.setLoginTimeout((int) TimeUnit.MILLISECONDS.toSeconds(loginTimeout));
     }
 
+    // PostgreSQL expresses these timeouts in seconds, the wrapper properties are in milliseconds.
     final Integer connectTimeout = PropertyUtils.getIntegerPropertyValue(props, PropertyDefinition.CONNECT_TIMEOUT);
     if (connectTimeout != null) {
       baseDataSource.setConnectTimeout((int) TimeUnit.MILLISECONDS.toSeconds(connectTimeout));
@@ -80,12 +108,6 @@ public class PgDriverHelper {
     if (socketTimeout != null) {
       baseDataSource.setSocketTimeout((int) TimeUnit.MILLISECONDS.toSeconds(socketTimeout));
     }
-
-    // keep unknown properties (the ones that don't belong to AWS Wrapper Driver)
-    // and try to apply them to data source
-    PropertyDefinition.removeAll(props);
-
-    PropertyUtils.applyProperties(dataSource, props);
   }
 
   public boolean isDriverRegistered() throws SQLException {

--- a/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/PgTargetDriverDialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/PgTargetDriverDialect.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
+import javax.sql.CommonDataSource;
 import javax.sql.DataSource;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -50,11 +51,13 @@ public class PgTargetDriverDialect extends GenericTargetDriverDialect {
   private static final String SIMPLE_DS_CLASS_NAME = "org.postgresql.ds.PGSimpleDataSource";
   private static final String POOLING_DS_CLASS_NAME = "org.postgresql.ds.PGPoolingDataSource";
   private static final String CP_DS_CLASS_NAME = "org.postgresql.ds.PGConnectionPoolDataSource";
+  private static final String XA_DS_CLASS_NAME = "org.postgresql.xa.PGXADataSource";
 
   private static final Set<String> dataSourceClassMap = new HashSet<>(Arrays.asList(
       SIMPLE_DS_CLASS_NAME,
       POOLING_DS_CLASS_NAME,
-      CP_DS_CLASS_NAME));
+      CP_DS_CLASS_NAME,
+      XA_DS_CLASS_NAME));
 
   private static final Set<String> PG_ALLOWED_ON_CLOSED_METHOD_NAMES = Collections.unmodifiableSet(
       new HashSet<String>() {
@@ -160,6 +163,19 @@ public class PgTargetDriverDialect extends GenericTargetDriverDialect {
     // direct reference to org.postgresql.ds.common.BaseDataSource
     final PgDriverHelper helper = new PgDriverHelper();
     helper.prepareDataSource(dataSource, hostSpec, props);
+  }
+
+  @Override
+  public String prepareTargetDataSource(
+      final @NonNull CommonDataSource dataSource,
+      final @NonNull String url,
+      final @NonNull Properties props) {
+
+    // The logic is isolated to a separated class since it uses
+    // direct reference to org.postgresql.ds.common.BaseDataSource
+    final PgDriverHelper helper = new PgDriverHelper();
+    helper.prepareTargetDataSource(dataSource, props);
+    return url;
   }
 
   @Override

--- a/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/TargetDriverDialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/TargetDriverDialect.java
@@ -23,6 +23,7 @@ import java.sql.SQLException;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.Executor;
+import javax.sql.CommonDataSource;
 import javax.sql.DataSource;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -44,6 +45,33 @@ public interface TargetDriverDialect {
       final @NonNull String protocol,
       final @NonNull HostSpec hostSpec,
       final @NonNull Properties props) throws SQLException;
+
+  /**
+   * Applies AWS Wrapper connection settings that a target data source can only receive through
+   * driver-specific bean setters (for example connect/socket timeouts, whose unit differs per
+   * driver), and returns the connection URL to apply to that data source.
+   *
+   * <p>This is used by the XA datasource path, which configures a target driver
+   * {@link javax.sql.XADataSource} directly instead of going through
+   * {@link #prepareConnectInfo(String, HostSpec, Properties)}. Because that path hands the target
+   * only its own (non-wrapper) properties, wrapper properties such as {@code socketTimeout} would
+   * otherwise be dropped. Dialects whose target data source cannot express a setting as a bean
+   * property may instead add it to the returned URL.
+   *
+   * <p>The default implementation applies nothing and returns {@code url} unchanged.
+   *
+   * @param dataSource the target driver data source being configured.
+   * @param url        the target driver URL, with AWS Wrapper parameters already removed.
+   * @param props      the effective connection properties, including AWS Wrapper properties.
+   * @return the URL to apply to the target data source.
+   * @throws SQLException if a setting cannot be applied to the target data source.
+   */
+  default String prepareTargetDataSource(
+      final @NonNull CommonDataSource dataSource,
+      final @NonNull String url,
+      final @NonNull Properties props) throws SQLException {
+    return url;
+  }
 
   boolean isDriverRegistered() throws SQLException;
 

--- a/wrapper/src/test/java/integration/TestEnvironmentInfo.java
+++ b/wrapper/src/test/java/integration/TestEnvironmentInfo.java
@@ -43,6 +43,9 @@ public class TestEnvironmentInfo {
 
   private String clusterParameterGroupName = null;
 
+  // Instance-level parameter group, used by the RDS (non-Aurora) deployments.
+  private String dbParameterGroupName = null;
+
   // Random alphanumeric combination that is used to form a test cluster name or an instance name.
   private String randomBase = null;
 
@@ -196,6 +199,14 @@ public class TestEnvironmentInfo {
 
   public void setClusterParameterGroupName(String clusterParameterGroupName) {
     this.clusterParameterGroupName = clusterParameterGroupName;
+  }
+
+  public String getDbParameterGroupName() {
+    return this.dbParameterGroupName;
+  }
+
+  public void setDbParameterGroupName(String dbParameterGroupName) {
+    this.dbParameterGroupName = dbParameterGroupName;
   }
 
   public String getRandomBase() {

--- a/wrapper/src/test/java/integration/container/tests/ReadWriteSplittingTests.java
+++ b/wrapper/src/test/java/integration/container/tests/ReadWriteSplittingTests.java
@@ -19,6 +19,7 @@ package integration.container.tests;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
@@ -1046,13 +1047,17 @@ public class ReadWriteSplittingTests {
             () -> stmt.execute("CREATE DATABASE " + limitedUserNewDb));
       }
 
-      assertThrows(
-          HikariPool.PoolInitializationException.class, () -> {
+      // The internal pool provider wraps Hikari's fail-fast PoolInitializationException in a
+      // SQLException so that callers relying on the 'throws SQLException' contract (the failover
+      // retry loop) treat it as a recoverable connection failure.
+      final SQLException exception = assertThrows(
+          SQLException.class, () -> {
             try (final Connection ignored = DriverManager.getConnection(
                 ConnectionStringHelper.getWrapperUrl(), wrongUserRightPasswordProps)) {
               // Do nothing (close connection automatically)
             }
           });
+      assertInstanceOf(HikariPool.PoolInitializationException.class, exception.getCause());
     } finally {
       ConnectionProviderManager.releaseResources();
       Driver.resetCustomConnectionProvider();

--- a/wrapper/src/test/java/integration/container/tests/XaFailoverTest.java
+++ b/wrapper/src/test/java/integration/container/tests/XaFailoverTest.java
@@ -169,8 +169,11 @@ public class XaFailoverTest {
       newDs.setJdbcUrl(ConnectionStringHelper.getWrapperClusterEndpointUrl());
       newDs.setUser(TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getUsername());
       newDs.setPassword(TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getPassword());
-      final Properties newProps = new Properties();
-      newProps.setProperty(PropertyDefinition.PLUGINS.name, "");
+      // The default properties carry the driver-specific settings the connection needs, notably
+      // allowPublicKeyRetrieval for the MariaDB driver: authenticating against the promoted writer
+      // runs the full caching_sha2_password exchange, which otherwise fails with "RSA public key is
+      // not available client side".
+      final Properties newProps = ConnectionStringHelper.getDefaultPropertiesWithNoPlugins();
       newDs.setTargetDataSourceProperties(newProps);
 
       XAConnection xaConn2 = null;
@@ -295,10 +298,13 @@ public class XaFailoverTest {
     // Use the cluster writer endpoint so reads/writes always target the current writer. After a
     // failover this follows the promoted node; a fixed instance host would resolve to the demoted
     // reader and either serve stale (replica-lagged) rows or reject writes.
+    //
+    // The default properties (rather than just user/password) are used because they carry the
+    // driver-specific settings this connection needs after a failover, notably
+    // allowPublicKeyRetrieval for the MariaDB driver.
     return java.sql.DriverManager.getConnection(
         ConnectionStringHelper.getWrapperClusterEndpointUrl(),
-        TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getUsername(),
-        TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getPassword());
+        ConnectionStringHelper.getDefaultProperties());
   }
 
   private void recreateTable() throws SQLException {

--- a/wrapper/src/test/java/integration/container/tests/XaFailoverTest.java
+++ b/wrapper/src/test/java/integration/container/tests/XaFailoverTest.java
@@ -34,6 +34,7 @@ import integration.container.condition.EnableOnNumOfInstances;
 import integration.container.condition.EnableOnTestFeature;
 import integration.container.condition.MakeSureFirstInstanceWriter;
 import integration.util.AuroraTestUtility;
+import integration.util.XaTestUtility;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -107,6 +108,8 @@ public class XaFailoverTest {
   @TestTemplate
   @EnableOnNumOfInstances(min = 2)
   public void test_failoverDuringXaBranch_failsFast() throws Exception {
+    // The post-failover verification commits a new XA transaction, which goes through prepare.
+    XaTestUtility.assumePreparedTransactionsSupported();
     recreateTable();
 
     final TestInstanceInfo writer =

--- a/wrapper/src/test/java/integration/container/tests/XaIamAuthenticationTest.java
+++ b/wrapper/src/test/java/integration/container/tests/XaIamAuthenticationTest.java
@@ -29,6 +29,7 @@ import integration.container.condition.DisableOnTestDriver;
 import integration.container.condition.DisableOnTestFeature;
 import integration.container.condition.EnableOnDatabaseEngine;
 import integration.container.condition.EnableOnTestFeature;
+import integration.util.XaTestUtility;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.Statement;
@@ -117,6 +118,7 @@ public class XaIamAuthenticationTest {
   @TestTemplate
   @DisableOnTestDriver(TestDriver.MARIADB)
   public void test_iamAuth_xaBranchLifecycle() throws Exception {
+    XaTestUtility.assumePreparedTransactionsSupported();
     final AwsWrapperXADataSource ds = createIamXaDataSource();
     final XAConnection xaConn = ds.getXAConnection();
     try {

--- a/wrapper/src/test/java/integration/container/tests/XaIamAuthenticationTest.java
+++ b/wrapper/src/test/java/integration/container/tests/XaIamAuthenticationTest.java
@@ -29,6 +29,7 @@ import integration.container.condition.DisableOnTestDriver;
 import integration.container.condition.DisableOnTestFeature;
 import integration.container.condition.EnableOnDatabaseEngine;
 import integration.container.condition.EnableOnTestFeature;
+import integration.container.condition.MakeSureFirstInstanceWriter;
 import integration.util.XaTestUtility;
 import java.sql.Connection;
 import java.sql.ResultSet;
@@ -72,6 +73,11 @@ import software.amazon.jdbc.plugin.iam.IamAuthConnectionPlugin;
     TestEnvironmentFeatures.RUN_AUTOSCALING_TESTS_ONLY,
     TestEnvironmentFeatures.BLUE_GREEN_DEPLOYMENT,
     TestEnvironmentFeatures.RUN_DB_METRICS_ONLY})
+// The XA datasource connects to the first instance and prepares a transaction on it, so that instance
+// must be the writer: a reader is permanently in recovery and rejects PREPARE TRANSACTION with
+// "cannot execute PREPARE TRANSACTION during recovery". A preceding failover test can leave the first
+// instance demoted, so have the first instance restored as the writer before running.
+@MakeSureFirstInstanceWriter
 @Order(26)
 @Tag("xa")
 public class XaIamAuthenticationTest {

--- a/wrapper/src/test/java/integration/container/tests/XaTransactionTest.java
+++ b/wrapper/src/test/java/integration/container/tests/XaTransactionTest.java
@@ -31,12 +31,14 @@ import integration.container.condition.DisableOnTestFeature;
 import integration.container.condition.EnableOnDatabaseEngine;
 import integration.container.condition.EnableOnNumOfInstances;
 import integration.util.AuroraTestUtility;
+import integration.util.XaTestUtility;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Arrays;
 import java.util.Properties;
+import java.util.logging.Logger;
 import javax.sql.XAConnection;
 import javax.transaction.xa.XAResource;
 import javax.transaction.xa.Xid;
@@ -69,6 +71,8 @@ import software.amazon.jdbc.wrapper.ConnectionWrapper;
 @Order(24)
 @Tag("xa")
 public class XaTransactionTest {
+
+  private static final Logger LOGGER = Logger.getLogger(XaTransactionTest.class.getName());
 
   private static final String TABLE = "xa_test_table";
 
@@ -126,6 +130,7 @@ public class XaTransactionTest {
 
   @TestTemplate
   public void test_xaLifecycle_commitPersists() throws Exception {
+    XaTestUtility.assumePreparedTransactionsSupported();
     recreateTable();
     final int id = 1;
     final AwsWrapperXADataSource ds = createXaDataSource();
@@ -153,6 +158,7 @@ public class XaTransactionTest {
 
   @TestTemplate
   public void test_xaLifecycle_rollbackDiscards() throws Exception {
+    XaTestUtility.assumePreparedTransactionsSupported();
     recreateTable();
     final int id = 2;
     final AwsWrapperXADataSource ds = createXaDataSource();
@@ -203,6 +209,7 @@ public class XaTransactionTest {
 
   @TestTemplate
   public void test_recover_returnsPreparedBranch() throws Exception {
+    XaTestUtility.assumePreparedTransactionsSupported();
     recreateTable();
     final int id = 4;
     final AwsWrapperXADataSource ds = createXaDataSource();
@@ -254,19 +261,35 @@ public class XaTransactionTest {
       // Requesting read-only inside an XA branch must NOT switch to a reader: the transaction-aware
       // gate pins the physical connection for the branch. If the connection had switched, the
       // reported instance id would change. We assert on the instance id rather than performing a
-      // write, because when the switch is skipped the underlying driver still applies read-only to
-      // the pinned session, which would block a subsequent INSERT (that is expected driver behavior,
-      // not a switch).
-      conn.setReadOnly(true);
+      // write, because when the switch is skipped the request is passed on to the pinned session,
+      // where the driver decides what to do with it: MySQL applies read-only (which would block a
+      // subsequent INSERT), while PostgreSQL rejects the call outright because a transaction is
+      // active ("Cannot change transaction read-only property in the middle of a transaction",
+      // allowed by the JDBC spec). Either outcome is fine here - both mean no switch happened.
+      setReadOnlyIgnoringDriverRejection(conn, true);
       final String instanceAfterSetReadOnly = auroraUtil.queryInstanceId(conn);
       assertEquals(instanceInBranch, instanceAfterSetReadOnly,
           "read/write splitting must not switch the connection during an XA branch");
 
-      conn.setReadOnly(false);
+      setReadOnlyIgnoringDriverRejection(conn, false);
       xaResource.end(xid, XAResource.TMSUCCESS);
       xaResource.rollback(xid);
     } finally {
       xaConn.close();
+    }
+  }
+
+  /**
+   * Calls {@code setReadOnly} and tolerates a driver that refuses to change the read-only property
+   * while a transaction is active (PostgreSQL). The rejection happens client-side, before any
+   * statement is sent, so the XA branch remains usable.
+   */
+  private static void setReadOnlyIgnoringDriverRejection(final Connection conn, final boolean readOnly)
+      throws SQLException {
+    try {
+      conn.setReadOnly(readOnly);
+    } catch (final SQLException e) {
+      LOGGER.finest(() -> "setReadOnly(" + readOnly + ") was rejected during the XA branch: " + e.getMessage());
     }
   }
 

--- a/wrapper/src/test/java/integration/container/tests/XaTransactionTest.java
+++ b/wrapper/src/test/java/integration/container/tests/XaTransactionTest.java
@@ -30,6 +30,7 @@ import integration.container.TestEnvironment;
 import integration.container.condition.DisableOnTestFeature;
 import integration.container.condition.EnableOnDatabaseEngine;
 import integration.container.condition.EnableOnNumOfInstances;
+import integration.container.condition.MakeSureFirstInstanceWriter;
 import integration.util.AuroraTestUtility;
 import integration.util.XaTestUtility;
 import java.sql.Connection;
@@ -68,6 +69,11 @@ import software.amazon.jdbc.wrapper.ConnectionWrapper;
     TestEnvironmentFeatures.RUN_AUTOSCALING_TESTS_ONLY,
     TestEnvironmentFeatures.BLUE_GREEN_DEPLOYMENT,
     TestEnvironmentFeatures.RUN_DB_METRICS_ONLY})
+// The XA datasource connects to the first instance and writes and prepares a transaction on it, so
+// that instance must be the writer: a reader is permanently in recovery and rejects PREPARE
+// TRANSACTION. A preceding failover test can leave the first instance demoted, so have the first
+// instance restored as the writer before running.
+@MakeSureFirstInstanceWriter
 @Order(24)
 @Tag("xa")
 public class XaTransactionTest {

--- a/wrapper/src/test/java/integration/container/tests/XaTwoPhaseCommitTest.java
+++ b/wrapper/src/test/java/integration/container/tests/XaTwoPhaseCommitTest.java
@@ -26,6 +26,7 @@ import integration.container.TestDriverProvider;
 import integration.container.TestEnvironment;
 import integration.container.condition.DisableOnTestFeature;
 import integration.container.condition.EnableOnDatabaseEngine;
+import integration.container.condition.MakeSureFirstInstanceWriter;
 import integration.util.XaTestUtility;
 import java.sql.Connection;
 import java.sql.ResultSet;
@@ -67,6 +68,11 @@ import software.amazon.jdbc.ds.AwsWrapperXADataSource;
     TestEnvironmentFeatures.RUN_AUTOSCALING_TESTS_ONLY,
     TestEnvironmentFeatures.BLUE_GREEN_DEPLOYMENT,
     TestEnvironmentFeatures.RUN_DB_METRICS_ONLY})
+// Both XA datasources connect to the first instance and the transaction manager prepares on it, so
+// that instance must be the writer: a reader is permanently in recovery and rejects PREPARE
+// TRANSACTION. A preceding failover test can leave the first instance demoted, so have the first
+// instance restored as the writer before running.
+@MakeSureFirstInstanceWriter
 @Order(25)
 @Tag("xa")
 public class XaTwoPhaseCommitTest {

--- a/wrapper/src/test/java/integration/container/tests/XaTwoPhaseCommitTest.java
+++ b/wrapper/src/test/java/integration/container/tests/XaTwoPhaseCommitTest.java
@@ -26,6 +26,7 @@ import integration.container.TestDriverProvider;
 import integration.container.TestEnvironment;
 import integration.container.condition.DisableOnTestFeature;
 import integration.container.condition.EnableOnDatabaseEngine;
+import integration.util.XaTestUtility;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -246,6 +247,8 @@ public class XaTwoPhaseCommitTest {
 
   @TestTemplate
   public void test_twoResourceCommit_bothTransactionManagers() throws Exception {
+    // A two-resource commit always goes through prepare, which requires prepared transactions.
+    XaTestUtility.assumePreparedTransactionsSupported();
     for (final Tm tm : Tm.values()) {
       recreateTables();
       final int id = 10;

--- a/wrapper/src/test/java/integration/host/TestEnvironment.java
+++ b/wrapper/src/test/java/integration/host/TestEnvironment.java
@@ -198,6 +198,7 @@ public class TestEnvironment implements AutoCloseable {
         env.auroraUtil.testClustersCleanUp();
         env.auroraUtil.testInstancesCleanUp();
         env.auroraUtil.testClusterParameterGroupsCleanUp();
+        env.auroraUtil.testDbParameterGroupsCleanUp();
         env.auroraUtil.securityGroupRulesCleanUp();
       }
     }
@@ -283,6 +284,7 @@ public class TestEnvironment implements AutoCloseable {
           initEnv(env);
           cleanUp(env);
           authorizeRunnerIpAddress(env);
+          createCustomParameterGroups(env);
           createMultiAzInstance(env);
           configureIamAccess(env);
           break;
@@ -290,6 +292,7 @@ public class TestEnvironment implements AutoCloseable {
           initEnv(env);
           cleanUp(env);
           authorizeRunnerIpAddress(env);
+          createCustomParameterGroups(env);
           createDbCluster(env);
           configureIamAccess(env);
           break;
@@ -297,16 +300,7 @@ public class TestEnvironment implements AutoCloseable {
           initEnv(env);
           cleanUp(env);
           authorizeRunnerIpAddress(env);
-
-          if (!env.reuseDb
-              && env.info.getRequest().getFeatures().contains(TestEnvironmentFeatures.BLUE_GREEN_DEPLOYMENT)) {
-            createCustomClusterParameterGroup(env);
-          }
-          if (!env.reuseDb
-              && env.info.getClusterParameterGroupName() == null
-              && env.info.getRequest().getDatabaseEngine() == DatabaseEngine.MYSQL) {
-            createMysqlClusterParameterGroup(env);
-          }
+          createCustomParameterGroups(env);
           createDbCluster(env);
           configureIamAccess(env);
           break;
@@ -417,6 +411,55 @@ public class TestEnvironment implements AutoCloseable {
     }
   }
 
+  /**
+   * Creates the custom parameter groups the database needs, before the database itself is created, so
+   * that it comes up with the required settings and no reboot is necessary. Nothing is created when an
+   * existing database is reused.
+   *
+   * <p>Which group type is used depends on the deployment. A cluster (Aurora or RDS multi-az) takes a
+   * DB cluster parameter group, which is the only parameter group {@code CreateDBCluster} accepts and
+   * which carries the instance-level parameters as well. A multi-az instance takes a DB parameter
+   * group, through {@code CreateDBInstance}.
+   */
+  private static void createCustomParameterGroups(TestEnvironment env) {
+    if (env.reuseDb) {
+      return;
+    }
+
+    final TestEnvironmentRequest request = env.info.getRequest();
+    switch (request.getDatabaseEngineDeployment()) {
+      case AURORA:
+        if (request.getFeatures().contains(TestEnvironmentFeatures.BLUE_GREEN_DEPLOYMENT)) {
+          createCustomClusterParameterGroup(env);
+        }
+        if (env.info.getClusterParameterGroupName() == null) {
+          switch (request.getDatabaseEngine()) {
+            case MYSQL:
+              createMysqlClusterParameterGroup(env);
+              break;
+            case PG:
+              createPgClusterParameterGroup(env);
+              break;
+            default:
+              break;
+          }
+        }
+        break;
+      case RDS_MULTI_AZ_CLUSTER:
+        if (request.getDatabaseEngine() == DatabaseEngine.PG) {
+          createPgClusterParameterGroup(env);
+        }
+        break;
+      case RDS_MULTI_AZ_INSTANCE:
+        if (request.getDatabaseEngine() == DatabaseEngine.PG) {
+          createPgDbParameterGroup(env);
+        }
+        break;
+      default:
+        break;
+    }
+  }
+
   private static void createCustomClusterParameterGroup(TestEnvironment env) {
     String groupName = String.format("test-cpg-%s", env.info.getRandomBase());
     String engine = getDbEngine(env.info.getRequest());
@@ -432,6 +475,52 @@ public class TestEnvironment implements AutoCloseable {
     String engineVersion = getDbEngineVersion(engine, env);
     env.auroraUtil.createMysqlClusterParameterGroup(groupName, engine, engineVersion);
     env.info.setClusterParameterGroupName(groupName);
+  }
+
+  /**
+   * Creates the DB cluster parameter group that enables prepared (two-phase) transactions on a
+   * PostgreSQL cluster (Aurora or RDS multi-az), so that the XA tests can prepare a branch instead of
+   * being skipped.
+   *
+   * <p>Enabling prepared transactions is a bonus for the XA tests, not a prerequisite for the rest of
+   * the suite: if the parameter group cannot be created the environment is created without it, and the
+   * XA tests that need a prepared branch skip themselves as they did before.
+   */
+  private static void createPgClusterParameterGroup(TestEnvironment env) {
+    String groupName = String.format("test-pg-cpg-%s", env.info.getRandomBase());
+    String engine = getDbEngine(env.info.getRequest());
+    String engineVersion = getDbEngineVersion(engine, env);
+    try {
+      env.auroraUtil.createPgClusterParameterGroup(groupName, engine, engineVersion);
+      env.info.setClusterParameterGroupName(groupName);
+    } catch (Exception ex) {
+      LOGGER.warning(String.format(
+          "Could not create the PG cluster parameter group %s; the database will be created with the default "
+              + "parameter group and the XA tests that need prepared transactions will be skipped. %s",
+          groupName, ex));
+      env.auroraUtil.deleteCustomClusterParameterGroupSafely(groupName);
+    }
+  }
+
+  /**
+   * Creates the DB parameter group that enables prepared (two-phase) transactions on an RDS PostgreSQL
+   * multi-az instance. Best-effort, for the same reason as
+   * {@link #createPgClusterParameterGroup(TestEnvironment)}.
+   */
+  private static void createPgDbParameterGroup(TestEnvironment env) {
+    String groupName = String.format("test-pg-dpg-%s", env.info.getRandomBase());
+    String engine = getDbEngine(env.info.getRequest());
+    String engineVersion = getDbEngineVersion(engine, env);
+    try {
+      env.auroraUtil.createPgDbParameterGroup(groupName, engine, engineVersion);
+      env.info.setDbParameterGroupName(groupName);
+    } catch (Exception ex) {
+      LOGGER.warning(String.format(
+          "Could not create the PG DB parameter group %s; the database will be created with the default parameter "
+              + "group and the XA tests that need prepared transactions will be skipped. %s",
+          groupName, ex));
+      env.auroraUtil.deleteCustomDbParameterGroupSafely(groupName);
+    }
   }
 
   private static void createValkeyCacheContainer(TestEnvironment env) {
@@ -883,6 +972,7 @@ public class TestEnvironment implements AutoCloseable {
                 engine,
                 instanceClass,
                 engineVersion,
+                env.info.getDbParameterGroupName(),
                 instances);
 
         env.info.setDatabaseEngine(engine);
@@ -1569,6 +1659,9 @@ public class TestEnvironment implements AutoCloseable {
         break;
       case RDS_MULTI_AZ_CLUSTER:
         deleteDbCluster(false);
+        if (!StringUtils.isNullOrEmpty(this.info.getClusterParameterGroupName())) {
+          deleteCustomClusterParameterGroup(this.info.getClusterParameterGroupName());
+        }
         deAuthorizeIP(this);
         break;
       case RDS_MULTI_AZ_INSTANCE:
@@ -1577,6 +1670,7 @@ public class TestEnvironment implements AutoCloseable {
           deleteBlueGreenDeployment();
         }
         deleteMultiAzInstance();
+        deleteCustomDbParameterGroup(this.info.getDbParameterGroupName());
         deAuthorizeIP(this);
         break;
       case RDS:
@@ -1711,6 +1805,16 @@ public class TestEnvironment implements AutoCloseable {
     }
   }
 
+  private void deleteCustomDbParameterGroup(String groupName) {
+    if (!this.reuseDb && !StringUtils.isNullOrEmpty(groupName)) {
+      try {
+        this.auroraUtil.deleteCustomDbParameterGroup(groupName);
+      } catch (Exception ex) {
+        LOGGER.finest(String.format("Error deleting DB parameter group %s. %s", groupName, ex));
+      }
+    }
+  }
+
   private static void preCreateEnvironment(int currentEnvIndex) {
     int index = currentEnvIndex + 1; // inclusive
     int endIndex = index + NUM_OR_ENV_PRE_CREATE; //  exclusive
@@ -1745,6 +1849,7 @@ public class TestEnvironment implements AutoCloseable {
                 initEnv(env);
                 cleanUp(env);
                 authorizeRunnerIpAddress(env);
+                createCustomParameterGroups(env);
                 createMultiAzInstance(env);
                 configureIamAccess(env);
                 break;
@@ -1752,6 +1857,7 @@ public class TestEnvironment implements AutoCloseable {
                 initEnv(env);
                 cleanUp(env);
                 authorizeRunnerIpAddress(env);
+                createCustomParameterGroups(env);
                 createDbCluster(env);
                 configureIamAccess(env);
                 break;
@@ -1759,14 +1865,7 @@ public class TestEnvironment implements AutoCloseable {
                 initEnv(env);
                 cleanUp(env);
                 authorizeRunnerIpAddress(env);
-
-                if (env.info.getRequest().getFeatures().contains(TestEnvironmentFeatures.BLUE_GREEN_DEPLOYMENT)) {
-                  createCustomClusterParameterGroup(env);
-                }
-                if (env.info.getClusterParameterGroupName() == null
-                    && env.info.getRequest().getDatabaseEngine() == DatabaseEngine.MYSQL) {
-                  createMysqlClusterParameterGroup(env);
-                }
+                createCustomParameterGroups(env);
                 createDbCluster(env);
                 configureIamAccess(env);
                 break;

--- a/wrapper/src/test/java/integration/util/AuroraTestUtility.java
+++ b/wrapper/src/test/java/integration/util/AuroraTestUtility.java
@@ -621,7 +621,7 @@ public class AuroraTestUtility {
                 CreateDbClusterParameterGroupRequest.builder()
                 .dbClusterParameterGroupName(groupName)
                 .description("Test custom cluster parameter group for BGD.")
-                .dbParameterGroupFamily(this.getAuroraParameterGroupFamily(engine, engineVersion))
+                .dbParameterGroupFamily(this.getParameterGroupFamily(engine, engineVersion))
                 .tags(this.getTag())
                 .build());
 
@@ -681,7 +681,7 @@ public class AuroraTestUtility {
         CreateDbClusterParameterGroupRequest.builder()
             .dbClusterParameterGroupName(groupName)
             .description("Test cluster parameter group with require_secure_transport disabled.")
-            .dbParameterGroupFamily(this.getAuroraParameterGroupFamily(engine, engineVersion))
+            .dbParameterGroupFamily(this.getParameterGroupFamily(engine, engineVersion))
             .tags(this.getTag())
             .build());
 
@@ -1324,35 +1324,58 @@ public class AuroraTestUtility {
   }
 
   /**
-   * Returns the parameter group family for the given engine, covering both the Aurora engines and the
-   * RDS engines used by the multi-az deployments. The family name is shared by the DB cluster
+   * Returns the parameter group family of the given engine version, covering both the Aurora engines
+   * and the RDS engines used by the multi-az deployments. The family name is shared by the DB cluster
    * parameter groups and the DB parameter groups of an engine.
+   *
+   * <p>The family is looked up from RDS, so that a parameter group is always created in the family the
+   * database actually requires. A hardcoded mapping goes stale as soon as a new major version becomes
+   * the default (RDS then rejects the group with "cannot be used for this instance"), so it is only
+   * used as a fallback when the lookup fails.
    *
    * @param engine        the database engine, for example {@code aurora-postgresql} or {@code postgres}
    * @param engineVersion the database engine version
    * @return the parameter group family name
    */
   public String getParameterGroupFamily(String engine, String engineVersion) {
-    switch (engine) {
-      case "postgres":
-        // RDS PostgreSQL families are named after the major version, for example "postgres17".
-        if (StringUtils.isNullOrEmpty(engineVersion)) {
-          return "postgres" + DEFAULT_PG_MAJOR_VERSION;
-        }
-        final int dotIndex = engineVersion.indexOf('.');
-        return "postgres" + (dotIndex < 0 ? engineVersion : engineVersion.substring(0, dotIndex));
-      default:
-        return getAuroraParameterGroupFamily(engine, engineVersion);
+    final String family = queryParameterGroupFamily(engine, engineVersion);
+    if (!StringUtils.isNullOrEmpty(family)) {
+      return family;
+    }
+    return buildParameterGroupFamily(engine, engineVersion);
+  }
+
+  /**
+   * Asks RDS for the parameter group family of an engine version, or returns null when it cannot be
+   * determined.
+   */
+  private @Nullable String queryParameterGroupFamily(String engine, String engineVersion) {
+    try {
+      final DescribeDbEngineVersionsRequest.Builder request =
+          DescribeDbEngineVersionsRequest.builder().engine(engine);
+      if (!StringUtils.isNullOrEmpty(engineVersion)) {
+        request.engineVersion(engineVersion);
+      }
+      final DescribeDbEngineVersionsResponse response = rdsClient.describeDBEngineVersions(request.build());
+      return response.dbEngineVersions().stream()
+          .map(DBEngineVersion::dbParameterGroupFamily)
+          .filter(family -> !StringUtils.isNullOrEmpty(family))
+          .findFirst()
+          .orElse(null);
+    } catch (Exception ex) {
+      LOGGER.finest(String.format(
+          "Could not query the parameter group family of %s %s: %s", engine, engineVersion, ex.getMessage()));
+      return null;
     }
   }
 
-  public String getAuroraParameterGroupFamily(String engine, String engineVersion) {
+  /** Best-effort parameter group family name, used when RDS cannot be queried. */
+  private String buildParameterGroupFamily(String engine, String engineVersion) {
     switch (engine) {
       case "aurora-postgresql":
-        if (StringUtils.isNullOrEmpty(engineVersion) || engineVersion.startsWith("17.")) {
-          return "aurora-postgresql17";
-        }
-        return "aurora-postgresql16";
+      case "postgres":
+        // The PostgreSQL families are named after the major version, for example "aurora-postgresql17".
+        return engine + majorVersion(engineVersion, DEFAULT_PG_MAJOR_VERSION);
       case "aurora-mysql":
         if (StringUtils.isNullOrEmpty(engineVersion) || engineVersion.contains("8.0")) {
           return "aurora-mysql8.0";
@@ -1364,6 +1387,19 @@ public class AuroraTestUtility {
       default:
         throw new UnsupportedOperationException(engine);
     }
+  }
+
+  private String majorVersion(String engineVersion, String defaultMajorVersion) {
+    if (StringUtils.isNullOrEmpty(engineVersion)) {
+      return defaultMajorVersion;
+    }
+    final int dotIndex = engineVersion.indexOf('.');
+    return dotIndex < 0 ? engineVersion : engineVersion.substring(0, dotIndex);
+  }
+
+  /** Kept for compatibility; {@link #getParameterGroupFamily} also covers the non-Aurora engines. */
+  public String getAuroraParameterGroupFamily(String engine, String engineVersion) {
+    return getParameterGroupFamily(engine, engineVersion);
   }
 
   public List<TestInstanceInfo> getTestInstancesInfo(final String clusterId) {

--- a/wrapper/src/test/java/integration/util/AuroraTestUtility.java
+++ b/wrapper/src/test/java/integration/util/AuroraTestUtility.java
@@ -104,11 +104,14 @@ import software.amazon.awssdk.services.rds.model.CreateDbClusterParameterGroupRe
 import software.amazon.awssdk.services.rds.model.CreateDbClusterRequest;
 import software.amazon.awssdk.services.rds.model.CreateDbInstanceRequest;
 import software.amazon.awssdk.services.rds.model.CreateDbInstanceResponse;
+import software.amazon.awssdk.services.rds.model.CreateDbParameterGroupRequest;
+import software.amazon.awssdk.services.rds.model.CreateDbParameterGroupResponse;
 import software.amazon.awssdk.services.rds.model.DBCluster;
 import software.amazon.awssdk.services.rds.model.DBClusterMember;
 import software.amazon.awssdk.services.rds.model.DBClusterParameterGroup;
 import software.amazon.awssdk.services.rds.model.DBEngineVersion;
 import software.amazon.awssdk.services.rds.model.DBInstance;
+import software.amazon.awssdk.services.rds.model.DBParameterGroup;
 import software.amazon.awssdk.services.rds.model.DbClusterNotFoundException;
 import software.amazon.awssdk.services.rds.model.DbInstanceNotFoundException;
 import software.amazon.awssdk.services.rds.model.DeleteBlueGreenDeploymentRequest;
@@ -117,6 +120,7 @@ import software.amazon.awssdk.services.rds.model.DeleteDbClusterParameterGroupRe
 import software.amazon.awssdk.services.rds.model.DeleteDbClusterResponse;
 import software.amazon.awssdk.services.rds.model.DeleteDbInstanceRequest;
 import software.amazon.awssdk.services.rds.model.DeleteDbInstanceResponse;
+import software.amazon.awssdk.services.rds.model.DeleteDbParameterGroupRequest;
 import software.amazon.awssdk.services.rds.model.DescribeBlueGreenDeploymentsResponse;
 import software.amazon.awssdk.services.rds.model.DescribeDbClusterParameterGroupsResponse;
 import software.amazon.awssdk.services.rds.model.DescribeDbClustersRequest;
@@ -125,6 +129,7 @@ import software.amazon.awssdk.services.rds.model.DescribeDbEngineVersionsRequest
 import software.amazon.awssdk.services.rds.model.DescribeDbEngineVersionsResponse;
 import software.amazon.awssdk.services.rds.model.DescribeDbInstancesRequest;
 import software.amazon.awssdk.services.rds.model.DescribeDbInstancesResponse;
+import software.amazon.awssdk.services.rds.model.DescribeDbParameterGroupsResponse;
 import software.amazon.awssdk.services.rds.model.FailoverDbClusterResponse;
 import software.amazon.awssdk.services.rds.model.Filter;
 import software.amazon.awssdk.services.rds.model.InvalidDbClusterStateException;
@@ -133,6 +138,8 @@ import software.amazon.awssdk.services.rds.model.ListTagsForResourceRequest;
 import software.amazon.awssdk.services.rds.model.ListTagsForResourceResponse;
 import software.amazon.awssdk.services.rds.model.ModifyDbClusterParameterGroupRequest;
 import software.amazon.awssdk.services.rds.model.ModifyDbClusterParameterGroupResponse;
+import software.amazon.awssdk.services.rds.model.ModifyDbParameterGroupRequest;
+import software.amazon.awssdk.services.rds.model.ModifyDbParameterGroupResponse;
 import software.amazon.awssdk.services.rds.model.Parameter;
 import software.amazon.awssdk.services.rds.model.PromoteReadReplicaDbClusterRequest;
 import software.amazon.awssdk.services.rds.model.PromoteReadReplicaDbClusterResponse;
@@ -165,6 +172,11 @@ public class AuroraTestUtility {
   private static final int DEFAULT_IOPS = 64000;
   private static final int DEFAULT_ALLOCATED_STORAGE = 400;
   private static final int MULTI_AZ_SIZE = 3;
+  // Number of concurrently prepared (two-phase) transactions the PostgreSQL test databases allow.
+  // The XA tests never hold more than a handful, and each unused slot only costs shared memory.
+  private static final String PG_MAX_PREPARED_TRANSACTIONS = "100";
+  // Used to build a PostgreSQL parameter group family name when the engine version is unknown.
+  private static final String DEFAULT_PG_MAJOR_VERSION = "17";
   private static final Random rand = new Random();
 
   private final RdsClient rdsClient;
@@ -253,6 +265,8 @@ public class AuroraTestUtility {
    * @param instanceClass the instance class, refer to
    *                      <a href="https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.Support.html">Supported instance classes</a>
    * @param version       the database engine's version
+   * @param clusterParameterGroupName the custom DB cluster parameter group to associate with the cluster, or null to
+   *                                  use the default one
    * @param numInstances  the number of instances to create for the cluster
    * @throws InterruptedException when clusters have not started after 30 minutes
    */
@@ -283,7 +297,8 @@ public class AuroraTestUtility {
                   + MULTI_AZ_SIZE + " instances.");
         }
         createMultiAzCluster(
-            username, password, dbName, identifier, region, engine, instanceClass, version);
+            username, password, dbName, identifier, region, engine, instanceClass, version,
+            clusterParameterGroupName);
         break;
       default:
         throw new UnsupportedOperationException(deployment.toString());
@@ -299,6 +314,7 @@ public class AuroraTestUtility {
       String engine,
       String instanceClass,
       String version,
+      @Nullable String dbParameterGroupName,
       ArrayList<TestInstanceInfo> instances) {
 
     if (deployment != RDS_MULTI_AZ_INSTANCE) {
@@ -316,6 +332,7 @@ public class AuroraTestUtility {
         .engine(engine)
         .engineVersion(version)
         .dbInstanceClass(instanceClass)
+        .dbParameterGroupName(dbParameterGroupName)
         .enablePerformanceInsights(false)
         .backupRetentionPeriod(1)
         .storageEncrypted(true)
@@ -452,6 +469,10 @@ public class AuroraTestUtility {
    * @param instanceClass the instance class, refer to
    *                      <a href="https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.Support.html">Supported instance classes</a>
    * @param version       the database engine's version
+   * @param clusterParameterGroupName the custom DB cluster parameter group to associate with the cluster, or null to
+   *                                  use the default one. A multi-az cluster's DB cluster parameter group carries the
+   *                                  instance-level parameters too, and it is the only parameter group that
+   *                                  {@code CreateDBCluster} accepts.
    * @throws InterruptedException when clusters have not started after 30 minutes
    */
   public void createMultiAzCluster(String username,
@@ -461,7 +482,8 @@ public class AuroraTestUtility {
       String region,
       String engine,
       String instanceClass,
-      String version)
+      String version,
+      @Nullable String clusterParameterGroupName)
       throws InterruptedException {
     CreateDbClusterRequest.Builder clusterBuilder =
         CreateDbClusterRequest.builder()
@@ -479,6 +501,7 @@ public class AuroraTestUtility {
             .tags(this.getTag())
             .allocatedStorage(DEFAULT_ALLOCATED_STORAGE)
             .dbClusterInstanceClass(instanceClass)
+            .dbClusterParameterGroupName(clusterParameterGroupName)
             .storageType(DEFAULT_STORAGE_TYPE)
             .enableIAMDatabaseAuthentication(true)
             .iops(DEFAULT_IOPS);
@@ -629,11 +652,13 @@ public class AuroraTestUtility {
         response2 = rdsClient.modifyDBClusterParameterGroup(
             ModifyDbClusterParameterGroupRequest.builder()
                 .dbClusterParameterGroupName(groupName)
-                .parameters(Parameter.builder()
-                    .parameterName("rds.logical_replication")
-                    .parameterValue("true")
-                    .applyMethod(ApplyMethod.PENDING_REBOOT)
-                    .build())
+                .parameters(
+                    Parameter.builder()
+                        .parameterName("rds.logical_replication")
+                        .parameterValue("true")
+                        .applyMethod(ApplyMethod.PENDING_REBOOT)
+                        .build(),
+                    maxPreparedTransactionsParameter())
                 .build());
         break;
       default:
@@ -681,12 +706,123 @@ public class AuroraTestUtility {
     }
   }
 
+  /**
+   * Creates a DB cluster parameter group for PostgreSQL clusters (Aurora or RDS multi-az) that enables
+   * prepared (two-phase) transactions. A cluster's DB cluster parameter group carries the
+   * instance-level parameters as well, and it is the only parameter group {@code CreateDBCluster}
+   * accepts; see {@link #createPgDbParameterGroup} for a standalone (multi-az) instance.
+   *
+   * @param groupName     the name of the parameter group to create
+   * @param engine        the database engine the group is created for
+   * @param engineVersion the database engine version the group is created for
+   */
+  public void createPgClusterParameterGroup(String groupName, String engine, String engineVersion) {
+    CreateDbClusterParameterGroupResponse response = rdsClient.createDBClusterParameterGroup(
+        CreateDbClusterParameterGroupRequest.builder()
+            .dbClusterParameterGroupName(groupName)
+            .description("Test cluster parameter group with prepared (two-phase) transactions enabled.")
+            .dbParameterGroupFamily(this.getParameterGroupFamily(engine, engineVersion))
+            .tags(this.getTag())
+            .build());
+
+    if (!response.sdkHttpResponse().isSuccessful()) {
+      throw new RuntimeException(
+          "Error creating PG cluster parameter group. " + response.sdkHttpResponse());
+    }
+
+    ModifyDbClusterParameterGroupResponse response2 = rdsClient.modifyDBClusterParameterGroup(
+        ModifyDbClusterParameterGroupRequest.builder()
+            .dbClusterParameterGroupName(groupName)
+            .parameters(maxPreparedTransactionsParameter())
+            .build());
+
+    if (!response2.sdkHttpResponse().isSuccessful()) {
+      throw new RuntimeException(
+          "Error setting max_prepared_transactions. " + response2.sdkHttpResponse());
+    }
+  }
+
+  /**
+   * Creates a DB parameter group for an RDS PostgreSQL instance (the multi-az instance deployment) that
+   * enables prepared (two-phase) transactions. A standalone instance has no cluster, so the setting is
+   * applied through the instance-level parameter group that {@code CreateDBInstance} accepts.
+   *
+   * @param groupName     the name of the parameter group to create
+   * @param engine        the database engine the group is created for
+   * @param engineVersion the database engine version the group is created for
+   */
+  public void createPgDbParameterGroup(String groupName, String engine, String engineVersion) {
+    CreateDbParameterGroupResponse response = rdsClient.createDBParameterGroup(
+        CreateDbParameterGroupRequest.builder()
+            .dbParameterGroupName(groupName)
+            .description("Test DB parameter group with prepared (two-phase) transactions enabled.")
+            .dbParameterGroupFamily(this.getParameterGroupFamily(engine, engineVersion))
+            .tags(this.getTag())
+            .build());
+
+    if (!response.sdkHttpResponse().isSuccessful()) {
+      throw new RuntimeException("Error creating PG DB parameter group. " + response.sdkHttpResponse());
+    }
+
+    ModifyDbParameterGroupResponse response2 = rdsClient.modifyDBParameterGroup(
+        ModifyDbParameterGroupRequest.builder()
+            .dbParameterGroupName(groupName)
+            .parameters(maxPreparedTransactionsParameter())
+            .build());
+
+    if (!response2.sdkHttpResponse().isSuccessful()) {
+      throw new RuntimeException(
+          "Error setting max_prepared_transactions. " + response2.sdkHttpResponse());
+    }
+  }
+
+  /**
+   * PostgreSQL disables prepared (two-phase) transactions by default
+   * ({@code max_prepared_transactions = 0}), which makes {@code XAResource.prepare} fail with
+   * "prepared transactions are disabled". The parameter is static, so it is applied on the next start
+   * of the database: setting it in the parameter group that the database is created with means the
+   * database comes up with prepared transactions already enabled, without an extra reboot.
+   */
+  private Parameter maxPreparedTransactionsParameter() {
+    return Parameter.builder()
+        .parameterName("max_prepared_transactions")
+        .parameterValue(PG_MAX_PREPARED_TRANSACTIONS)
+        .applyMethod(ApplyMethod.PENDING_REBOOT)
+        .build();
+  }
+
   public void deleteCustomClusterParameterGroup(String groupName) {
     rdsClient.deleteDBClusterParameterGroup(
         DeleteDbClusterParameterGroupRequest.builder()
             .dbClusterParameterGroupName(groupName)
             .build()
     );
+  }
+
+  public void deleteCustomDbParameterGroup(String groupName) {
+    rdsClient.deleteDBParameterGroup(
+        DeleteDbParameterGroupRequest.builder()
+            .dbParameterGroupName(groupName)
+            .build()
+    );
+  }
+
+  /** Deletes a DB cluster parameter group, ignoring the case where it was never created. */
+  public void deleteCustomClusterParameterGroupSafely(String groupName) {
+    try {
+      deleteCustomClusterParameterGroup(groupName);
+    } catch (Exception ex) {
+      LOGGER.finest("Could not delete cluster parameter group " + groupName + ": " + ex.getMessage());
+    }
+  }
+
+  /** Deletes a DB parameter group, ignoring the case where it was never created. */
+  public void deleteCustomDbParameterGroupSafely(String groupName) {
+    try {
+      deleteCustomDbParameterGroup(groupName);
+    } catch (Exception ex) {
+      LOGGER.finest("Could not delete DB parameter group " + groupName + ": " + ex.getMessage());
+    }
   }
 
   /**
@@ -1184,6 +1320,29 @@ public class AuroraTestUtility {
         return DatabaseEngine.MYSQL;
       default:
         throw new UnsupportedOperationException(instance.engine());
+    }
+  }
+
+  /**
+   * Returns the parameter group family for the given engine, covering both the Aurora engines and the
+   * RDS engines used by the multi-az deployments. The family name is shared by the DB cluster
+   * parameter groups and the DB parameter groups of an engine.
+   *
+   * @param engine        the database engine, for example {@code aurora-postgresql} or {@code postgres}
+   * @param engineVersion the database engine version
+   * @return the parameter group family name
+   */
+  public String getParameterGroupFamily(String engine, String engineVersion) {
+    switch (engine) {
+      case "postgres":
+        // RDS PostgreSQL families are named after the major version, for example "postgres17".
+        if (StringUtils.isNullOrEmpty(engineVersion)) {
+          return "postgres" + DEFAULT_PG_MAJOR_VERSION;
+        }
+        final int dotIndex = engineVersion.indexOf('.');
+        return "postgres" + (dotIndex < 0 ? engineVersion : engineVersion.substring(0, dotIndex));
+      default:
+        return getAuroraParameterGroupFamily(engine, engineVersion);
     }
   }
 
@@ -2657,41 +2816,11 @@ public class AuroraTestUtility {
           continue;
         }
 
-        // Check age via the "created" tag — skip groups younger than 2 hours to protect
+        // Check age via the "created" tag — skip groups that are still young to protect
         // parameter groups that have been created but not yet attached to a cluster.
-        if (paramGroup.dbClusterParameterGroupArn() != null) {
-          try {
-            ListTagsForResourceResponse tagsResponse = rdsClient.listTagsForResource(
-                ListTagsForResourceRequest.builder()
-                    .resourceName(paramGroup.dbClusterParameterGroupArn())
-                    .build());
-            String createdValue = null;
-            for (Tag tag : tagsResponse.tagList()) {
-              if ("created".equals(tag.key())) {
-                createdValue = tag.value();
-                break;
-              }
-            }
-            if (createdValue != null) {
-              try {
-                ZonedDateTime createdTime = ZonedDateTime.parse(
-                    createdValue, DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss zzz"));
-                if (createdTime.toInstant().plus(12, ChronoUnit.HOURS).isAfter(Instant.now())) {
-                  // Parameter group is less than 12 hours old — skip it
-                  continue;
-                }
-              } catch (Exception parseEx) {
-                // If we can't parse the tag, proceed with deletion (best-effort)
-                LOGGER.finest("Could not parse 'created' tag for " + paramGroup.dbClusterParameterGroupName()
-                    + ": " + parseEx.getMessage());
-              }
-            }
-            // If no "created" tag exists, proceed with deletion (legacy parameter group)
-          } catch (Exception tagEx) {
-            // If we can't read tags, proceed with deletion (best-effort)
-            LOGGER.finest("Could not read tags for " + paramGroup.dbClusterParameterGroupName()
-                + ": " + tagEx.getMessage());
-          }
+        if (isRecentlyCreated(
+            paramGroup.dbClusterParameterGroupArn(), paramGroup.dbClusterParameterGroupName())) {
+          continue;
         }
 
         LOGGER.finest("Deleting cluster parameter group " + paramGroup.dbClusterParameterGroupName());
@@ -2706,5 +2835,89 @@ public class AuroraTestUtility {
     } catch (Exception ex) {
       LOGGER.warning(ex.getMessage());
     }
+  }
+
+  /**
+   * Deletes the leftover test DB parameter groups (the instance-level counterpart of
+   * {@link #testClusterParameterGroupsCleanUp()}), so that an aborted test run that never reached its
+   * cleanup step does not consume the account's parameter group quota.
+   */
+  public void testDbParameterGroupsCleanUp() {
+    try {
+      // Collect parameter group names currently in use by test instances.
+      Set<String> inUseParameterGroups = ConcurrentHashMap.newKeySet();
+      try {
+        DescribeDbInstancesResponse describeDbInstancesResponse = rdsClient.describeDBInstances();
+        for (DBInstance dbInstance : describeDbInstancesResponse.dbInstances()) {
+          dbInstance.dbParameterGroups().forEach(group -> inUseParameterGroups.add(group.dbParameterGroupName()));
+        }
+      } catch (Exception ex) {
+        LOGGER.warning("Error listing instances for parameter group cleanup: " + ex.getMessage());
+      }
+
+      DescribeDbParameterGroupsResponse response = rdsClient.describeDBParameterGroups();
+      for (DBParameterGroup paramGroup : response.dbParameterGroups()) {
+        if (!paramGroup.dbParameterGroupName().startsWith("test-")) {
+          continue;
+        }
+        if (inUseParameterGroups.contains(paramGroup.dbParameterGroupName())) {
+          continue;
+        }
+        if (isRecentlyCreated(paramGroup.dbParameterGroupArn(), paramGroup.dbParameterGroupName())) {
+          continue;
+        }
+
+        LOGGER.finest("Deleting DB parameter group " + paramGroup.dbParameterGroupName());
+        try {
+          rdsClient.deleteDBParameterGroup(builder -> builder
+              .dbParameterGroupName(paramGroup.dbParameterGroupName())
+              .build());
+        } catch (Exception ex) {
+          LOGGER.warning(ex.getMessage());
+        }
+      }
+    } catch (Exception ex) {
+      LOGGER.warning(ex.getMessage());
+    }
+  }
+
+  /**
+   * Returns true when the resource carries a "created" tag that is less than 12 hours old, which
+   * protects a parameter group that has been created but not yet attached to a database. A resource
+   * without a readable or parsable tag is treated as old (best-effort cleanup), which matches the
+   * behavior for legacy parameter groups created before the tag was introduced.
+   */
+  private boolean isRecentlyCreated(final @Nullable String resourceArn, final String resourceName) {
+    if (resourceArn == null) {
+      return false;
+    }
+    try {
+      ListTagsForResourceResponse tagsResponse = rdsClient.listTagsForResource(
+          ListTagsForResourceRequest.builder()
+              .resourceName(resourceArn)
+              .build());
+      String createdValue = null;
+      for (Tag tag : tagsResponse.tagList()) {
+        if ("created".equals(tag.key())) {
+          createdValue = tag.value();
+          break;
+        }
+      }
+      if (createdValue != null) {
+        try {
+          ZonedDateTime createdTime = ZonedDateTime.parse(
+              createdValue, DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss zzz"));
+          return createdTime.toInstant().plus(12, ChronoUnit.HOURS).isAfter(Instant.now());
+        } catch (Exception parseEx) {
+          // If we can't parse the tag, proceed with deletion (best-effort)
+          LOGGER.finest("Could not parse 'created' tag for " + resourceName + ": " + parseEx.getMessage());
+        }
+      }
+      // If no "created" tag exists, proceed with deletion (legacy parameter group)
+    } catch (Exception tagEx) {
+      // If we can't read tags, proceed with deletion (best-effort)
+      LOGGER.finest("Could not read tags for " + resourceName + ": " + tagEx.getMessage());
+    }
+    return false;
   }
 }

--- a/wrapper/src/test/java/integration/util/XaTestUtility.java
+++ b/wrapper/src/test/java/integration/util/XaTestUtility.java
@@ -56,7 +56,9 @@ public final class XaTestUtility {
         maxPreparedTransactions > 0,
         "PostgreSQL prepared (two-phase) transactions are disabled on this server "
             + "(max_prepared_transactions=" + maxPreparedTransactions + "). Set max_prepared_transactions "
-            + "to a value greater than 0 in the DB (cluster) parameter group to run the XA prepare tests.");
+            + "to a value greater than 0 in the DB (cluster) parameter group to run the XA prepare tests. "
+            + "The test framework enables it on the PostgreSQL databases it creates, so this test is only "
+            + "skipped when running against a database that was created without it (for example a reused one).");
   }
 
   private static int queryMaxPreparedTransactions() throws SQLException {

--- a/wrapper/src/test/java/integration/util/XaTestUtility.java
+++ b/wrapper/src/test/java/integration/util/XaTestUtility.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integration.util;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import integration.DatabaseEngine;
+import integration.container.ConnectionStringHelper;
+import integration.container.TestEnvironment;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.logging.Logger;
+
+/** Shared helpers for the XA ({@code XADataSource}) integration tests. */
+public final class XaTestUtility {
+
+  private static final Logger LOGGER = Logger.getLogger(XaTestUtility.class.getName());
+
+  private XaTestUtility() {
+  }
+
+  /**
+   * Skips the calling test when the database cannot prepare (two-phase) transactions.
+   *
+   * <p>PostgreSQL disables prepared transactions by default ({@code max_prepared_transactions = 0}),
+   * in which case {@code XAResource.prepare} always fails with "prepared transactions are disabled".
+   * That is a server prerequisite (set through the RDS/Aurora parameter group), not something the
+   * driver can work around, so tests that need a prepared branch are skipped instead of failing.
+   * MySQL/InnoDB supports XA out of the box, so nothing is skipped there.
+   */
+  public static void assumePreparedTransactionsSupported() throws SQLException {
+    final DatabaseEngine engine = TestEnvironment.getCurrent().getInfo().getRequest().getDatabaseEngine();
+    if (!DatabaseEngine.PG.equals(engine)) {
+      return;
+    }
+
+    final int maxPreparedTransactions = queryMaxPreparedTransactions();
+    assumeTrue(
+        maxPreparedTransactions > 0,
+        "PostgreSQL prepared (two-phase) transactions are disabled on this server "
+            + "(max_prepared_transactions=" + maxPreparedTransactions + "). Set max_prepared_transactions "
+            + "to a value greater than 0 in the DB (cluster) parameter group to run the XA prepare tests.");
+  }
+
+  private static int queryMaxPreparedTransactions() throws SQLException {
+    try (final Connection conn = DriverManager.getConnection(
+            ConnectionStringHelper.getWrapperUrl(),
+            TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getUsername(),
+            TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getPassword());
+        final Statement stmt = conn.createStatement();
+        final ResultSet rs = stmt.executeQuery("SHOW max_prepared_transactions")) {
+      if (!rs.next()) {
+        return 0;
+      }
+      final String value = rs.getString(1);
+      try {
+        return Integer.parseInt(value.trim());
+      } catch (final NumberFormatException e) {
+        LOGGER.finest(() -> "Unexpected max_prepared_transactions value: " + value);
+        return 0;
+      }
+    }
+  }
+}

--- a/wrapper/src/test/java/software/amazon/jdbc/ds/AwsWrapperXADataSourceTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/ds/AwsWrapperXADataSourceTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.mysql.cj.jdbc.MysqlXADataSource;
 import java.io.PrintWriter;
 import java.sql.SQLException;
 import java.util.Properties;
@@ -29,6 +30,8 @@ import javax.sql.XAConnection;
 import javax.sql.XADataSource;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.mariadb.jdbc.MariaDbDataSource;
+import org.postgresql.xa.PGXADataSource;
 import software.amazon.jdbc.ConnectionProvider;
 import software.amazon.jdbc.Driver;
 import software.amazon.jdbc.ds.AwsWrapperXADataSource.ResolvedConfig;
@@ -126,6 +129,85 @@ public class AwsWrapperXADataSourceTest {
     assertTrue(targetUrl.contains("ssl=true"), "target parameter was dropped: " + targetUrl);
     assertTrue(targetUrl.contains("ApplicationName=myapp"), "target parameter was dropped: " + targetUrl);
     assertTrue(targetUrl.startsWith("jdbc:postgresql://host:5432/mydb"), "unexpected base URL: " + targetUrl);
+  }
+
+  @Test
+  void configureTargetXaDataSource_appliesTimeoutsToPgXaDataSource() throws SQLException {
+    // Wrapper timeouts are expressed in milliseconds; PostgreSQL expects seconds.
+    final AwsWrapperXADataSource ds = new AwsWrapperXADataSource();
+    ds.setJdbcUrl("jdbc:aws-wrapper:postgresql://host:5432/mydb");
+    ds.setTargetDataSourceClassName("org.postgresql.xa.PGXADataSource");
+    final Properties props = new Properties();
+    props.setProperty("connectTimeout", "10000");
+    props.setProperty("socketTimeout", "5000");
+    props.setProperty("tcpKeepAlive", "true");
+    ds.setTargetDataSourceProperties(props);
+
+    final PGXADataSource target = new PGXADataSource();
+    ds.configureTargetXaDataSource(target, ds.resolveConfig());
+
+    assertEquals(10, target.getConnectTimeout());
+    assertEquals(5, target.getSocketTimeout());
+    assertTrue(target.getTcpKeepAlive());
+  }
+
+  @Test
+  void configureTargetXaDataSource_appliesTimeoutsToMysqlXaDataSource() throws Exception {
+    // MySQL Connector/J uses milliseconds, the same unit as the wrapper properties.
+    final AwsWrapperXADataSource ds = new AwsWrapperXADataSource();
+    ds.setJdbcUrl("jdbc:aws-wrapper:mysql://host:3306/mydb");
+    ds.setTargetDataSourceClassName("com.mysql.cj.jdbc.MysqlXADataSource");
+    final Properties props = new Properties();
+    props.setProperty("connectTimeout", "10000");
+    props.setProperty("socketTimeout", "2000");
+    ds.setTargetDataSourceProperties(props);
+
+    final MysqlXADataSource target = new MysqlXADataSource();
+    ds.configureTargetXaDataSource(target, ds.resolveConfig());
+
+    assertEquals(10000, target.getConnectTimeout());
+    assertEquals(2000, target.getSocketTimeout());
+  }
+
+  @Test
+  void configureTargetXaDataSource_mariadbTargetAcceptsMysqlSchemeUrl() throws SQLException {
+    // MariaDB Connector/J rejects a "jdbc:mysql://" URL outright ("Wrong mariaDB url") unless the
+    // URL itself carries permitMysqlScheme, and it only accepts timeouts as URL parameters. The
+    // driver normalizes the URL it was given, so assert on the settings it kept rather than on the
+    // exact string.
+    final AwsWrapperXADataSource ds = new AwsWrapperXADataSource();
+    ds.setJdbcProtocol("jdbc:mysql://");
+    ds.setServerName("host");
+    ds.setServerPort("3306");
+    ds.setDatabase("mydb");
+    ds.setTargetDataSourceClassName("org.mariadb.jdbc.MariaDbDataSource");
+    final Properties props = new Properties();
+    props.setProperty("socketTimeout", "2000");
+    ds.setTargetDataSourceProperties(props);
+
+    final MariaDbDataSource target = new MariaDbDataSource();
+    ds.configureTargetXaDataSource(target, ds.resolveConfig());
+
+    final String targetUrl = target.getUrl();
+    assertTrue(targetUrl.contains("host"), "unexpected URL: " + targetUrl);
+    assertTrue(targetUrl.contains("mydb"), "unexpected URL: " + targetUrl);
+    assertTrue(targetUrl.contains("permitMysqlScheme"), "permitMysqlScheme was not added: " + targetUrl);
+    assertTrue(targetUrl.contains("socketTimeout=2000"), "socketTimeout was dropped: " + targetUrl);
+  }
+
+  @Test
+  void configureTargetXaDataSource_mariadbTargetKeepsMariadbSchemeUrlUnchanged() throws SQLException {
+    final AwsWrapperXADataSource ds = new AwsWrapperXADataSource();
+    ds.setJdbcUrl("jdbc:aws-wrapper:mariadb://host:3306/mydb");
+    ds.setTargetDataSourceClassName("org.mariadb.jdbc.MariaDbDataSource");
+
+    final MariaDbDataSource target = new MariaDbDataSource();
+    ds.configureTargetXaDataSource(target, ds.resolveConfig());
+
+    final String targetUrl = target.getUrl();
+    assertTrue(targetUrl.startsWith("jdbc:mariadb://"), "unexpected URL: " + targetUrl);
+    assertFalse(targetUrl.contains("permitMysqlScheme"),
+        "permitMysqlScheme must only be added for a jdbc:mysql:// URL: " + targetUrl);
   }
 
   /** A minimal fake XADataSource exposing bean setters that PropertyUtils can invoke by name. */

--- a/wrapper/src/test/java/software/amazon/jdbc/targetdriverdialect/MariadbTargetDriverDialectTests.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/targetdriverdialect/MariadbTargetDriverDialectTests.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.mariadb.jdbc.MariaDbDataSource;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import software.amazon.jdbc.PropertyDefinition;
 
 public class MariadbTargetDriverDialectTests {
   @Mock private PreparedStatement mockStatement;
@@ -94,6 +95,37 @@ public class MariadbTargetDriverDialectTests {
 
     assertTrue(url.contains("connectTimeout=10000"), url);
     assertTrue(url.contains("socketTimeout=2000"), url);
+  }
+
+  @Test
+  void prepareTargetDataSource_forwardsTargetDriverPropertiesButNotCredentials() throws SQLException {
+    final Properties props = new Properties();
+    props.setProperty(PropertyDefinition.USER.name, "alice");
+    props.setProperty(PropertyDefinition.PASSWORD.name, "secret");
+    props.setProperty(PropertyDefinition.PLUGINS.name, "failover2,efm2");
+    props.setProperty(PropertyDefinition.DATABASE.name, "db");
+    // Unknown to the wrapper, therefore a target driver option. MariaDB data sources have no bean
+    // setter for it, so it has to travel in the URL.
+    props.setProperty("allowPublicKeyRetrieval", "true");
+
+    final String url = dialect.prepareTargetDataSource(
+        new MariaDbDataSource(), "jdbc:mysql://host:3306/db", props);
+
+    assertEquals("jdbc:mysql://host:3306/db?permitMysqlScheme&allowPublicKeyRetrieval=true", url);
+  }
+
+  @Test
+  void prepareTargetDataSource_urlWithForwardedPropertiesIsAcceptedByTheDriver() throws SQLException {
+    final Properties props = new Properties();
+    props.setProperty("allowPublicKeyRetrieval", "true");
+    props.setProperty(PropertyDefinition.SOCKET_TIMEOUT.name, "2000");
+
+    final MariaDbDataSource dataSource = new MariaDbDataSource();
+    final String url = dialect.prepareTargetDataSource(dataSource, "jdbc:mysql://host:3306/db", props);
+    dataSource.setUrl(url);
+
+    assertTrue(dataSource.getUrl().contains("allowPublicKeyRetrieval=true"), dataSource.getUrl());
+    assertTrue(dataSource.getUrl().contains("socketTimeout=2000"), dataSource.getUrl());
   }
 
   @Test

--- a/wrapper/src/test/java/software/amazon/jdbc/targetdriverdialect/MariadbTargetDriverDialectTests.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/targetdriverdialect/MariadbTargetDriverDialectTests.java
@@ -18,12 +18,16 @@ package software.amazon.jdbc.targetdriverdialect;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Properties;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mariadb.jdbc.MariaDbDataSource;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -53,5 +57,53 @@ public class MariadbTargetDriverDialectTests {
         dialect.getSQLQueryString(mockStatement));
     assertNull(dialect.getSQLQueryString(mockStatement));
     assertNull(dialect.getSQLQueryString(mockStatement));
+  }
+
+  @Test
+  void prepareTargetDataSource_addsPermitMysqlSchemeForMysqlUrl() throws SQLException {
+    final String url = dialect.prepareTargetDataSource(
+        new MariaDbDataSource(), "jdbc:mysql://host:3306/db", new Properties());
+
+    assertEquals("jdbc:mysql://host:3306/db?permitMysqlScheme", url);
+  }
+
+  @Test
+  void prepareTargetDataSource_keepsExistingQueryStringAndSkipsDuplicates() throws SQLException {
+    final String url = dialect.prepareTargetDataSource(
+        new MariaDbDataSource(), "jdbc:mysql://host:3306/db?permitMysqlScheme&sslMode=trust", new Properties());
+
+    assertEquals("jdbc:mysql://host:3306/db?permitMysqlScheme&sslMode=trust", url);
+  }
+
+  @Test
+  void prepareTargetDataSource_leavesMariadbUrlUnchanged() throws SQLException {
+    final String url = dialect.prepareTargetDataSource(
+        new MariaDbDataSource(), "jdbc:mariadb://host:3306/db", new Properties());
+
+    assertEquals("jdbc:mariadb://host:3306/db", url);
+  }
+
+  @Test
+  void prepareTargetDataSource_addsTimeoutsInMilliseconds() throws SQLException {
+    final Properties props = new Properties();
+    props.setProperty("connectTimeout", "10000");
+    props.setProperty("socketTimeout", "2000");
+
+    final String url = dialect.prepareTargetDataSource(
+        new MariaDbDataSource(), "jdbc:mariadb://host:3306/db", props);
+
+    assertTrue(url.contains("connectTimeout=10000"), url);
+    assertTrue(url.contains("socketTimeout=2000"), url);
+  }
+
+  @Test
+  void prepareTargetDataSource_doesNotOverrideTimeoutsAlreadyInUrl() throws SQLException {
+    final Properties props = new Properties();
+    props.setProperty("socketTimeout", "2000");
+
+    final String url = dialect.prepareTargetDataSource(
+        new MariaDbDataSource(), "jdbc:mariadb://host:3306/db?socketTimeout=500", props);
+
+    assertEquals("jdbc:mariadb://host:3306/db?socketTimeout=500", url);
   }
 }


### PR DESCRIPTION
## Summary

Fixes the failures from [Run Aurora Integration Tests Latest #30384801581](https://github.com/aws/aws-advanced-jdbc-wrapper/actions/runs/30384801581) on `main` (all 5 jobs failed). The failures fell into five root causes; this PR addresses all of them.

## Main code

**Wrapper timeouts were silently dropped on the XA datasource path.** `AwsWrapperXADataSource` configures the target driver's `XADataSource` directly instead of going through `TargetDriverDialect#prepareConnectInfo`, and hands it only non-wrapper properties. `connectTimeout` / `socketTimeout` / `tcpKeepAlive` were therefore discarded, so an XA connection ran with no socket timeout: when the network was blackholed, the pinned XA session waited instead of surfacing a connection failure, and failover never triggered. This is what made `XaFailoverTest` fail on RDS multi-AZ (where the test simulates an outage with a proxy blackhole rather than a real server failover) with "Expected `XaFailoverNotSupportedSQLException` to be thrown, but nothing was thrown".

- New `TargetDriverDialect#prepareTargetDataSource(CommonDataSource, url, props)` hook (default implementation is a no-op returning the URL unchanged), called from `AwsWrapperXADataSource#configureTargetXaDataSource` and again at connect time in `XADataSourceConnectionProvider` against the final per-connect properties.
- PostgreSQL and MySQL Connector/J dialects apply keep-alive and timeouts to the target in the unit each driver expects (seconds for PostgreSQL, milliseconds for Connector/J). The timeout/keep-alive block in `PgDriverHelper` was extracted so both entry points share it, with no change to the existing call order.
- Both dialects now recognize their XA data source class names (`org.postgresql.xa.PGXADataSource`, `com.mysql.cj.jdbc.MysqlXADataSource`), so the XA path resolves the real driver dialect instead of falling back to the generic one.

**MariaDB Connector/J rejected the target URL.** `MariaDbDataSource#setUrl` refuses a `jdbc:mysql://` URL ("Wrong mariaDB url") unless the URL itself carries `permitMysqlScheme`, which cannot be set as a bean property. The MariaDB dialect now adds it for a MySQL-scheme URL, along with the connect/socket timeouts that driver only accepts as URL parameters (existing parameters are never duplicated or overridden).

## Tests

- `ReadWriteSplittingTests#test_pooledConnection_differentUsers` asserted on `HikariPool.PoolInitializationException`, which #2051 now wraps in a `SQLException` inside `HikariPooledConnectionProvider`. The test expects the `SQLException` and asserts on its cause. This one assertion accounted for 4 failures per environment (the test is inherited by `Auto`, `Simple`, and `AutoSimple` subclasses) across every job.
- `XaTransactionTest#test_readWriteSplittingDoesNotSwitchDuringXaBranch` tolerates a driver that refuses `setReadOnly` while a transaction is active. pgjdbc rejects it client-side ("Cannot change transaction read-only property in the middle of a transaction"), which the JDBC spec allows and which equally proves no connection switch happened. The instance-id assertion is unchanged.
- XA tests that need a prepared branch are skipped (JUnit assumption with an explanatory message) when the server has prepared transactions disabled. PostgreSQL defaults to `max_prepared_transactions = 0`, which makes `XAResource.prepare` fail with "prepared transactions are disabled"; that is a server prerequisite set through the DB/cluster parameter group, not something the driver can work around. This was the largest single contributor to the PostgreSQL job failures. Enabling `max_prepared_transactions` on the PostgreSQL test clusters is a follow-up needed to get real XA coverage there; the containerized standard tests already enable it.

## Testing

- `:aws-advanced-jdbc-wrapper:test` - 1315 unit tests pass.
- New unit tests cover the timeout forwarding for `PGXADataSource` (ms to seconds) and `MysqlXADataSource` (ms passthrough), and the MariaDB URL handling (adds `permitMysqlScheme` only for the MySQL scheme, adds timeouts, does not duplicate or override existing parameters, and the URL is accepted by a real `MariaDbDataSource`).
- `checkstyleMain` / `checkstyleTest` pass; the Checker Framework nullness build compiles with no new findings.
- The Aurora/RDS integration tests themselves were not run locally (they need a live AWS test environment).
