### PR TITLE
chore: shard integration tests across parallel jobs and clusters

### DIFF
--- a/.github/workflows/mlc_config.json
+++ b/.github/workflows/mlc_config.json
@@ -1,6 +1,17 @@
 {
   "retryOn429": true,
   "retryCount": 5,
+  "//": [
+    "aliveStatusCodes treats 403 as reachable: several documentation sites answer 403 to the",
+    "link checker's user agent even though the page is fine. ignorePatterns skips dev.mysql.com",
+    "entirely because it blocks CI runners outright rather than just returning a bot challenge."
+  ],
+  "aliveStatusCodes": [200, 206, 403],
+  "ignorePatterns": [
+    {
+      "pattern": "^https://dev\\.mysql\\.com/"
+    }
+  ],
   "replacementPatterns": [
     {
       "pattern": "^#",

--- a/.github/workflows/mysql_advanced_performance.yml
+++ b/.github/workflows/mysql_advanced_performance.yml
@@ -7,6 +7,16 @@ permissions:
   id-token: write   # This is required for requesting the JWT
   contents: read    # This is required for actions/checkout
 
+concurrency:
+  # These workflows create real RDS clusters and whitelist the runner's IP in the region's
+  # default security group. Running two of them at once risks exhausting the security group
+  # rule quota (60 inbound rules per group) and the DB cluster/instance quotas, since a single
+  # sharded run already claims 20 clusters and 20 rules. Every quota-consuming workflow shares
+  # this group so only one runs at a time; `queue: max` makes the others wait their turn
+  # instead of being cancelled (the default `queue: single` would drop them).
+  group: rds-integration-tests
+  queue: max
+
 jobs:
   aurora-mysql-performance-tests:
     concurrency: AdvancedPerformanceTests-Aurora

--- a/.github/workflows/mysql_performance.yml
+++ b/.github/workflows/mysql_performance.yml
@@ -7,6 +7,16 @@ permissions:
   id-token: write   # This is required for requesting the JWT
   contents: read    # This is required for actions/checkout
 
+concurrency:
+  # These workflows create real RDS clusters and whitelist the runner's IP in the region's
+  # default security group. Running two of them at once risks exhausting the security group
+  # rule quota (60 inbound rules per group) and the DB cluster/instance quotas, since a single
+  # sharded run already claims 20 clusters and 20 rules. Every quota-consuming workflow shares
+  # this group so only one runs at a time; `queue: max` makes the others wait their turn
+  # instead of being cancelled (the default `queue: single` would drop them).
+  group: rds-integration-tests
+  queue: max
+
 jobs:
   aurora-mysql-performance-tests:
     concurrency: PerformanceTests-Aurora

--- a/.github/workflows/pg_advanced_performance.yml
+++ b/.github/workflows/pg_advanced_performance.yml
@@ -7,6 +7,16 @@ permissions:
   id-token: write   # This is required for requesting the JWT
   contents: read    # This is required for actions/checkout
 
+concurrency:
+  # These workflows create real RDS clusters and whitelist the runner's IP in the region's
+  # default security group. Running two of them at once risks exhausting the security group
+  # rule quota (60 inbound rules per group) and the DB cluster/instance quotas, since a single
+  # sharded run already claims 20 clusters and 20 rules. Every quota-consuming workflow shares
+  # this group so only one runs at a time; `queue: max` makes the others wait their turn
+  # instead of being cancelled (the default `queue: single` would drop them).
+  group: rds-integration-tests
+  queue: max
+
 jobs:
   aurora-postgres-performance-tests:
     concurrency: AdvancedPerformanceTests-Aurora

--- a/.github/workflows/pg_performance.yml
+++ b/.github/workflows/pg_performance.yml
@@ -7,6 +7,16 @@ permissions:
   id-token: write   # This is required for requesting the JWT
   contents: read    # This is required for actions/checkout
 
+concurrency:
+  # These workflows create real RDS clusters and whitelist the runner's IP in the region's
+  # default security group. Running two of them at once risks exhausting the security group
+  # rule quota (60 inbound rules per group) and the DB cluster/instance quotas, since a single
+  # sharded run already claims 20 clusters and 20 rules. Every quota-consuming workflow shares
+  # this group so only one runs at a time; `queue: max` makes the others wait their turn
+  # instead of being cancelled (the default `queue: single` would drop them).
+  group: rds-integration-tests
+  queue: max
+
 jobs:
   aurora-postgres-performance-tests:
     concurrency: PerformanceTests-Aurora

--- a/.github/workflows/run-autoscaling-tests.yml
+++ b/.github/workflows/run-autoscaling-tests.yml
@@ -8,8 +8,14 @@ permissions:
   contents: read    # This is required for actions/checkout
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # These workflows create real RDS clusters and whitelist the runner's IP in the region's
+  # default security group. Running two of them at once risks exhausting the security group
+  # rule quota (60 inbound rules per group) and the DB cluster/instance quotas, since a single
+  # sharded run already claims 20 clusters and 20 rules. Every quota-consuming workflow shares
+  # this group so only one runs at a time; `queue: max` makes the others wait their turn
+  # instead of being cancelled (the default `queue: single` would drop them).
+  group: rds-integration-tests
+  queue: max
 
 jobs:
   all-integration-tests:

--- a/.github/workflows/run-bg-integration-tests-latest.yml
+++ b/.github/workflows/run-bg-integration-tests-latest.yml
@@ -10,6 +10,16 @@ permissions:
   id-token: write   # This is required for requesting the JWT
   contents: read    # This is required for actions/checkout
 
+concurrency:
+  # These workflows create real RDS clusters and whitelist the runner's IP in the region's
+  # default security group. Running two of them at once risks exhausting the security group
+  # rule quota (60 inbound rules per group) and the DB cluster/instance quotas, since a single
+  # sharded run already claims 20 clusters and 20 rules. Every quota-consuming workflow shares
+  # this group so only one runs at a time; `queue: max` makes the others wait their turn
+  # instead of being cancelled (the default `queue: single` would drop them).
+  group: rds-integration-tests
+  queue: max
+
 jobs:
   all-bg-integration-tests-latest:
     name: Run Blue/Green integration tests with latest engine version

--- a/.github/workflows/run-integration-tests-5-instance-default.yml
+++ b/.github/workflows/run-integration-tests-5-instance-default.yml
@@ -7,6 +7,16 @@ permissions:
   id-token: write   # This is required for requesting the JWT
   contents: read    # This is required for actions/checkout
 
+concurrency:
+  # These workflows create real RDS clusters and whitelist the runner's IP in the region's
+  # default security group. Running two of them at once risks exhausting the security group
+  # rule quota (60 inbound rules per group) and the DB cluster/instance quotas, since a single
+  # sharded run already claims 20 clusters and 20 rules. Every quota-consuming workflow shares
+  # this group so only one runs at a time; `queue: max` makes the others wait their turn
+  # instead of being cancelled (the default `queue: single` would drop them).
+  group: rds-integration-tests
+  queue: max
+
 jobs:
   aurora-5-instance-integration-tests-default:
     name: 'Run Aurora 5-instance integration tests with default engine version'

--- a/.github/workflows/run-integration-tests-5-instance-latest.yml
+++ b/.github/workflows/run-integration-tests-5-instance-latest.yml
@@ -7,6 +7,16 @@ permissions:
   id-token: write   # This is required for requesting the JWT
   contents: read    # This is required for actions/checkout
 
+concurrency:
+  # These workflows create real RDS clusters and whitelist the runner's IP in the region's
+  # default security group. Running two of them at once risks exhausting the security group
+  # rule quota (60 inbound rules per group) and the DB cluster/instance quotas, since a single
+  # sharded run already claims 20 clusters and 20 rules. Every quota-consuming workflow shares
+  # this group so only one runs at a time; `queue: max` makes the others wait their turn
+  # instead of being cancelled (the default `queue: single` would drop them).
+  group: rds-integration-tests
+  queue: max
+
 jobs:
   aurora-5-instance-integration-tests-latest:
     name: 'Run Aurora 5-instance integration tests with latest engine version'

--- a/.github/workflows/run-integration-tests-codebuild.yml
+++ b/.github/workflows/run-integration-tests-codebuild.yml
@@ -8,8 +8,14 @@ permissions:
   contents: read    # This is required for actions/checkout
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # These workflows create real RDS clusters and whitelist the runner's IP in the region's
+  # default security group. Running two of them at once risks exhausting the security group
+  # rule quota (60 inbound rules per group) and the DB cluster/instance quotas, since a single
+  # sharded run already claims 20 clusters and 20 rules. Every quota-consuming workflow shares
+  # this group so only one runs at a time; `queue: max` makes the others wait their turn
+  # instead of being cancelled (the default `queue: single` would drop them).
+  group: rds-integration-tests
+  queue: max
 
 jobs:
   aurora-integration-tests:

--- a/.github/workflows/run-integration-tests-default.yml
+++ b/.github/workflows/run-integration-tests-default.yml
@@ -13,6 +13,16 @@ permissions:
 
 # See run-integration-tests-latest.yml for an explanation of the sharded matrix. The two workflows
 # are deliberately kept identical in shape so that a shard layout change is applied to both.
+concurrency:
+  # These workflows create real RDS clusters and whitelist the runner's IP in the region's
+  # default security group. Running two of them at once risks exhausting the security group
+  # rule quota (60 inbound rules per group) and the DB cluster/instance quotas, since a single
+  # sharded run already claims 20 clusters and 20 rules. Every quota-consuming workflow shares
+  # this group so only one runs at a time; `queue: max` makes the others wait their turn
+  # instead of being cancelled (the default `queue: single` would drop them).
+  group: rds-integration-tests
+  queue: max
+
 jobs:
   all-integration-tests-default:
     name: 'Default / ${{ matrix.name }}'

--- a/.github/workflows/run-integration-tests-default.yml
+++ b/.github/workflows/run-integration-tests-default.yml
@@ -11,14 +11,45 @@ permissions:
   id-token: write   # This is required for requesting the JWT
   contents: read    # This is required for actions/checkout
 
+# See run-integration-tests-latest.yml for an explanation of the sharded matrix. The two workflows
+# are deliberately kept identical in shape so that a shard layout change is applied to both.
 jobs:
   all-integration-tests-default:
-    name: 'Run Aurora integration tests with default engine version'
+    name: 'Default / ${{ matrix.name }}'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        dbEngine: [ "mysql-aurora", "mysql-aurora-mariadb-driver", "mysql-multi-az", "pg-aurora", "pg-multi-az" ]
+        include:
+          # --- Aurora PG, 3 instances -> 4 shards
+          - { name: pg-aurora-3inst-1of4, task: test-all-pg-aurora, envArgs: '-Dtest-no-instances-1=true', shard: 1, shardCount: 4 }
+          - { name: pg-aurora-3inst-2of4, task: test-all-pg-aurora, envArgs: '-Dtest-no-instances-1=true', shard: 2, shardCount: 4 }
+          - { name: pg-aurora-3inst-3of4, task: test-all-pg-aurora, envArgs: '-Dtest-no-instances-1=true', shard: 3, shardCount: 4 }
+          - { name: pg-aurora-3inst-4of4, task: test-all-pg-aurora, envArgs: '-Dtest-no-instances-1=true', shard: 4, shardCount: 4 }
+          - { name: pg-aurora-1inst, task: test-all-pg-aurora, envArgs: '-Dtest-no-instances-3=true', shard: 1, shardCount: 1 }
+
+          # --- Aurora MySQL (MySQL driver), 3 instances -> 3 shards
+          - { name: mysql-aurora-3inst-1of3, task: test-all-mysql-aurora, envArgs: '-Dtest-no-instances-1=true', shard: 1, shardCount: 3 }
+          - { name: mysql-aurora-3inst-2of3, task: test-all-mysql-aurora, envArgs: '-Dtest-no-instances-1=true', shard: 2, shardCount: 3 }
+          - { name: mysql-aurora-3inst-3of3, task: test-all-mysql-aurora, envArgs: '-Dtest-no-instances-1=true', shard: 3, shardCount: 3 }
+          - { name: mysql-aurora-1inst, task: test-all-mysql-aurora, envArgs: '-Dtest-no-instances-3=true', shard: 1, shardCount: 1 }
+
+          # --- Aurora MySQL (MariaDB driver), 3 instances -> 2 shards
+          - { name: mysql-aurora-mariadb-3inst-1of2, task: test-all-mysql-aurora-mariadb-driver, envArgs: '-Dtest-no-instances-1=true', shard: 1, shardCount: 2 }
+          - { name: mysql-aurora-mariadb-3inst-2of2, task: test-all-mysql-aurora-mariadb-driver, envArgs: '-Dtest-no-instances-1=true', shard: 2, shardCount: 2 }
+          - { name: mysql-aurora-mariadb-1inst, task: test-all-mysql-aurora-mariadb-driver, envArgs: '-Dtest-no-instances-3=true', shard: 1, shardCount: 1 }
+
+          # --- RDS Multi-AZ MySQL cluster -> 4 shards
+          - { name: mysql-multi-az-cluster-1of4, task: test-all-mysql-multi-az, envArgs: '-Dtest-no-multi-az-instance=true', shard: 1, shardCount: 4 }
+          - { name: mysql-multi-az-cluster-2of4, task: test-all-mysql-multi-az, envArgs: '-Dtest-no-multi-az-instance=true', shard: 2, shardCount: 4 }
+          - { name: mysql-multi-az-cluster-3of4, task: test-all-mysql-multi-az, envArgs: '-Dtest-no-multi-az-instance=true', shard: 3, shardCount: 4 }
+          - { name: mysql-multi-az-cluster-4of4, task: test-all-mysql-multi-az, envArgs: '-Dtest-no-multi-az-instance=true', shard: 4, shardCount: 4 }
+          - { name: mysql-multi-az-instance, task: test-all-mysql-multi-az, envArgs: '-Dtest-no-multi-az-cluster=true', shard: 1, shardCount: 1 }
+
+          # --- RDS Multi-AZ PG cluster -> 2 shards
+          - { name: pg-multi-az-cluster-1of2, task: test-all-pg-multi-az, envArgs: '-Dtest-no-multi-az-instance=true', shard: 1, shardCount: 2 }
+          - { name: pg-multi-az-cluster-2of2, task: test-all-pg-multi-az, envArgs: '-Dtest-no-multi-az-instance=true', shard: 2, shardCount: 2 }
+          - { name: pg-multi-az-instance, task: test-all-pg-multi-az, envArgs: '-Dtest-no-multi-az-cluster=true', shard: 1, shardCount: 1 }
     steps:
       - name: 'Clone repository'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -29,6 +60,7 @@ jobs:
         with:
           distribution: 'corretto'
           java-version: 8
+          cache: 'gradle'
       - name: 'Configure AWS credentials'
         id: creds
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c  # v6
@@ -40,7 +72,12 @@ jobs:
           output-credentials: true
       - name: Run integration tests
         run: |
-          ./gradlew --no-parallel --no-daemon test-all-${{ matrix.dbEngine }} -Dtest-no-instances-5=true
+          ./gradlew --no-parallel --no-daemon ${{ matrix.task }} \
+            -Dtest-no-instances-2=true \
+            -Dtest-no-instances-5=true \
+            ${{ matrix.envArgs }} \
+            -Dtest-shard-index=${{ matrix.shard }} \
+            -Dtest-shard-count=${{ matrix.shardCount }}
         env:
           AURORA_CLUSTER_DOMAIN: ${{ secrets.DB_CONN_SUFFIX }}
           RDS_DB_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
@@ -52,18 +89,18 @@ jobs:
       - name: Mask data
         run: |
           ./gradlew --no-parallel --no-daemon maskJunitHtmlReport
-      - name: Archive junit results for ${{ matrix.dbEngine }}
+      - name: Archive junit results for ${{ matrix.name }}
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: junit-report-default-${{ matrix.dbEngine }}
+          name: junit-report-default-${{ matrix.name }}
           path: ./wrapper/build/test-results
           retention-days: 5
-      - name: Archive html summary report for ${{ matrix.dbEngine }}
+      - name: Archive html summary report for ${{ matrix.name }}
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: html-summary-report-default-${{ matrix.dbEngine }}
+          name: html-summary-report-default-${{ matrix.name }}
           path: ./wrapper/build/report
           retention-days: 5
       - name: Get Github Action IP

--- a/.github/workflows/run-integration-tests-default.yml
+++ b/.github/workflows/run-integration-tests-default.yml
@@ -21,29 +21,29 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # --- Aurora PG, 3 instances -> 4 shards
-          - { name: pg-aurora-3inst-1of4, task: test-all-pg-aurora, envArgs: '-Dtest-no-instances-1=true', shard: 1, shardCount: 4 }
-          - { name: pg-aurora-3inst-2of4, task: test-all-pg-aurora, envArgs: '-Dtest-no-instances-1=true', shard: 2, shardCount: 4 }
-          - { name: pg-aurora-3inst-3of4, task: test-all-pg-aurora, envArgs: '-Dtest-no-instances-1=true', shard: 3, shardCount: 4 }
-          - { name: pg-aurora-3inst-4of4, task: test-all-pg-aurora, envArgs: '-Dtest-no-instances-1=true', shard: 4, shardCount: 4 }
+          # --- Aurora PG, 3 instances -> 3 shards
+          - { name: pg-aurora-3inst-1of3, task: test-all-pg-aurora, envArgs: '-Dtest-no-instances-1=true', shard: 1, shardCount: 3 }
+          - { name: pg-aurora-3inst-2of3, task: test-all-pg-aurora, envArgs: '-Dtest-no-instances-1=true', shard: 2, shardCount: 3 }
+          - { name: pg-aurora-3inst-3of3, task: test-all-pg-aurora, envArgs: '-Dtest-no-instances-1=true', shard: 3, shardCount: 3 }
           - { name: pg-aurora-1inst, task: test-all-pg-aurora, envArgs: '-Dtest-no-instances-3=true', shard: 1, shardCount: 1 }
 
-          # --- Aurora MySQL (MySQL driver), 3 instances -> 3 shards
-          - { name: mysql-aurora-3inst-1of3, task: test-all-mysql-aurora, envArgs: '-Dtest-no-instances-1=true', shard: 1, shardCount: 3 }
-          - { name: mysql-aurora-3inst-2of3, task: test-all-mysql-aurora, envArgs: '-Dtest-no-instances-1=true', shard: 2, shardCount: 3 }
-          - { name: mysql-aurora-3inst-3of3, task: test-all-mysql-aurora, envArgs: '-Dtest-no-instances-1=true', shard: 3, shardCount: 3 }
+          # --- Aurora MySQL (MySQL driver), 3 instances -> 4 shards
+          - { name: mysql-aurora-3inst-1of4, task: test-all-mysql-aurora, envArgs: '-Dtest-no-instances-1=true', shard: 1, shardCount: 4 }
+          - { name: mysql-aurora-3inst-2of4, task: test-all-mysql-aurora, envArgs: '-Dtest-no-instances-1=true', shard: 2, shardCount: 4 }
+          - { name: mysql-aurora-3inst-3of4, task: test-all-mysql-aurora, envArgs: '-Dtest-no-instances-1=true', shard: 3, shardCount: 4 }
+          - { name: mysql-aurora-3inst-4of4, task: test-all-mysql-aurora, envArgs: '-Dtest-no-instances-1=true', shard: 4, shardCount: 4 }
           - { name: mysql-aurora-1inst, task: test-all-mysql-aurora, envArgs: '-Dtest-no-instances-3=true', shard: 1, shardCount: 1 }
 
-          # --- Aurora MySQL (MariaDB driver), 3 instances -> 2 shards
-          - { name: mysql-aurora-mariadb-3inst-1of2, task: test-all-mysql-aurora-mariadb-driver, envArgs: '-Dtest-no-instances-1=true', shard: 1, shardCount: 2 }
-          - { name: mysql-aurora-mariadb-3inst-2of2, task: test-all-mysql-aurora-mariadb-driver, envArgs: '-Dtest-no-instances-1=true', shard: 2, shardCount: 2 }
+          # --- Aurora MySQL (MariaDB driver), 3 instances -> 3 shards (critical path)
+          - { name: mysql-aurora-mariadb-3inst-1of3, task: test-all-mysql-aurora-mariadb-driver, envArgs: '-Dtest-no-instances-1=true', shard: 1, shardCount: 3 }
+          - { name: mysql-aurora-mariadb-3inst-2of3, task: test-all-mysql-aurora-mariadb-driver, envArgs: '-Dtest-no-instances-1=true', shard: 2, shardCount: 3 }
+          - { name: mysql-aurora-mariadb-3inst-3of3, task: test-all-mysql-aurora-mariadb-driver, envArgs: '-Dtest-no-instances-1=true', shard: 3, shardCount: 3 }
           - { name: mysql-aurora-mariadb-1inst, task: test-all-mysql-aurora-mariadb-driver, envArgs: '-Dtest-no-instances-3=true', shard: 1, shardCount: 1 }
 
-          # --- RDS Multi-AZ MySQL cluster -> 4 shards
-          - { name: mysql-multi-az-cluster-1of4, task: test-all-mysql-multi-az, envArgs: '-Dtest-no-multi-az-instance=true', shard: 1, shardCount: 4 }
-          - { name: mysql-multi-az-cluster-2of4, task: test-all-mysql-multi-az, envArgs: '-Dtest-no-multi-az-instance=true', shard: 2, shardCount: 4 }
-          - { name: mysql-multi-az-cluster-3of4, task: test-all-mysql-multi-az, envArgs: '-Dtest-no-multi-az-instance=true', shard: 3, shardCount: 4 }
-          - { name: mysql-multi-az-cluster-4of4, task: test-all-mysql-multi-az, envArgs: '-Dtest-no-multi-az-instance=true', shard: 4, shardCount: 4 }
+          # --- RDS Multi-AZ MySQL cluster -> 3 shards
+          - { name: mysql-multi-az-cluster-1of3, task: test-all-mysql-multi-az, envArgs: '-Dtest-no-multi-az-instance=true', shard: 1, shardCount: 3 }
+          - { name: mysql-multi-az-cluster-2of3, task: test-all-mysql-multi-az, envArgs: '-Dtest-no-multi-az-instance=true', shard: 2, shardCount: 3 }
+          - { name: mysql-multi-az-cluster-3of3, task: test-all-mysql-multi-az, envArgs: '-Dtest-no-multi-az-instance=true', shard: 3, shardCount: 3 }
           - { name: mysql-multi-az-instance, task: test-all-mysql-multi-az, envArgs: '-Dtest-no-multi-az-cluster=true', shard: 1, shardCount: 1 }
 
           # --- RDS Multi-AZ PG cluster -> 2 shards

--- a/.github/workflows/run-integration-tests-full-matrix-weekly.yml
+++ b/.github/workflows/run-integration-tests-full-matrix-weekly.yml
@@ -1,0 +1,92 @@
+name: Run Aurora Integration Tests Full Matrix Weekly
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Saturdays at 12:30 AM PST (8:30 AM UTC), when nothing else is competing for clusters.
+    - cron: '30 8 * * 6'
+
+permissions:
+  id-token: write   # This is required for requesting the JWT
+  contents: read    # This is required for actions/checkout
+
+# The daily "default" and "latest" workflows skip the 2-instance Aurora environment: it re-runs
+# almost exactly the same tests as the 3-instance environment for ~60 minutes per engine, and only
+# these 9 tests genuinely need a 2-node topology:
+#
+#   FailoverTest / Failover2Test / GdbFailoverTest       test_failFromReaderToWriter
+#   ReadWriteSplittingTests / AutoReadWriteSplittingTests
+#       test_setReadOnlyTrue_oneReaderDown_failoverRecovers
+#       test_setReadOnlyTrue_oneReaderDown_fallsBackToWriter
+#       test_setReadOnlyTrue_oneReaderDown_readThrows
+#
+# This workflow keeps that coverage on a weekly cadence. It runs the 2-instance environment only
+# (the other topologies are covered daily), unsharded, one job per engine.
+jobs:
+  two-instance-integration-tests:
+    name: 'Weekly 2-instance / ${{ matrix.dbEngine }}'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        dbEngine: [ "mysql-aurora", "mysql-aurora-mariadb-driver", "pg-aurora" ]
+    steps:
+      - name: 'Clone repository'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          fetch-depth: 50
+      - name: 'Set up JDK 8'
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95  # v5
+        with:
+          distribution: 'corretto'
+          java-version: 8
+          cache: 'gradle'
+      - name: 'Configure AWS credentials'
+        id: creds
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c  # v6
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_DEPLOY_ROLE }}
+          role-session-name: run_integration_test_weekly_full_matrix
+          role-duration-seconds: 21600
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+          output-credentials: true
+      - name: Run integration tests
+        run: |
+          ./gradlew --no-parallel --no-daemon test-all-${{ matrix.dbEngine }} \
+            -Dtest-no-instances-1=true \
+            -Dtest-no-instances-3=true \
+            -Dtest-no-instances-5=true
+        env:
+          AURORA_CLUSTER_DOMAIN: ${{ secrets.DB_CONN_SUFFIX }}
+          RDS_DB_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+          AWS_ACCESS_KEY_ID: ${{ steps.creds.outputs.aws-access-key-id }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.creds.outputs.aws-secret-access-key }}
+          AWS_SESSION_TOKEN: ${{ steps.creds.outputs.aws-session-token }}
+          MYSQL_VERSION: "latest"
+          PG_VERSION: "latest"
+      - name: Mask data
+        run: |
+          ./gradlew --no-parallel --no-daemon maskJunitHtmlReport
+      - name: Archive junit results for ${{ matrix.dbEngine }}
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: junit-report-weekly-2inst-${{ matrix.dbEngine }}
+          path: ./wrapper/build/test-results
+          retention-days: 5
+      - name: Archive html summary report for ${{ matrix.dbEngine }}
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: html-summary-report-weekly-2inst-${{ matrix.dbEngine }}
+          path: ./wrapper/build/report
+          retention-days: 5
+      - name: Get Github Action IP
+        if: always()
+        id: ip
+        run: echo "ipv4=$(curl -s https://checkip.amazonaws.com)" >> $GITHUB_OUTPUT
+
+      - name: Remove Github Action IP
+        if: always()
+        run: |
+          aws ec2 revoke-security-group-ingress --group-name default --protocol all --port 0-65535 --cidr ${{ steps.ip.outputs.ipv4 }}/32

