### PR TITLE
fix: resolve javadoc reference errors in rw-splitting resolvers

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/resolver/ReaderResolver.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/resolver/ReaderResolver.java
@@ -21,8 +21,10 @@ import software.amazon.jdbc.plugin.readwritesplitting.RwSplitContext;
 
 /**
  * Establishes a reader connection and switches the current connection to it ("how to reach a
- * reader?"). The default implementation composes a {@link ReaderCandidateSource} with a
- * {@link LoadBalancingPolicy} and applies the per-call connect/retry loop.
+ * reader?"). The default implementation composes a
+ * {@link software.amazon.jdbc.plugin.readwritesplitting.source.ReaderCandidateSource} with a
+ * {@link software.amazon.jdbc.plugin.readwritesplitting.balancer.LoadBalancingPolicy} and applies
+ * the per-call connect/retry loop.
  */
 public interface ReaderResolver {
 

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/resolver/TopologyWriterResolver.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/resolver/TopologyWriterResolver.java
@@ -24,7 +24,8 @@ import software.amazon.jdbc.util.Messages;
 
 /**
  * {@link WriterResolver} that connects to the writer identified from the cluster topology (set by
- * the {@link TopologyRefresher} before this runs). Ports the legacy
+ * the {@link software.amazon.jdbc.plugin.readwritesplitting.refresher.TopologyRefresher} before
+ * this runs). Ports the legacy
  * {@code ReadWriteSplittingPlugin.initializeWriterConnection} connect step.
  */
 public class TopologyWriterResolver implements WriterResolver {


### PR DESCRIPTION
## Summary

Fixes the `javadoc` task failure that broke the `Snapshot to Maven` build on `main`
([run 30482281353](https://github.com/aws/aws-advanced-jdbc-wrapper/actions/runs/30482281353), commit `cb63702`).

The `Build Driver` step (`./gradlew --no-parallel --no-daemon -x test build`) failed with:

```
Execution failed for task ':aws-advanced-jdbc-wrapper:javadoc'.
> Javadoc generation failed.
```

The underlying cause was three `error: reference not found` messages. Three `{@link}` tags in the
`readwritesplitting.resolver` package referenced types that live in sibling packages and were not
imported, so javadoc had no way to resolve the simple names:

| Location | Unresolved reference | Actual package |
| --- | --- | --- |
| `ReaderResolver.java:24` | `ReaderCandidateSource` | `...readwritesplitting.source` |
| `ReaderResolver.java:25` | `LoadBalancingPolicy` | `...readwritesplitting.balancer` |
| `TopologyWriterResolver.java:27` | `TopologyRefresher` | `...readwritesplitting.refresher` |

## Changes

Replaced the simple names in those `{@link}` tags with fully qualified names, rather than adding
imports that only the doc comments would consume.

This touches doc comments only. No executable code, control flow, logging, or exception behavior
was changed, so there is no behavior impact.

## Testing

Verified locally on the same commit as the failing run:

- `./gradlew :aws-advanced-jdbc-wrapper:javadoc` - BUILD SUCCESSFUL, zero `error:` lines
- `./gradlew :aws-advanced-jdbc-wrapper:checkstyleMain` - BUILD SUCCESSFUL (the longer fully
  qualified lines stay within the line-length limit)
- `./gradlew --no-parallel -x test build` - BUILD SUCCESSFUL, mirroring what the failing CI step runs

The pre-existing `warning: no @param/@return/@throws` messages in this area are unchanged; they were
present before this commit and do not fail the build.