--- a/.github/workflows/run-integration-tests-full-matrix-weekly.yml
+++ b/.github/workflows/run-integration-tests-full-matrix-weekly.yml
@@ -3,8 +3,9 @@ name: Run Aurora Integration Tests Full Matrix Weekly
 on:
   workflow_dispatch:
   schedule:
-    # Saturdays at 12:30 AM PST (8:30 AM UTC), when nothing else is competing for clusters.
-    - cron: '30 8 * * 6'
+    # Sundays at 12:30 AM PST (8:30 AM UTC). Sunday is the only day with no other scheduled
+    # integration test workflow, so this never has to queue behind one.
+    - cron: '30 8 * * 0'
 
 permissions:
   id-token: write   # This is required for requesting the JWT
@@ -22,6 +23,16 @@ permissions:
 #
 # This workflow keeps that coverage on a weekly cadence. It runs the 2-instance environment only
 # (the other topologies are covered daily), unsharded, one job per engine.
+concurrency:
+  # These workflows create real RDS clusters and whitelist the runner's IP in the region's
+  # default security group. Running two of them at once risks exhausting the security group
+  # rule quota (60 inbound rules per group) and the DB cluster/instance quotas, since a single
+  # sharded run already claims 20 clusters and 20 rules. Every quota-consuming workflow shares
+  # this group so only one runs at a time; `queue: max` makes the others wait their turn
+  # instead of being cancelled (the default `queue: single` would drop them).
+  group: rds-integration-tests
+  queue: max
+
 jobs:
   two-instance-integration-tests:
     name: 'Weekly 2-instance / ${{ matrix.dbEngine }}'

--- a/.github/workflows/run-integration-tests-latest.yml
+++ b/.github/workflows/run-integration-tests-latest.yml
@@ -10,14 +10,56 @@ permissions:
   id-token: write   # This is required for requesting the JWT
   contents: read    # This is required for actions/checkout
 
+# Each matrix entry below pins itself to exactly ONE test environment and runs ONE shard of the
+# integration test classes against its own database cluster, so the whole suite runs in parallel
+# instead of one engine at a time. 20 entries => at most 20 concurrent clusters / ~52 DB instances,
+# and 20 inbound rules in the region's default security group (quota is 60 per security group).
+#
+# Shard counts are sized from measured per-class timings so every shard lands at roughly the same
+# duration; see the weight table in wrapper/src/test/build.gradle.kts. Class-to-shard assignment is
+# computed there from the compiled classes on disk, so adding a test class needs no change here.
+#
+# The 2-instance Aurora environment is NOT covered here - it is a near-duplicate of the 3-instance
+# one and is exercised by run-integration-tests-full-matrix-weekly.yml instead.
 jobs:
   all-integration-tests-latest:
-    name: Run Aurora integration tests with latest engine version
+    name: 'Latest / ${{ matrix.name }}'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        dbEngine: [ "mysql-aurora", "mysql-aurora-mariadb-driver", "mysql-multi-az", "pg-aurora", "pg-multi-az" ]
+        include:
+          # --- Aurora PG, 3 instances: 116.8 min of tests -> 4 shards
+          - { name: pg-aurora-3inst-1of4, task: test-all-pg-aurora, envArgs: '-Dtest-no-instances-1=true', shard: 1, shardCount: 4 }
+          - { name: pg-aurora-3inst-2of4, task: test-all-pg-aurora, envArgs: '-Dtest-no-instances-1=true', shard: 2, shardCount: 4 }
+          - { name: pg-aurora-3inst-3of4, task: test-all-pg-aurora, envArgs: '-Dtest-no-instances-1=true', shard: 3, shardCount: 4 }
+          - { name: pg-aurora-3inst-4of4, task: test-all-pg-aurora, envArgs: '-Dtest-no-instances-1=true', shard: 4, shardCount: 4 }
+          # --- Aurora PG, single instance: 4.2 min of tests -> 1 shard
+          - { name: pg-aurora-1inst, task: test-all-pg-aurora, envArgs: '-Dtest-no-instances-3=true', shard: 1, shardCount: 1 }
+
+          # --- Aurora MySQL (MySQL driver), 3 instances: 110.2 min -> 3 shards
+          - { name: mysql-aurora-3inst-1of3, task: test-all-mysql-aurora, envArgs: '-Dtest-no-instances-1=true', shard: 1, shardCount: 3 }
+          - { name: mysql-aurora-3inst-2of3, task: test-all-mysql-aurora, envArgs: '-Dtest-no-instances-1=true', shard: 2, shardCount: 3 }
+          - { name: mysql-aurora-3inst-3of3, task: test-all-mysql-aurora, envArgs: '-Dtest-no-instances-1=true', shard: 3, shardCount: 3 }
+          - { name: mysql-aurora-1inst, task: test-all-mysql-aurora, envArgs: '-Dtest-no-instances-3=true', shard: 1, shardCount: 1 }
+
+          # --- Aurora MySQL (MariaDB driver), 3 instances: 71.3 min -> 2 shards
+          - { name: mysql-aurora-mariadb-3inst-1of2, task: test-all-mysql-aurora-mariadb-driver, envArgs: '-Dtest-no-instances-1=true', shard: 1, shardCount: 2 }
+          - { name: mysql-aurora-mariadb-3inst-2of2, task: test-all-mysql-aurora-mariadb-driver, envArgs: '-Dtest-no-instances-1=true', shard: 2, shardCount: 2 }
+          - { name: mysql-aurora-mariadb-1inst, task: test-all-mysql-aurora-mariadb-driver, envArgs: '-Dtest-no-instances-3=true', shard: 1, shardCount: 1 }
+
+          # --- RDS Multi-AZ MySQL cluster: 89.0 min -> 4 shards (Multi-AZ provisioning is slow, so
+          #     these shards are kept small to offset the larger fixed overhead)
+          - { name: mysql-multi-az-cluster-1of4, task: test-all-mysql-multi-az, envArgs: '-Dtest-no-multi-az-instance=true', shard: 1, shardCount: 4 }
+          - { name: mysql-multi-az-cluster-2of4, task: test-all-mysql-multi-az, envArgs: '-Dtest-no-multi-az-instance=true', shard: 2, shardCount: 4 }
+          - { name: mysql-multi-az-cluster-3of4, task: test-all-mysql-multi-az, envArgs: '-Dtest-no-multi-az-instance=true', shard: 3, shardCount: 4 }
+          - { name: mysql-multi-az-cluster-4of4, task: test-all-mysql-multi-az, envArgs: '-Dtest-no-multi-az-instance=true', shard: 4, shardCount: 4 }
+          - { name: mysql-multi-az-instance, task: test-all-mysql-multi-az, envArgs: '-Dtest-no-multi-az-cluster=true', shard: 1, shardCount: 1 }
+
+          # --- RDS Multi-AZ PG cluster: 40.4 min -> 2 shards
+          - { name: pg-multi-az-cluster-1of2, task: test-all-pg-multi-az, envArgs: '-Dtest-no-multi-az-instance=true', shard: 1, shardCount: 2 }
+          - { name: pg-multi-az-cluster-2of2, task: test-all-pg-multi-az, envArgs: '-Dtest-no-multi-az-instance=true', shard: 2, shardCount: 2 }
+          - { name: pg-multi-az-instance, task: test-all-pg-multi-az, envArgs: '-Dtest-no-multi-az-cluster=true', shard: 1, shardCount: 1 }
     steps:
       - name: 'Clone repository'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -28,6 +70,7 @@ jobs:
         with:
           distribution: 'corretto'
           java-version: 8
+          cache: 'gradle'
       - name: 'Configure AWS credentials'
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c  # v6
         id: creds
@@ -39,7 +82,12 @@ jobs:
           output-credentials: true
       - name: Run integration tests
         run: |
-          ./gradlew --no-parallel --no-daemon test-all-${{ matrix.dbEngine }} -Dtest-no-instances-5=true
+          ./gradlew --no-parallel --no-daemon ${{ matrix.task }} \
+            -Dtest-no-instances-2=true \
+            -Dtest-no-instances-5=true \
+            ${{ matrix.envArgs }} \
+            -Dtest-shard-index=${{ matrix.shard }} \
+            -Dtest-shard-count=${{ matrix.shardCount }}
         env:
           AURORA_CLUSTER_DOMAIN: ${{ secrets.DB_CONN_SUFFIX }}
           RDS_DB_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
@@ -51,18 +99,18 @@ jobs:
       - name: Mask data
         run: |
           ./gradlew --no-parallel --no-daemon maskJunitHtmlReport
-      - name: Archive junit results for ${{ matrix.dbEngine }}
+      - name: Archive junit results for ${{ matrix.name }}
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: junit-report-latest-${{ matrix.dbEngine }}
+          name: junit-report-latest-${{ matrix.name }}
           path: ./wrapper/build/test-results
           retention-days: 5
-      - name: Archive html summary report for ${{ matrix.dbEngine }}
+      - name: Archive html summary report for ${{ matrix.name }}
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: html-summary-report-latest-${{ matrix.dbEngine }}
+          name: html-summary-report-latest-${{ matrix.name }}
           path: ./wrapper/build/report
           retention-days: 5
       - name: Get Github Action IP

--- a/.github/workflows/run-integration-tests-latest.yml
+++ b/.github/workflows/run-integration-tests-latest.yml
@@ -22,6 +22,16 @@ permissions:
 #
 # The 2-instance Aurora environment is NOT covered here - it is a near-duplicate of the 3-instance
 # one and is exercised by run-integration-tests-full-matrix-weekly.yml instead.
+concurrency:
+  # These workflows create real RDS clusters and whitelist the runner's IP in the region's
+  # default security group. Running two of them at once risks exhausting the security group
+  # rule quota (60 inbound rules per group) and the DB cluster/instance quotas, since a single
+  # sharded run already claims 20 clusters and 20 rules. Every quota-consuming workflow shares
+  # this group so only one runs at a time; `queue: max` makes the others wait their turn
+  # instead of being cancelled (the default `queue: single` would drop them).
+  group: rds-integration-tests
+  queue: max
+
 jobs:
   all-integration-tests-latest:
     name: 'Latest / ${{ matrix.name }}'

--- a/.github/workflows/run-integration-tests-latest.yml
+++ b/.github/workflows/run-integration-tests-latest.yml
@@ -12,12 +12,13 @@ permissions:
 
 # Each matrix entry below pins itself to exactly ONE test environment and runs ONE shard of the
 # integration test classes against its own database cluster, so the whole suite runs in parallel
-# instead of one engine at a time. 20 entries => at most 20 concurrent clusters / ~52 DB instances,
+# instead of one engine at a time. 20 entries => at most 20 concurrent clusters / 50 DB instances,
 # and 20 inbound rules in the region's default security group (quota is 60 per security group).
 #
-# Shard counts are sized from measured per-class timings so every shard lands at roughly the same
-# duration; see the weight table in wrapper/src/test/build.gradle.kts. Class-to-shard assignment is
-# computed there from the compiled classes on disk, so adding a test class needs no change here.
+# Shard counts are sized from the per-environment totals measured in run 30645460736, and the
+# per-class weight table in wrapper/src/test/build.gradle.kts keeps the shards within a group evenly
+# sized. Class-to-shard assignment is computed there from the compiled classes on disk, so adding a
+# test class needs no change here. Projected critical path is ~54 min (mysql-aurora-mariadb-3inst).
 #
 # The 2-instance Aurora environment is NOT covered here - it is a near-duplicate of the 3-instance
 # one and is exercised by run-integration-tests-full-matrix-weekly.yml instead.
@@ -29,34 +30,34 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # --- Aurora PG, 3 instances: 116.8 min of tests -> 4 shards
-          - { name: pg-aurora-3inst-1of4, task: test-all-pg-aurora, envArgs: '-Dtest-no-instances-1=true', shard: 1, shardCount: 4 }
-          - { name: pg-aurora-3inst-2of4, task: test-all-pg-aurora, envArgs: '-Dtest-no-instances-1=true', shard: 2, shardCount: 4 }
-          - { name: pg-aurora-3inst-3of4, task: test-all-pg-aurora, envArgs: '-Dtest-no-instances-1=true', shard: 3, shardCount: 4 }
-          - { name: pg-aurora-3inst-4of4, task: test-all-pg-aurora, envArgs: '-Dtest-no-instances-1=true', shard: 4, shardCount: 4 }
-          # --- Aurora PG, single instance: 4.2 min of tests -> 1 shard
+          # --- Aurora PG, 3 instances: 95.6 min of tests -> 3 shards (~47 min)
+          - { name: pg-aurora-3inst-1of3, task: test-all-pg-aurora, envArgs: '-Dtest-no-instances-1=true', shard: 1, shardCount: 3 }
+          - { name: pg-aurora-3inst-2of3, task: test-all-pg-aurora, envArgs: '-Dtest-no-instances-1=true', shard: 2, shardCount: 3 }
+          - { name: pg-aurora-3inst-3of3, task: test-all-pg-aurora, envArgs: '-Dtest-no-instances-1=true', shard: 3, shardCount: 3 }
+          # --- Aurora PG, single instance: 4.9 min of tests -> 1 shard
           - { name: pg-aurora-1inst, task: test-all-pg-aurora, envArgs: '-Dtest-no-instances-3=true', shard: 1, shardCount: 1 }
 
-          # --- Aurora MySQL (MySQL driver), 3 instances: 110.2 min -> 3 shards
-          - { name: mysql-aurora-3inst-1of3, task: test-all-mysql-aurora, envArgs: '-Dtest-no-instances-1=true', shard: 1, shardCount: 3 }
-          - { name: mysql-aurora-3inst-2of3, task: test-all-mysql-aurora, envArgs: '-Dtest-no-instances-1=true', shard: 2, shardCount: 3 }
-          - { name: mysql-aurora-3inst-3of3, task: test-all-mysql-aurora, envArgs: '-Dtest-no-instances-1=true', shard: 3, shardCount: 3 }
+          # --- Aurora MySQL (MySQL driver), 3 instances: 126.8 min -> 4 shards (~47 min)
+          - { name: mysql-aurora-3inst-1of4, task: test-all-mysql-aurora, envArgs: '-Dtest-no-instances-1=true', shard: 1, shardCount: 4 }
+          - { name: mysql-aurora-3inst-2of4, task: test-all-mysql-aurora, envArgs: '-Dtest-no-instances-1=true', shard: 2, shardCount: 4 }
+          - { name: mysql-aurora-3inst-3of4, task: test-all-mysql-aurora, envArgs: '-Dtest-no-instances-1=true', shard: 3, shardCount: 4 }
+          - { name: mysql-aurora-3inst-4of4, task: test-all-mysql-aurora, envArgs: '-Dtest-no-instances-1=true', shard: 4, shardCount: 4 }
           - { name: mysql-aurora-1inst, task: test-all-mysql-aurora, envArgs: '-Dtest-no-instances-3=true', shard: 1, shardCount: 1 }
 
-          # --- Aurora MySQL (MariaDB driver), 3 instances: 71.3 min -> 2 shards
-          - { name: mysql-aurora-mariadb-3inst-1of2, task: test-all-mysql-aurora-mariadb-driver, envArgs: '-Dtest-no-instances-1=true', shard: 1, shardCount: 2 }
-          - { name: mysql-aurora-mariadb-3inst-2of2, task: test-all-mysql-aurora-mariadb-driver, envArgs: '-Dtest-no-instances-1=true', shard: 2, shardCount: 2 }
+          # --- Aurora MySQL (MariaDB driver), 3 instances: 114.8 min -> 3 shards (~54 min).
+          #     This is the critical path; give it a 4th shard first if more clusters become available.
+          - { name: mysql-aurora-mariadb-3inst-1of3, task: test-all-mysql-aurora-mariadb-driver, envArgs: '-Dtest-no-instances-1=true', shard: 1, shardCount: 3 }
+          - { name: mysql-aurora-mariadb-3inst-2of3, task: test-all-mysql-aurora-mariadb-driver, envArgs: '-Dtest-no-instances-1=true', shard: 2, shardCount: 3 }
+          - { name: mysql-aurora-mariadb-3inst-3of3, task: test-all-mysql-aurora-mariadb-driver, envArgs: '-Dtest-no-instances-1=true', shard: 3, shardCount: 3 }
           - { name: mysql-aurora-mariadb-1inst, task: test-all-mysql-aurora-mariadb-driver, envArgs: '-Dtest-no-instances-3=true', shard: 1, shardCount: 1 }
 
-          # --- RDS Multi-AZ MySQL cluster: 89.0 min -> 4 shards (Multi-AZ provisioning is slow, so
-          #     these shards are kept small to offset the larger fixed overhead)
-          - { name: mysql-multi-az-cluster-1of4, task: test-all-mysql-multi-az, envArgs: '-Dtest-no-multi-az-instance=true', shard: 1, shardCount: 4 }
-          - { name: mysql-multi-az-cluster-2of4, task: test-all-mysql-multi-az, envArgs: '-Dtest-no-multi-az-instance=true', shard: 2, shardCount: 4 }
-          - { name: mysql-multi-az-cluster-3of4, task: test-all-mysql-multi-az, envArgs: '-Dtest-no-multi-az-instance=true', shard: 3, shardCount: 4 }
-          - { name: mysql-multi-az-cluster-4of4, task: test-all-mysql-multi-az, envArgs: '-Dtest-no-multi-az-instance=true', shard: 4, shardCount: 4 }
+          # --- RDS Multi-AZ MySQL cluster: 97.1 min -> 3 shards (~50 min)
+          - { name: mysql-multi-az-cluster-1of3, task: test-all-mysql-multi-az, envArgs: '-Dtest-no-multi-az-instance=true', shard: 1, shardCount: 3 }
+          - { name: mysql-multi-az-cluster-2of3, task: test-all-mysql-multi-az, envArgs: '-Dtest-no-multi-az-instance=true', shard: 2, shardCount: 3 }
+          - { name: mysql-multi-az-cluster-3of3, task: test-all-mysql-multi-az, envArgs: '-Dtest-no-multi-az-instance=true', shard: 3, shardCount: 3 }
           - { name: mysql-multi-az-instance, task: test-all-mysql-multi-az, envArgs: '-Dtest-no-multi-az-cluster=true', shard: 1, shardCount: 1 }
 
-          # --- RDS Multi-AZ PG cluster: 40.4 min -> 2 shards
+          # --- RDS Multi-AZ PG cluster: 44.2 min -> 2 shards (~43 min)
           - { name: pg-multi-az-cluster-1of2, task: test-all-pg-multi-az, envArgs: '-Dtest-no-multi-az-instance=true', shard: 1, shardCount: 2 }
           - { name: pg-multi-az-cluster-2of2, task: test-all-pg-multi-az, envArgs: '-Dtest-no-multi-az-instance=true', shard: 2, shardCount: 2 }
           - { name: pg-multi-az-instance, task: test-all-pg-multi-az, envArgs: '-Dtest-no-multi-az-cluster=true', shard: 1, shardCount: 1 }

--- a/.github/workflows/run-integration-tests-mysql-aurora-java-lts.yml
+++ b/.github/workflows/run-integration-tests-mysql-aurora-java-lts.yml
@@ -10,6 +10,16 @@ permissions:
   id-token: write   # This is required for requesting the JWT
   contents: read    # This is required for actions/checkout
 
+concurrency:
+  # These workflows create real RDS clusters and whitelist the runner's IP in the region's
+  # default security group. Running two of them at once risks exhausting the security group
+  # rule quota (60 inbound rules per group) and the DB cluster/instance quotas, since a single
+  # sharded run already claims 20 clusters and 20 rules. Every quota-consuming workflow shares
+  # this group so only one runs at a time; `queue: max` makes the others wait their turn
+  # instead of being cancelled (the default `queue: single` would drop them).
+  group: rds-integration-tests
+  queue: max
+
 jobs:
   all-mysql-integration-tests-java-lts:
     name: Run integration tests with MySQL Aurora latest version

--- a/.github/workflows/run-metrics-latest.yml
+++ b/.github/workflows/run-metrics-latest.yml
@@ -9,6 +9,16 @@ permissions:
   id-token: write   # This is required for requesting the JWT
   contents: read    # This is required for actions/checkout
 
+concurrency:
+  # These workflows create real RDS clusters and whitelist the runner's IP in the region's
+  # default security group. Running two of them at once risks exhausting the security group
+  # rule quota (60 inbound rules per group) and the DB cluster/instance quotas, since a single
+  # sharded run already claims 20 clusters and 20 rules. Every quota-consuming workflow shares
+  # this group so only one runs at a time; `queue: max` makes the others wait their turn
+  # instead of being cancelled (the default `queue: single` would drop them).
+  group: rds-integration-tests
+  queue: max
+
 jobs:
   run-metrics-with-latest:
     name: Run Metrics with latest engine version

--- a/.github/workflows/test-encryption-e2e.yml
+++ b/.github/workflows/test-encryption-e2e.yml
@@ -8,8 +8,14 @@ on:
       - kms_encryption_rebased
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # These workflows create real RDS clusters and whitelist the runner's IP in the region's
+  # default security group. Running two of them at once risks exhausting the security group
+  # rule quota (60 inbound rules per group) and the DB cluster/instance quotas, since a single
+  # sharded run already claims 20 clusters and 20 rules. Every quota-consuming workflow shares
+  # this group so only one runs at a time; `queue: max` makes the others wait their turn
+  # instead of being cancelled (the default `queue: single` would drop them).
+  group: rds-integration-tests
+  queue: max
 
 permissions:
   contents: read

--- a/docs/JDBC-WRAPPER-CONFIGURATION-ASSISTANT.md
+++ b/docs/JDBC-WRAPPER-CONFIGURATION-ASSISTANT.md
@@ -371,7 +371,7 @@ URL: cluster reader endpoint (`*.cluster-ro-XXX.<region>.rds.amazonaws.com`). Re
 - **`efm2` left out by default** — `tcpKeepAlive=true` covers the analytics datasource, and short OLTP queries time out via `socketTimeout` long before EFM would fire. Add `efm2` to either datasource if you can't tune OS keep-alive (see §6.10 decision matrix).
 - **Same `clusterId`** — both pools see the same physical cluster, so they share topology cache and monitor threads. Different `clusterId` would duplicate that work.
 
-For Spring Boot bean wiring with two `EntityManagerFactory`s, see the [`SpringHibernateBalancedReaderTwoDataSourceExample`](../../examples/SpringHibernateBalancedReaderTwoDataSourceExample/) project in the wrapper repo.
+For Spring Boot bean wiring with two `EntityManagerFactory`s, see the [`SpringHibernateBalancedReaderTwoDataSourceExample`](../examples/SpringHibernateBalancedReaderTwoDataSourceExample/) project in the wrapper repo.
 
 ### 3.7 Aurora Global Database — primary region writer
 

--- a/docs/development-guide/IntegrationTests.md
+++ b/docs/development-guide/IntegrationTests.md
@@ -70,6 +70,44 @@ cmd /c ./gradlew --no-parallel --no-daemon test-all-environments
 
 Test results can be found at `wrapper/build/report/index.html`.
 
+### Splitting a Test Run Across Several Machines (Sharding)
+
+A full Aurora run takes hours because every test executes serially against a single cluster. The
+scheduled CI workflows therefore split the work: each job pins itself to one test environment and
+runs one *shard* of the integration test classes against its own database cluster.
+
+Two system properties control this:
+
+| System Property     | Default | Description                                                                 |
+|---------------------|---------|-----------------------------------------------------------------------------|
+| `test-shard-count`  | `1`     | Number of shards the integration test classes are divided into.              |
+| `test-shard-index`  | `1`     | Which shard this run executes. 1-based, must be in `[1, test-shard-count]`.  |
+
+The default of shard 1 of 1 runs every test class, so local runs and non-sharded workflows behave
+exactly as before.
+
+```bash
+./gradlew --no-parallel --no-daemon test-all-pg-aurora \
+  -Dtest-shard-index=2 -Dtest-shard-count=4
+```
+
+Sharding only selects *test classes*. Which environments are exercised (deployment, engine,
+instance count) is still controlled separately by the `test-no-*` properties, so a sharded CI job
+usually combines both, for example `-Dtest-no-instances-1=true -Dtest-shard-index=2
+-Dtest-shard-count=4`.
+
+Notes for maintainers:
+
+- The shard split is computed in `wrapper/src/test/build.gradle.kts`. The list of classes is read
+  from the compiled classes under `integration.container.tests`, so a newly added test class is
+  automatically picked up by exactly one shard - no workflow change is needed.
+- A `testClassWeightsSeconds` table in that file records the approximate cost of each class and is
+  used only to keep shards evenly sized. A missing or stale entry costs some balance but can never
+  drop coverage. Update it when a class's runtime changes substantially.
+- Any class under `integration.container.tests` that neither ends in `Test`/`Tests` nor appears in
+  `nonTestHelperClasses` fails the build rather than being silently left out of every shard.
+- Running all shards of a group covers exactly the same classes as one unsharded run.
+
 If you encounter unexplained build issues/errors, or after major project structure changes, try running the following to perform a clean build:
 
 macOS:

--- a/docs/using-the-jdbc-driver/using-plugins/UsingTheKmsEncryptionPlugin.md
+++ b/docs/using-the-jdbc-driver/using-plugins/UsingTheKmsEncryptionPlugin.md
@@ -408,4 +408,4 @@ Check the application logs for encryption-related messages.
 
 ## Example Application
 
-See the [KmsEncryptionExample.java](../../../examples/AWSDriverExample/src/main/java/software/amazon/KmsEncryptionExample.java) for a complete working example.
+See [KmsEncryptionIntegrationTest.java](../../../wrapper/src/test/java/integration/container/tests/KmsEncryptionIntegrationTest.java) for a complete working example.

--- a/wrapper/build.gradle.kts
+++ b/wrapper/build.gradle.kts
@@ -652,6 +652,8 @@ tasks.withType<Test> {
         if (it.key.toString().startsWith("test-no-")
             || it.key.toString() == "test-include-tags"
             || it.key.toString() == "test-exclude-tags"
+            || it.key.toString() == "test-shard-index"
+            || it.key.toString() == "test-shard-count"
         ) {
             systemProperty(it.key.toString(), it.value.toString())
         }

--- a/wrapper/src/test/build.gradle.kts
+++ b/wrapper/src/test/build.gradle.kts
@@ -151,10 +151,155 @@ tasks.withType<Test> {
     reports.html.required.set(false)
 }
 
+// Approximate cost of each integration test class, in seconds, derived from measured CI runs.
+// Used ONLY to balance test classes across shards - it never affects which tests run, so a stale
+// or missing entry costs some balance but can never drop coverage. Values are the worst case
+// (slowest environment) observed for the class.
+val testClassWeightsSeconds = mapOf(
+    "FailoverTest" to 1136,
+    "SimpleReadWriteSplittingTests" to 1003,
+    "Failover2Test" to 937,
+    "GdbFailoverTest" to 908,
+    "AutoSimpleReadWriteSplittingTests" to 889,
+    "AutoReadWriteSplittingTests" to 844,
+    "ReadWriteSplittingTests" to 701,
+    "CustomEndpointTest" to 403,
+    "XaFailoverTest" to 349,
+    "HikariTests" to 215,
+    "FastestResponseStrategyTest" to 82,
+    "AuroraInitialConnectionStrategyTest" to 71,
+    "EFM2Test" to 47,
+    "AwsIamIntegrationTest" to 44,
+    "AwsSecretsManager2IntegrationTest" to 43,
+    "DataCachePluginTests" to 43,
+    "BasicConnectivityTests" to 70,
+    "XaTransactionTest" to 54,
+    "XaTwoPhaseCommitTest" to 29,
+    "LogQueryPluginTests" to 17,
+    "DriverConfigurationProfileTests" to 16,
+    "XaIamAuthenticationTest" to 15,
+    "DataSourceTests" to 13,
+    "RdsConnectivityTests" to 11,
+    "SpringTests" to 8,
+    // Gated off by deployment/feature conditions in the sharded Aurora and Multi-AZ workflows, so
+    // they cost nothing there. They still run (unsharded) in their own dedicated workflows, where
+    // these weights are unused.
+    "AdvancedPerformanceTest" to 0,
+    "AutoscalingTests" to 0,
+    "BlueGreenDeploymentTests" to 0,
+    "DatabasePerformanceMetricTest" to 0,
+    "KmsEncryptionIntegrationTest" to 0,
+    "PerformanceTest" to 0,
+    "ReadWriteSplittingPerformanceTest" to 0,
+    "RemoteQueryCachePluginTests" to 0,
+    "SpringCachingTests" to 0
+)
+
+// Any class missing from the table above still runs; it is just assumed to be moderately
+// expensive so that a newly added test cannot quietly unbalance a shard by a large amount.
+val defaultTestClassWeightSeconds = 60
+
+// Classes that live under integration.container.tests but hold no tests. They are listed
+// explicitly so that any *other* class not following the Test/Tests naming convention fails the
+// build instead of quietly never being assigned to a shard.
+val nonTestHelperClasses = setOf(
+    "integration.container.tests.metrics.FailoverResult",
+    "integration.container.tests.metrics.RunData",
+    "integration.container.tests.metrics.RunDataNode",
+    "integration.container.tests.metrics.RunDataRow",
+    "integration.container.tests.metrics.Runs",
+    "integration.container.tests.metrics.TopologyEventHolder"
+)
+
+/**
+ * Returns the fully qualified names of every compiled class under integration.container.tests.
+ *
+ * The universe is read from disk rather than from a hardcoded list so that a newly added test
+ * class is always picked up by exactly one shard instead of being silently skipped.
+ */
+fun discoverContainerTestClasses(): List<String> {
+    val classesRoot = file("./test")
+    val testsPackageDir = file("./test/integration/container/tests")
+    if (!testsPackageDir.isDirectory) {
+        return emptyList()
+    }
+    return testsPackageDir.walkTopDown()
+        .filter { it.isFile && it.name.endsWith(".class") && !it.name.contains('$') }
+        .map {
+            it.relativeTo(classesRoot).path
+                .removeSuffix(".class")
+                .replace('\\', '.')
+                .replace('/', '.')
+        }
+        .sorted()
+        .toList()
+}
+
+/**
+ * Assigns classes to [shardCount] shards with a longest-processing-time-first pass and returns the
+ * ones belonging to [shardIndex] (1-based). Every class lands in exactly one shard, and the result
+ * depends only on the class list and the weight table, so all shards of a run agree on the split
+ * without needing to talk to each other.
+ */
+fun selectShard(classNames: List<String>, shardIndex: Int, shardCount: Int): List<String> {
+    val shardTotals = LongArray(shardCount)
+    val shards = List(shardCount) { mutableListOf<String>() }
+    val ordered = classNames.sortedWith(
+        // Heaviest first, then by name so ties are broken deterministically.
+        compareByDescending<String> {
+            testClassWeightsSeconds[it.substringAfterLast('.')] ?: defaultTestClassWeightSeconds
+        }.thenBy { it }
+    )
+    for (className in ordered) {
+        val weight = testClassWeightsSeconds[className.substringAfterLast('.')]
+            ?: defaultTestClassWeightSeconds
+        var target = 0
+        for (i in 1 until shardCount) {
+            if (shardTotals[i] < shardTotals[target]) {
+                target = i
+            }
+        }
+        shards[target].add(className)
+        shardTotals[target] += weight.toLong()
+    }
+    return shards[shardIndex - 1].sorted()
+}
+
 tasks.register<Test>("in-container") {
     filter.excludeTestsMatching("software.*") // exclude unit tests
 
-    // modify below filter to select specific integration tests
-    // see https://docs.gradle.org/current/javadoc/org/gradle/api/tasks/testing/TestFilter.html
-    filter.includeTestsMatching("integration.container.tests.*")
+    val shardIndex = (System.getProperty("test-shard-index") ?: "1").toInt()
+    val shardCount = (System.getProperty("test-shard-count") ?: "1").toInt()
+
+    if (shardCount <= 1) {
+        // modify below filter to select specific integration tests
+        // see https://docs.gradle.org/current/javadoc/org/gradle/api/tasks/testing/TestFilter.html
+        filter.includeTestsMatching("integration.container.tests.*")
+    } else {
+        require(shardIndex in 1..shardCount) {
+            "test-shard-index must be between 1 and test-shard-count ($shardCount), got $shardIndex"
+        }
+        val discovered = discoverContainerTestClasses()
+        require(discovered.isNotEmpty()) {
+            "Sharding was requested but no compiled classes were found under " +
+                "integration.container.tests. Is ./test populated?"
+        }
+        val unclassified = discovered.filter {
+            !nonTestHelperClasses.contains(it) && !it.endsWith("Test") && !it.endsWith("Tests")
+        }
+        require(unclassified.isEmpty()) {
+            "Cannot shard: $unclassified neither follow the Test/Tests naming convention nor appear " +
+                "in nonTestHelperClasses, so it is unclear whether they must be run. Rename them or " +
+                "add them to nonTestHelperClasses in wrapper/src/test/build.gradle.kts."
+        }
+        val allClasses = discovered.filter { !nonTestHelperClasses.contains(it) }
+        require(allClasses.size >= shardCount) {
+            "test-shard-count ($shardCount) exceeds the number of discovered test classes " +
+                "(${allClasses.size}); some shards would have nothing to run."
+        }
+        val shardClasses = selectShard(allClasses, shardIndex, shardCount)
+        println("Test shard $shardIndex of $shardCount: ${shardClasses.size} of ${allClasses.size} classes")
+        shardClasses.forEach { println("  $it") }
+        shardClasses.forEach { filter.includeTestsMatching(it) }
+    }
 }

--- a/wrapper/src/test/build.gradle.kts
+++ b/wrapper/src/test/build.gradle.kts
@@ -153,34 +153,38 @@ tasks.withType<Test> {
 
 // Approximate cost of each integration test class, in seconds, derived from measured CI runs.
 // Used ONLY to balance test classes across shards - it never affects which tests run, so a stale
-// or missing entry costs some balance but can never drop coverage. Values are the worst case
-// (slowest environment) observed for the class.
+// or missing entry costs some balance but can never drop coverage.
+//
+// Each value is the worst per-environment cost observed for that class, taken as the maximum over
+// the most recent runs so that shards stay balanced for the slowest environment. Refresh these when
+// a class's runtime changes substantially; run 30645460736 showed that under-weighting a class by
+// 60% is enough to make its shard the critical path.
 val testClassWeightsSeconds = mapOf(
     "FailoverTest" to 1136,
-    "SimpleReadWriteSplittingTests" to 1003,
-    "Failover2Test" to 937,
-    "GdbFailoverTest" to 908,
-    "AutoSimpleReadWriteSplittingTests" to 889,
-    "AutoReadWriteSplittingTests" to 844,
-    "ReadWriteSplittingTests" to 701,
-    "CustomEndpointTest" to 403,
+    "AutoReadWriteSplittingTests" to 1101,
+    "GdbFailoverTest" to 1100,
+    "SimpleReadWriteSplittingTests" to 1095,
+    "AutoSimpleReadWriteSplittingTests" to 995,
+    "Failover2Test" to 971,
+    "ReadWriteSplittingTests" to 921,
+    "CustomEndpointTest" to 516,
+    "DataCachePluginTests" to 456,
     "XaFailoverTest" to 349,
-    "HikariTests" to 215,
+    "HikariTests" to 238,
+    "AuroraInitialConnectionStrategyTest" to 145,
+    "XaTransactionTest" to 90,
     "FastestResponseStrategyTest" to 82,
-    "AuroraInitialConnectionStrategyTest" to 71,
-    "EFM2Test" to 47,
-    "AwsIamIntegrationTest" to 44,
-    "AwsSecretsManager2IntegrationTest" to 43,
-    "DataCachePluginTests" to 43,
     "BasicConnectivityTests" to 70,
-    "XaTransactionTest" to 54,
-    "XaTwoPhaseCommitTest" to 29,
-    "LogQueryPluginTests" to 17,
+    "AwsIamIntegrationTest" to 61,
+    "AwsSecretsManager2IntegrationTest" to 61,
+    "EFM2Test" to 48,
+    "XaTwoPhaseCommitTest" to 47,
+    "LogQueryPluginTests" to 22,
+    "XaIamAuthenticationTest" to 20,
     "DriverConfigurationProfileTests" to 16,
-    "XaIamAuthenticationTest" to 15,
     "DataSourceTests" to 13,
+    "SpringTests" to 12,
     "RdsConnectivityTests" to 11,
-    "SpringTests" to 8,
     // Gated off by deployment/feature conditions in the sharded Aurora and Multi-AZ workflows, so
     // they cost nothing there. They still run (unsharded) in their own dedicated workflows, where
     // these weights are unused.

--- a/wrapper/src/test/build.gradle.kts
+++ b/wrapper/src/test/build.gradle.kts
@@ -155,36 +155,43 @@ tasks.withType<Test> {
 // Used ONLY to balance test classes across shards - it never affects which tests run, so a stale
 // or missing entry costs some balance but can never drop coverage.
 //
-// Each value is the worst per-environment cost observed for that class, taken as the maximum over
-// the most recent runs so that shards stay balanced for the slowest environment. Refresh these when
-// a class's runtime changes substantially; run 30645460736 showed that under-weighting a class by
-// 60% is enough to make its shard the critical path.
+// Each value is the worst per-environment cost observed for that class, taken from the most recent
+// green run (30654857141) so that shards stay balanced for the slowest environment. Refresh these
+// when a class's runtime changes substantially: run 30645460736 showed that under-weighting a class
+// by 60% is enough to make its shard the critical path.
+//
+// KNOWN LIMITATION: a single table cannot balance Aurora and RDS Multi-AZ at the same time, because
+// AuroraTestUtility.crashInstance performs a real failover on Aurora but only a toxiproxy outage on
+// Multi-AZ clusters. That inverts the cost profile - the failover classes cost roughly half as much
+// on Multi-AZ while the read/write-splitting classes cost 1.2-1.5x more. Using the maximum keeps
+// every shard within its budget but leaves the cheaper deployment unevenly packed. Making the
+// weights per-deployment would recover roughly 10 min of the critical path.
 val testClassWeightsSeconds = mapOf(
-    "FailoverTest" to 1136,
-    "AutoReadWriteSplittingTests" to 1101,
-    "GdbFailoverTest" to 1100,
-    "SimpleReadWriteSplittingTests" to 1095,
-    "AutoSimpleReadWriteSplittingTests" to 995,
-    "Failover2Test" to 971,
-    "ReadWriteSplittingTests" to 921,
-    "CustomEndpointTest" to 516,
-    "DataCachePluginTests" to 456,
-    "XaFailoverTest" to 349,
-    "HikariTests" to 238,
-    "AuroraInitialConnectionStrategyTest" to 145,
-    "XaTransactionTest" to 90,
-    "FastestResponseStrategyTest" to 82,
+    "GdbFailoverTest" to 1173,
+    "ReadWriteSplittingTests" to 1163,
+    "SimpleReadWriteSplittingTests" to 1024,
+    "FailoverTest" to 967,
+    "AutoSimpleReadWriteSplittingTests" to 905,
+    "Failover2Test" to 903,
+    "AutoReadWriteSplittingTests" to 864,
+    "CustomEndpointTest" to 509,
+    "HikariTests" to 352,
+    "XaFailoverTest" to 207,
+    "XaTransactionTest" to 159,
+    "FastestResponseStrategyTest" to 83,
+    "XaTwoPhaseCommitTest" to 73,
     "BasicConnectivityTests" to 70,
-    "AwsIamIntegrationTest" to 61,
-    "AwsSecretsManager2IntegrationTest" to 61,
+    "AwsIamIntegrationTest" to 62,
     "EFM2Test" to 48,
-    "XaTwoPhaseCommitTest" to 47,
-    "LogQueryPluginTests" to 22,
-    "XaIamAuthenticationTest" to 20,
-    "DriverConfigurationProfileTests" to 16,
-    "DataSourceTests" to 13,
+    "DataCachePluginTests" to 46,
+    "AuroraInitialConnectionStrategyTest" to 43,
+    "AwsSecretsManager2IntegrationTest" to 41,
+    "XaIamAuthenticationTest" to 32,
+    "DriverConfigurationProfileTests" to 19,
+    "LogQueryPluginTests" to 18,
+    "DataSourceTests" to 14,
+    "RdsConnectivityTests" to 13,
     "SpringTests" to 12,
-    "RdsConnectivityTests" to 11,
     // Gated off by deployment/feature conditions in the sharded Aurora and Multi-AZ workflows, so
     // they cost nothing there. They still run (unsharded) in their own dedicated workflows, where
     // these weights are unused.

--- a/wrapper/src/test/java/integration/host/TestEnvironment.java
+++ b/wrapper/src/test/java/integration/host/TestEnvironment.java
@@ -1550,7 +1550,9 @@ public class TestEnvironment implements AutoCloseable {
           taskName,
           config.includeTags,
           config.excludeTags,
-          this.info.getRequest().getTargetJvm());
+          this.info.getRequest().getTargetJvm(),
+          config.shardIndex,
+          config.shardCount);
     }
   }
 

--- a/wrapper/src/test/java/integration/host/TestEnvironment.java
+++ b/wrapper/src/test/java/integration/host/TestEnvironment.java
@@ -1573,7 +1573,9 @@ public class TestEnvironment implements AutoCloseable {
           taskName,
           config.includeTags,
           config.excludeTags,
-          this.info.getRequest().getTargetJvm());
+          this.info.getRequest().getTargetJvm(),
+          config.shardIndex,
+          config.shardCount);
     }
   }
 

--- a/wrapper/src/test/java/integration/host/TestEnvironmentConfiguration.java
+++ b/wrapper/src/test/java/integration/host/TestEnvironmentConfiguration.java
@@ -94,6 +94,18 @@ public class TestEnvironmentConfiguration {
   public String includeTags = System.getProperty("test-include-tags");
   public String excludeTags = System.getProperty("test-exclude-tags");
 
+  /**
+   * Splits the in-container integration test classes across several CI jobs so they can run in
+   * parallel, each against its own database cluster. {@code shardIndex} is 1-based and must be in
+   * the range {@code [1, shardCount]}. The default ({@code 1} of {@code 1}) runs every test class,
+   * which is what a local run or any non-sharded workflow does.
+   *
+   * <p>Only test class selection is affected. Which environments (deployment, engine, instance
+   * count) are exercised is still controlled by the {@code test-no-*} properties.
+   */
+  public int shardIndex = Integer.parseInt(System.getProperty("test-shard-index", "1"));
+  public int shardCount = Integer.parseInt(System.getProperty("test-shard-count", "1"));
+
   public String rdsDbRegion = System.getenv("RDS_DB_REGION");
 
   public boolean reuseRdsDb = Boolean.parseBoolean(System.getenv("REUSE_RDS_DB"));

--- a/wrapper/src/test/java/integration/util/ContainerHelper.java
+++ b/wrapper/src/test/java/integration/util/ContainerHelper.java
@@ -101,7 +101,9 @@ public class ContainerHelper {
       String task,
       String includeTags,
       String excludeTags,
-      TargetJvm targetJvm)
+      TargetJvm targetJvm,
+      int shardIndex,
+      int shardCount)
       throws IOException, InterruptedException {
     System.out.println("==== Container console feed ==== >>>>");
     Consumer<OutputFrame> consumer = new ConsoleConsumer(true);
@@ -118,6 +120,10 @@ public class ContainerHelper {
     }
     if (!StringUtils.isNullOrEmpty(excludeTags)) {
       commands.add(String.format("-Dtest-exclude-tags=%s", excludeTags.replaceAll(" ", "")));
+    }
+    if (shardCount > 1) {
+      commands.add(String.format("-Dtest-shard-index=%d", shardIndex));
+      commands.add(String.format("-Dtest-shard-count=%d", shardCount));
     }
 
     Long exitCode = execInContainer(container, consumer, commands.toArray(new String[0]));

--- a/wrapper/src/test/java/integration/util/ContainerHelper.java
+++ b/wrapper/src/test/java/integration/util/ContainerHelper.java
@@ -136,7 +136,9 @@ public class ContainerHelper {
       String task,
       String includeTags,
       String excludeTags,
-      TargetJvm targetJvm)
+      TargetJvm targetJvm,
+      int shardIndex,
+      int shardCount)
       throws IOException, InterruptedException {
     System.out.println("==== Container console feed ==== >>>>");
     Consumer<OutputFrame> consumer = new ConsoleConsumer();
@@ -154,6 +156,12 @@ public class ContainerHelper {
     }
     if (!StringUtils.isNullOrEmpty(excludeTags)) {
       commands.add(String.format("-Dtest-exclude-tags=%s", excludeTags.replaceAll(" ", "")));
+    }
+    // Forwarded for the same reason as in runTest: debugging a single shard must debug that
+    // shard, not silently fall back to running every test class.
+    if (shardCount > 1) {
+      commands.add(String.format("-Dtest-shard-index=%d", shardIndex));
+      commands.add(String.format("-Dtest-shard-count=%d", shardCount));
     }
 
     Long exitCode = execInContainer(container, consumer, commands.toArray(new String[0]));


### PR DESCRIPTION
## Summary

The scheduled Aurora integration test runs take about 3h18m of wall clock because each job runs its test environments one after another against a single cluster, with no parallelism inside a container.

Measured on [run 30530414463](https://github.com/aws/aws-advanced-jdbc-wrapper/actions/runs/30530414463):

| | |
|---|---|
| Wall clock | 3h18m |
| Critical path | 198.5 min (`pg-aurora`) |
| Total runner time | 738.5 min |
| In-container test execution | 629.9 min |

Within a job the environments run strictly sequentially, e.g. `pg-aurora` spends 4.2 min on the single-instance environment, 63.7 min on the 2-instance one and 116.8 min on the 3-instance one. Two test families dominate: the four read/write-splitting variants account for 46.2% of all test time and the three failover variants a further 36.9%.

This PR splits the work so each CI job pins itself to exactly **one** test environment and runs **one shard** of the integration test classes against its own database cluster.

## Mechanism

- New `test-shard-index` / `test-shard-count` system properties, defaulting to shard 1 of 1 so local runs and every non-sharded workflow behave exactly as before.
- Both are added to the allowlist in `wrapper/build.gradle.kts` that forwards system properties into the forked test JVM, and are relayed into the test container by `ContainerHelper`. Without the allowlist entry the properties would have been silently ignored and every job would have run the full suite while appearing to work.
- The split itself lives in `wrapper/src/test/build.gradle.kts`:
  - The class universe is discovered from the compiled classes under `integration.container.tests`, so a newly added test class is always picked up by exactly one shard with no workflow change.
  - A `testClassWeightsSeconds` table keeps shards evenly sized. It only affects balance and can never drop coverage, so a stale entry is harmless.
  - Any class in that package that neither follows the `Test`/`Tests` naming convention nor appears in `nonTestHelperClasses` fails the build rather than being silently left out of every shard.

## Workflows

`run-integration-tests-latest.yml` and `run-integration-tests-default.yml` now use a 20-entry matrix:

| Environment | Shards |
|---|---|
| Aurora PG, 3 instances | 4 |
| Aurora MySQL, 3 instances | 3 |
| Aurora MySQL with MariaDB driver, 3 instances | 2 |
| RDS Multi-AZ MySQL cluster | 4 |
| RDS Multi-AZ PG cluster | 2 |
| Five single-instance environments | 1 each |

That is at most 20 concurrent clusters, roughly 52 DB instances, and 20 inbound rules in the region's `default` security group. All are within the us-east-2 quotas of 60 clusters and 300 instances; the security group rule quota (60 per group) is the tightest of the three and is the ceiling to watch if the shard count is ever raised.

The 2-instance Aurora environment is dropped from the daily runs. It re-ran almost exactly the same tests as the 3-instance environment for about 60 minutes per engine, and only these 9 tests genuinely need a 2-node topology:

- `FailoverTest`, `Failover2Test`, `GdbFailoverTest` - `test_failFromReaderToWriter`
- `ReadWriteSplittingTests`, `AutoReadWriteSplittingTests` - `test_setReadOnlyTrue_oneReaderDown_failoverRecovers`, `test_setReadOnlyTrue_oneReaderDown_fallsBackToWriter`, `test_setReadOnlyTrue_oneReaderDown_readThrows`

A new `run-integration-tests-full-matrix-weekly.yml` keeps that coverage on a weekly cadence and documents the affected tests inline.

Also added Gradle dependency caching and per-entry artifact names.

## Expected effect

Projected critical path is about **53 min**, down from 198.5 min. Total runner minutes rise slightly (roughly 740 to 780) because each job repeats checkout and build - this trades total compute for latency.

## Testing

The sharding logic in `wrapper/src/test/build.gradle.kts` is not part of the root Gradle build, so it was validated with a throwaway harness containing a verbatim copy of the logic run against a stand-in class tree. That caught a genuine compile error (`LongArray[i] += Int` is not valid Kotlin) which would otherwise have failed inside the test container at runtime.

After the fix, for shard counts 2, 3 and 4:

- exact partition of all 34 test classes, no duplicates and no omissions
- deterministic across recomputation
- balanced to within 0.2 min at 4 shards
- javac's `$1.class` inner-class files correctly ignored

Also verified:

- `:aws-advanced-jdbc-wrapper:compileTestJava` passes; no diagnostics on any changed file.
- Workflow YAML parsed and checked structurally: 20 entries, 10 environment groups, 20 clusters, complete shard sequences with no gaps, consistent shard counts per group, unique entry names.
- `shardCount <= 1` reproduces the previous filter behaviour exactly and the extra `-D` flags are not passed, so the autoscaling, blue/green, hibernate, java-LTS, performance, metrics and standard workflows are unaffected.

## Not verified

An actual sharded CI run. The per-shard overhead used in the projection (about 14 min for Aurora, 31 min for Multi-AZ) was derived from the current 3-environment jobs, where background pre-creation hid 2 of 3 cluster creations. A single-environment shard job has nothing to pre-create ahead of it, so its provisioning is fully exposed and real overhead is likely 18-22 min for Aurora. **Expect the first real run to land above 53 min, and the shard counts to need one round of retuning from its timings.**

`debugTest` is deliberately left unsharded, since debugging is interactive and single-environment.
