### PR TITLE
fix: keep efm monitor threads alive after transient exceptions

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/v1/HostMonitorV1Impl.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/v1/HostMonitorV1Impl.java
@@ -127,7 +127,11 @@ public class HostMonitorV1Impl extends AbstractMonitor implements HostMonitor, S
   @Override
   public void startMonitoring(final ConnectionContext context) {
     if (this.stop.get()) {
+      // A stopped monitor never processes newContexts, so queueing more contexts here would grow the
+      // queue without bound. The monitor service replaces stopped monitors, so subsequent calls get
+      // a healthy monitor.
       LOGGER.warning(() -> Messages.get("HostMonitorImpl.monitorIsStopped", new Object[] {this.hostSpec.getHost()}));
+      return;
     }
 
     assert context instanceof HostMonitorConnectionContextV1;
@@ -151,124 +155,34 @@ public class HostMonitorV1Impl extends AbstractMonitor implements HostMonitor, S
           this, Collections.singleton(MonitorResetEvent.class));
 
       while (!this.stop.get()) {
-
-        // process new contexts
-        HostMonitorConnectionContextV1 newMonitorContext;
-        HostMonitorConnectionContextV1 firstAddedNewMonitorContext = null;
-        final long currentTimeNano = this.getCurrentTimeNano();
-
-        while ((newMonitorContext = this.newContexts.poll()) != null) {
-          if (this.stop.get()) {
-            break;
-          }
-          if (firstAddedNewMonitorContext == newMonitorContext) {
-            // This context has already been processed.
-            // Add it back to the queue and process it in the next round.
-            this.newContexts.add(newMonitorContext);
-            break;
-          }
-          if (newMonitorContext.isActiveContext()) {
-            if (newMonitorContext.getExpectedActiveMonitoringStartTimeNano() > currentTimeNano) {
-              // The context active monitoring time hasn't come.
-              // Add the context to the queue and check it later.
-              this.newContexts.add(newMonitorContext);
-              if (firstAddedNewMonitorContext == null) {
-                firstAddedNewMonitorContext = newMonitorContext;
-              }
-            } else {
-              // It's time to start actively monitor this context.
-              this.activeContexts.add(newMonitorContext);
-            }
-          }
-        }
-
-        final Connection copyConnection = this.monitoringConn.get();
-        if (!this.activeContexts.isEmpty()
-            || copyConnection == null
-            || copyConnection.isClosed()) {
-
-          final long statusCheckStartTimeNano = this.getCurrentTimeNano();
-          final boolean isValid = this.checkConnectionStatus(this.nodeCheckTimeoutMillis);
-          final long statusCheckEndTimeNano = this.getCurrentTimeNano();
-          final long elapsedTimeNano = statusCheckEndTimeNano - statusCheckStartTimeNano;
-          this.lastActivityTimestampNanos.set(statusCheckEndTimeNano);
-
-          long delayMillis = -1;
-          HostMonitorConnectionContextV1 monitorContext;
-          HostMonitorConnectionContextV1 firstAddedMonitorContext = null;
-
-          while ((monitorContext = this.activeContexts.poll()) != null) {
-            if (this.stop.get()) {
-              break;
-            }
-            monitorContext.getLock().lock();
-            try {
-              // If context is already invalid, just skip it
-              if (!monitorContext.isActiveContext()) {
-                continue;
-              }
-
-              if (firstAddedMonitorContext == monitorContext) {
-                // this context has already been processed by this loop
-                // add it to the queue and exit this loop
-                this.activeContexts.add(monitorContext);
-                break;
-              }
-
-              // otherwise, process this context
-              monitorContext.updateConnectionStatus(
-                  this.hostSpec.getUrl(),
-                  statusCheckStartTimeNano,
-                  statusCheckEndTimeNano,
-                  isValid);
-
-              // If context is still valid and node is still healthy, it needs to continue updating this context
-              if (monitorContext.isActiveContext() && !monitorContext.isNodeUnhealthy()) {
-                this.activeContexts.add(monitorContext);
-                if (firstAddedMonitorContext == null) {
-                  firstAddedMonitorContext = monitorContext;
-                }
-
-                if (delayMillis == -1 || delayMillis > monitorContext.getFailureDetectionIntervalMillis()) {
-                  delayMillis = monitorContext.getFailureDetectionIntervalMillis();
-                }
-              }
-            } finally {
-              monitorContext.getLock().unlock();
-            }
-          }
-
-          if (delayMillis == -1) {
-            // No active contexts
-            delayMillis = THREAD_SLEEP_WHEN_INACTIVE_MILLIS;
-          } else {
-            delayMillis -= TimeUnit.NANOSECONDS.toMillis(elapsedTimeNano);
-            // Check for min delay between node health check
-            if (delayMillis <= MIN_CONNECTION_CHECK_TIMEOUT_MILLIS) {
-              delayMillis = MIN_CONNECTION_CHECK_TIMEOUT_MILLIS;
-            }
-            // Use this delay as node checkout timeout since it corresponds to min interval for all active contexts
-            this.nodeCheckTimeoutMillis = delayMillis;
-          }
-
-          TimeUnit.MILLISECONDS.sleep(delayMillis);
-
-        } else {
+        try {
+          this.monitorIteration();
+        } catch (final InterruptedException intEx) {
+          Thread.currentThread().interrupt();
+          break;
+        } catch (final Throwable throwable) {
+          // A failed iteration must not terminate this thread; otherwise failure detection silently
+          // stops for this node and newContexts is never processed again. Log the error and keep
+          // monitoring.
+          LOGGER.log(
+              Level.WARNING,
+              Messages.get(
+                  "HostMonitorImpl.exceptionDuringMonitoringContinue",
+                  new Object[] {this.hostSpec.getHost()}),
+              throwable); // We want to print full trace stack of the exception.
           TimeUnit.MILLISECONDS.sleep(THREAD_SLEEP_WHEN_INACTIVE_MILLIS);
         }
       }
     } catch (final InterruptedException intEx) {
       Thread.currentThread().interrupt();
-    } catch (final Exception ex) {
+    } catch (final Throwable throwable) {
       // this should not be reached; log and exit thread
-      if (LOGGER.isLoggable(Level.FINEST)) {
-        LOGGER.log(
-            Level.FINEST,
-            Messages.get(
-                "HostMonitorImpl.exceptionDuringMonitoringStop",
-                new Object[] {this.hostSpec.getHost()}),
-            ex); // We want to print full trace stack of the exception.
-      }
+      LOGGER.log(
+          Level.WARNING,
+          Messages.get(
+              "HostMonitorImpl.exceptionDuringMonitoringStop",
+              new Object[] {this.hostSpec.getHost()}),
+          throwable); // We want to print full trace stack of the exception.
     } finally {
       this.stop.set(true);
       this.monitoringConn.clean();
@@ -279,6 +193,121 @@ public class HostMonitorV1Impl extends AbstractMonitor implements HostMonitor, S
     LOGGER.finest(() -> Messages.get(
         "HostMonitorImpl.stopMonitoringThread",
         new Object[] {this.hostSpec.getHost()}));
+  }
+
+  /**
+   * Performs a single monitoring iteration: promotes due contexts from the new contexts queue, checks the status of the
+   * monitored host if needed, and updates the active monitoring contexts.
+   *
+   * @throws SQLException         if the monitoring connection cannot be inspected.
+   * @throws InterruptedException if the thread is interrupted while waiting for the next iteration.
+   */
+  protected void monitorIteration() throws SQLException, InterruptedException {
+
+    // process new contexts
+    HostMonitorConnectionContextV1 newMonitorContext;
+    HostMonitorConnectionContextV1 firstAddedNewMonitorContext = null;
+    final long currentTimeNano = this.getCurrentTimeNano();
+
+    while ((newMonitorContext = this.newContexts.poll()) != null) {
+      if (this.stop.get()) {
+        break;
+      }
+      if (firstAddedNewMonitorContext == newMonitorContext) {
+        // This context has already been processed.
+        // Add it back to the queue and process it in the next round.
+        this.newContexts.add(newMonitorContext);
+        break;
+      }
+      if (newMonitorContext.isActiveContext()) {
+        if (newMonitorContext.getExpectedActiveMonitoringStartTimeNano() > currentTimeNano) {
+          // The context active monitoring time hasn't come.
+          // Add the context to the queue and check it later.
+          this.newContexts.add(newMonitorContext);
+          if (firstAddedNewMonitorContext == null) {
+            firstAddedNewMonitorContext = newMonitorContext;
+          }
+        } else {
+          // It's time to start actively monitor this context.
+          this.activeContexts.add(newMonitorContext);
+        }
+      }
+    }
+
+    final Connection copyConnection = this.monitoringConn.get();
+    if (!this.activeContexts.isEmpty()
+        || copyConnection == null
+        || copyConnection.isClosed()) {
+
+      final long statusCheckStartTimeNano = this.getCurrentTimeNano();
+      final boolean isValid = this.checkConnectionStatus(this.nodeCheckTimeoutMillis);
+      final long statusCheckEndTimeNano = this.getCurrentTimeNano();
+      final long elapsedTimeNano = statusCheckEndTimeNano - statusCheckStartTimeNano;
+      this.lastActivityTimestampNanos.set(statusCheckEndTimeNano);
+
+      long delayMillis = -1;
+      HostMonitorConnectionContextV1 monitorContext;
+      HostMonitorConnectionContextV1 firstAddedMonitorContext = null;
+
+      while ((monitorContext = this.activeContexts.poll()) != null) {
+        if (this.stop.get()) {
+          break;
+        }
+        monitorContext.getLock().lock();
+        try {
+          // If context is already invalid, just skip it
+          if (!monitorContext.isActiveContext()) {
+            continue;
+          }
+
+          if (firstAddedMonitorContext == monitorContext) {
+            // this context has already been processed by this loop
+            // add it to the queue and exit this loop
+            this.activeContexts.add(monitorContext);
+            break;
+          }
+
+          // otherwise, process this context
+          monitorContext.updateConnectionStatus(
+              this.hostSpec.getUrl(),
+              statusCheckStartTimeNano,
+              statusCheckEndTimeNano,
+              isValid);
+
+          // If context is still valid and node is still healthy, it needs to continue updating this context
+          if (monitorContext.isActiveContext() && !monitorContext.isNodeUnhealthy()) {
+            this.activeContexts.add(monitorContext);
+            if (firstAddedMonitorContext == null) {
+              firstAddedMonitorContext = monitorContext;
+            }
+
+            if (delayMillis == -1 || delayMillis > monitorContext.getFailureDetectionIntervalMillis()) {
+              delayMillis = monitorContext.getFailureDetectionIntervalMillis();
+            }
+          }
+        } finally {
+          monitorContext.getLock().unlock();
+        }
+      }
+
+      if (delayMillis == -1) {
+        // No active contexts
+        delayMillis = THREAD_SLEEP_WHEN_INACTIVE_MILLIS;
+      } else {
+        delayMillis -= TimeUnit.NANOSECONDS.toMillis(elapsedTimeNano);
+        // Check for min delay between node health check
+        if (delayMillis <= MIN_CONNECTION_CHECK_TIMEOUT_MILLIS) {
+          delayMillis = MIN_CONNECTION_CHECK_TIMEOUT_MILLIS;
+        }
+        // Use this delay as node checkout timeout since it corresponds to min interval for all active contexts
+        this.nodeCheckTimeoutMillis = delayMillis;
+      }
+
+      TimeUnit.MILLISECONDS.sleep(delayMillis);
+
+    } else {
+      TimeUnit.MILLISECONDS.sleep(THREAD_SLEEP_WHEN_INACTIVE_MILLIS);
+    }
   }
 
   /**

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/v2/HostMonitorV2Impl.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/v2/HostMonitorV2Impl.java
@@ -175,7 +175,11 @@ public class HostMonitorV2Impl extends AbstractMonitor implements HostMonitor, S
   @Override
   public void startMonitoring(final ConnectionContext context) {
     if (this.stop.get()) {
+      // A stopped monitor never drains newContexts, so queueing more contexts here would grow the
+      // map without bound. The monitor service replaces stopped monitors, so subsequent calls get
+      // a healthy monitor.
       LOGGER.warning(() -> Messages.get("HostMonitorImpl.monitorIsStopped", new Object[] {this.hostSpec.getHost()}));
+      return;
     }
 
     assert context instanceof HostMonitorConnectionContextV2;
@@ -209,43 +213,59 @@ public class HostMonitorV2Impl extends AbstractMonitor implements HostMonitor, S
 
     try {
       while (!this.stop.get()) {
-        final long currentTimeNano = this.getCurrentTimeNano();
-        this.lastActivityTimestampNanos.set(currentTimeNano);
+        try {
+          final long currentTimeNano = this.getCurrentTimeNano();
+          this.lastActivityTimestampNanos.set(currentTimeNano);
 
-        final ArrayList<Long> processedKeys = new ArrayList<>();
-        this.newContexts.entrySet().stream()
-            // Get entries with key (that is a time in nanos) less or equal than current time.
-            .filter(entry -> entry.getKey() < currentTimeNano)
-            .forEach(entry -> {
-              final Queue<WeakReference<HostMonitorConnectionContextV2>> queue = entry.getValue();
-              processedKeys.add(entry.getKey());
-              // Each value of found entry is a queue of monitoring contexts awaiting active monitoring.
-              // Add all contexts to an active monitoring contexts queue.
-              // Ignore disposed contexts.
-              WeakReference<HostMonitorConnectionContextV2> contextWeakRef;
-              while ((contextWeakRef = queue.poll()) != null) {
-                HostMonitorConnectionContextV2 context = contextWeakRef.get();
-                if (context != null && context.isActive()) {
-                  this.activeContexts.add(contextWeakRef);
+          final ArrayList<Long> processedKeys = new ArrayList<>();
+          this.newContexts.entrySet().stream()
+              // Get entries with key (that is a time in nanos) less or equal than current time.
+              .filter(entry -> entry.getKey() < currentTimeNano)
+              .forEach(entry -> {
+                final Queue<WeakReference<HostMonitorConnectionContextV2>> queue = entry.getValue();
+                processedKeys.add(entry.getKey());
+                // Each value of found entry is a queue of monitoring contexts awaiting active monitoring.
+                // Add all contexts to an active monitoring contexts queue.
+                // Ignore disposed contexts.
+                WeakReference<HostMonitorConnectionContextV2> contextWeakRef;
+                while ((contextWeakRef = queue.poll()) != null) {
+                  HostMonitorConnectionContextV2 context = contextWeakRef.get();
+                  if (context != null && context.isActive()) {
+                    this.activeContexts.add(contextWeakRef);
+                  }
                 }
-              }
-            });
-        processedKeys.forEach(this.newContexts::remove);
+              });
+          processedKeys.forEach(this.newContexts::remove);
+        } catch (final Throwable throwable) {
+          // A failed iteration must not terminate this thread. This thread is the only consumer of
+          // newContexts while startMonitoring() keeps adding to it on every monitored call, so an
+          // early exit means newContexts grows without bound (memory leak) and no context ever
+          // reaches activeContexts (failure detection silently stops for this node).
+          LOGGER.log(
+              Level.WARNING,
+              Messages.get(
+                  "HostMonitorImpl.exceptionDuringMonitoringContinue",
+                  new Object[] {this.hostSpec.getHost()}),
+              throwable); // We want to print full trace stack of the exception.
+        }
 
         TimeUnit.SECONDS.sleep(1);
       }
     } catch (final InterruptedException intEx) {
       Thread.currentThread().interrupt();
-    } catch (final Exception ex) {
+    } catch (final Throwable throwable) {
       // this should not be reached; log and exit thread
-      if (LOGGER.isLoggable(Level.FINEST)) {
-        LOGGER.log(
-            Level.FINEST,
-            Messages.get(
-                "HostMonitorImpl.exceptionDuringMonitoringStop",
-                new Object[] {this.hostSpec.getHost()}),
-            ex); // We want to print full trace stack of the exception.
-      }
+      LOGGER.log(
+          Level.WARNING,
+          Messages.get(
+              "HostMonitorImpl.exceptionDuringMonitoringStop",
+              new Object[] {this.hostSpec.getHost()}),
+          throwable); // We want to print full trace stack of the exception.
+    } finally {
+      // If this thread is gone, nothing drains newContexts anymore. Stopping the monitor lets the
+      // monitor service detect it and replace it with a healthy one, and makes startMonitoring()
+      // stop queueing contexts that would never be processed.
+      this.stop.set(true);
     }
 
     LOGGER.finest(() -> Messages.get(
@@ -266,69 +286,33 @@ public class HostMonitorV2Impl extends AbstractMonitor implements HostMonitor, S
           this, Collections.singleton(MonitorResetEvent.class));
 
       while (!this.stop.get()) {
-
-        if (this.activeContexts.isEmpty() && !this.nodeUnhealthy.get()) {
+        try {
+          this.monitorIteration();
+        } catch (final InterruptedException intEx) {
+          Thread.currentThread().interrupt();
+          break;
+        } catch (final Throwable throwable) {
+          // A failed iteration must not terminate this thread; otherwise failure detection silently
+          // stops for this node. Log the error and keep monitoring.
+          LOGGER.log(
+              Level.WARNING,
+              Messages.get(
+                  "HostMonitorImpl.exceptionDuringMonitoringContinue",
+                  new Object[] {this.hostSpec.getHost()}),
+              throwable); // We want to print full trace stack of the exception.
           TimeUnit.NANOSECONDS.sleep(THREAD_SLEEP_NANO);
-          continue;
         }
-
-        final long statusCheckStartTimeNano = this.getCurrentTimeNano();
-        final boolean isValid = this.checkConnectionStatus();
-        final long statusCheckEndTimeNano = this.getCurrentTimeNano();
-
-        this.updateNodeHealthStatus(isValid, statusCheckStartTimeNano, statusCheckEndTimeNano);
-
-        final List<WeakReference<HostMonitorConnectionContextV2>> tmpActiveContexts = new ArrayList<>();
-        WeakReference<HostMonitorConnectionContextV2> monitorContextWeakRef;
-
-        while ((monitorContextWeakRef = this.activeContexts.poll()) != null) {
-          if (this.stop.get()) {
-            break;
-          }
-
-          HostMonitorConnectionContextV2 monitorContext = monitorContextWeakRef.get();
-          if (monitorContext == null) {
-            continue;
-          }
-
-          if (this.nodeUnhealthy.get()) {
-            // Kill connection.
-            monitorContext.setNodeUnhealthy(true);
-            final Connection connectionToAbort = monitorContext.getConnection();
-            this.servicesContainer.getConnectionContextService().release(monitorContext);
-            if (connectionToAbort != null) {
-              this.abortConnection(connectionToAbort);
-              if (this.abortedConnectionsCounter != null) {
-                this.abortedConnectionsCounter.inc();
-              }
-            }
-          } else if (monitorContext.isActive()) {
-            tmpActiveContexts.add(monitorContextWeakRef);
-          }
-        }
-
-        // activeContexts is empty now and tmpActiveContexts contains all yet active contexts
-        // Add active contexts back to the queue.
-        this.activeContexts.addAll(tmpActiveContexts);
-
-        long delayNano = this.failureDetectionIntervalNano - (statusCheckEndTimeNano - statusCheckStartTimeNano);
-        if (delayNano < THREAD_SLEEP_NANO) {
-          delayNano = THREAD_SLEEP_NANO;
-        }
-        TimeUnit.NANOSECONDS.sleep(delayNano);
       }
     } catch (final InterruptedException intEx) {
       Thread.currentThread().interrupt();
-    } catch (final Exception ex) {
+    } catch (final Throwable throwable) {
       // this should not be reached; log and exit thread
-      if (LOGGER.isLoggable(Level.FINEST)) {
-        LOGGER.log(
-            Level.FINEST,
-            Messages.get(
-                "HostMonitorImpl.exceptionDuringMonitoringStop",
-                new Object[] {this.hostSpec.getHost()}),
-            ex); // We want to print full trace stack of the exception.
-      }
+      LOGGER.log(
+          Level.WARNING,
+          Messages.get(
+              "HostMonitorImpl.exceptionDuringMonitoringStop",
+              new Object[] {this.hostSpec.getHost()}),
+          throwable); // We want to print full trace stack of the exception.
     } finally {
       this.stop.set(true);
       this.monitoringConn.clean();
@@ -339,6 +323,65 @@ public class HostMonitorV2Impl extends AbstractMonitor implements HostMonitor, S
     LOGGER.finest(() -> Messages.get(
         "HostMonitorImpl.stopMonitoringThread",
         new Object[] {this.hostSpec.getHost()}));
+  }
+
+  /**
+   * Performs a single monitoring iteration: checks the status of the monitored host, updates its health status, and
+   * processes the active monitoring contexts.
+   *
+   * @throws InterruptedException if the thread is interrupted while waiting for the next iteration.
+   */
+  protected void monitorIteration() throws InterruptedException {
+
+    if (this.activeContexts.isEmpty() && !this.nodeUnhealthy.get()) {
+      TimeUnit.NANOSECONDS.sleep(THREAD_SLEEP_NANO);
+      return;
+    }
+
+    final long statusCheckStartTimeNano = this.getCurrentTimeNano();
+    final boolean isValid = this.checkConnectionStatus();
+    final long statusCheckEndTimeNano = this.getCurrentTimeNano();
+
+    this.updateNodeHealthStatus(isValid, statusCheckStartTimeNano, statusCheckEndTimeNano);
+
+    final List<WeakReference<HostMonitorConnectionContextV2>> tmpActiveContexts = new ArrayList<>();
+    WeakReference<HostMonitorConnectionContextV2> monitorContextWeakRef;
+
+    while ((monitorContextWeakRef = this.activeContexts.poll()) != null) {
+      if (this.stop.get()) {
+        break;
+      }
+
+      HostMonitorConnectionContextV2 monitorContext = monitorContextWeakRef.get();
+      if (monitorContext == null) {
+        continue;
+      }
+
+      if (this.nodeUnhealthy.get()) {
+        // Kill connection.
+        monitorContext.setNodeUnhealthy(true);
+        final Connection connectionToAbort = monitorContext.getConnection();
+        this.servicesContainer.getConnectionContextService().release(monitorContext);
+        if (connectionToAbort != null) {
+          this.abortConnection(connectionToAbort);
+          if (this.abortedConnectionsCounter != null) {
+            this.abortedConnectionsCounter.inc();
+          }
+        }
+      } else if (monitorContext.isActive()) {
+        tmpActiveContexts.add(monitorContextWeakRef);
+      }
+    }
+
+    // activeContexts is empty now and tmpActiveContexts contains all yet active contexts
+    // Add active contexts back to the queue.
+    this.activeContexts.addAll(tmpActiveContexts);
+
+    long delayNano = this.failureDetectionIntervalNano - (statusCheckEndTimeNano - statusCheckStartTimeNano);
+    if (delayNano < THREAD_SLEEP_NANO) {
+      delayNano = THREAD_SLEEP_NANO;
+    }
+    TimeUnit.NANOSECONDS.sleep(delayNano);
   }
 
   /**

--- a/wrapper/src/main/java/software/amazon/jdbc/util/monitoring/MonitorServiceImpl.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/monitoring/MonitorServiceImpl.java
@@ -30,6 +30,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -107,6 +108,18 @@ public class MonitorServiceImpl implements MonitorService, EventSubscriber {
   }
 
   protected void checkMonitors() {
+    // This method runs on a scheduleAtFixedRate task, and such tasks are silently cancelled when
+    // they throw. Swallowing errors here keeps monitor supervision alive: without it, a single
+    // unexpected exception would permanently stop stuck/expired monitor detection for every monitor
+    // type, letting a broken monitor stay in the cache and accumulate state indefinitely.
+    try {
+      this.checkMonitorsInternal();
+    } catch (final Throwable throwable) {
+      LOGGER.log(Level.WARNING, Messages.get("MonitorServiceImpl.errorCheckingMonitors"), throwable);
+    }
+  }
+
+  protected void checkMonitorsInternal() {
     LOGGER.finest(Messages.get("MonitorServiceImpl.checkingMonitors"));
     for (CacheContainer container : monitorCaches.values()) {
       ExternallyManagedCache<Object, MonitorItem> cache = container.getCache();

--- a/wrapper/src/main/resources/aws_advanced_jdbc_wrapper_messages.properties
+++ b/wrapper/src/main/resources/aws_advanced_jdbc_wrapper_messages.properties
@@ -352,6 +352,7 @@ HostMonitorConnectionContext.hostDead=Host {0} is *dead*.
 HostMonitorConnectionContext.hostNotResponding=Host {0} is not *responding* {1}.
 HostMonitorConnectionContext.hostAlive=Host {0} is *alive*.
 
+HostMonitorImpl.exceptionDuringMonitoringContinue=Unhandled exception was thrown in monitoring thread for node {0}. Monitoring continues.
 HostMonitorImpl.exceptionDuringMonitoringStop=Stopping monitoring after unhandled exception was thrown in monitoring thread for node {0}.
 HostMonitorImpl.monitorIsStopped=Monitoring was already stopped for node {0}.
 HostMonitorImpl.startMonitoringThreadNewContext=Start monitoring thread for checking new contexts for {0}.
@@ -362,6 +363,7 @@ HostMonitorImpl.stopMonitoringThread=Stop monitoring thread for {0}.
 HostResponseTimeServiceImpl.errorStartingMonitor=An error occurred while starting a response time monitor for ''{0}'': {1}
 
 MonitorServiceImpl.checkingMonitors=Checking monitors for errors...
+MonitorServiceImpl.errorCheckingMonitors=An unexpected error occurred while checking monitors. Monitor supervision will continue on the next scheduled check.
 MonitorServiceImpl.monitorClassMismatch=The monitor stored at ''{0}'' did not have the expected type. The expected type was ''{1}'', but the monitor ''{2}'' had a type of ''{3}''.
 MonitorServiceImpl.monitorStuck=Monitor ''{0}'' has not been updated within the inactive timeout of {1} milliseconds. The monitor will be stopped.
 MonitorServiceImpl.monitorTypeNotRegistered=The given monitor class ''{0}'' is not registered. Please register the monitor class before running monitors of that class with the monitor service.

--- a/wrapper/src/main/resources/aws_advanced_jdbc_wrapper_messages.properties
+++ b/wrapper/src/main/resources/aws_advanced_jdbc_wrapper_messages.properties
@@ -355,6 +355,7 @@ HostMonitorConnectionContext.hostDead=Host {0} is *dead*.
 HostMonitorConnectionContext.hostNotResponding=Host {0} is not *responding* {1}.
 HostMonitorConnectionContext.hostAlive=Host {0} is *alive*.
 
+HostMonitorImpl.exceptionDuringMonitoringContinue=Unhandled exception was thrown in monitoring thread for node {0}. Monitoring continues.
 HostMonitorImpl.exceptionDuringMonitoringStop=Stopping monitoring after unhandled exception was thrown in monitoring thread for node {0}.
 HostMonitorImpl.monitorIsStopped=Monitoring was already stopped for node {0}.
 HostMonitorImpl.startMonitoringThreadNewContext=Start monitoring thread for checking new contexts for {0}.
@@ -365,6 +366,7 @@ HostMonitorImpl.stopMonitoringThread=Stop monitoring thread for {0}.
 HostResponseTimeServiceImpl.errorStartingMonitor=An error occurred while starting a response time monitor for ''{0}'': {1}
 
 MonitorServiceImpl.checkingMonitors=Checking monitors for errors...
+MonitorServiceImpl.errorCheckingMonitors=An unexpected error occurred while checking monitors. Monitor supervision will continue on the next scheduled check.
 MonitorServiceImpl.monitorClassMismatch=The monitor stored at ''{0}'' did not have the expected type. The expected type was ''{1}'', but the monitor ''{2}'' had a type of ''{3}''.
 MonitorServiceImpl.monitorStuck=Monitor ''{0}'' has not been updated within the inactive timeout of {1} milliseconds. The monitor will be stopped.
 MonitorServiceImpl.monitorTypeNotRegistered=The given monitor class ''{0}'' is not registered. Please register the monitor class before running monitors of that class with the monitor service.

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/efm/v1/HostMonitorV1ImplTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/efm/v1/HostMonitorV1ImplTest.java
@@ -31,6 +31,7 @@ import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -185,7 +186,19 @@ class HostMonitorV1ImplTest {
   void test_startMonitoring_whenStopped() {
     monitor.stop();
     monitor.startMonitoring(contextWithShortInterval);
-    verify(contextWithShortInterval).setStartMonitorTimeNano(anyLong());
+
+    // A stopped monitor never processes queued contexts, so it must not accept any. Accepting them
+    // would grow the queue without bound while the caller keeps monitoring connections.
+    verify(contextWithShortInterval, never()).setStartMonitorTimeNano(anyLong());
+    assertEquals(0, getSnapshotStateValue("newContexts (size)"));
+  }
+
+  private Object getSnapshotStateValue(final String key) {
+    return monitor.getSnapshotState().stream()
+        .filter(pair -> key.equals(pair.getValue1()))
+        .map(Pair::getValue2)
+        .findFirst()
+        .orElseThrow(() -> new AssertionError("Snapshot state does not contain '" + key + "'"));
   }
 
   @Test

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/efm/v2/HostMonitorV2ImplTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/efm/v2/HostMonitorV2ImplTest.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.jdbc.plugin.efm.v2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import java.lang.ref.WeakReference;
+import java.lang.reflect.Field;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Queue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import software.amazon.jdbc.HostSpec;
+import software.amazon.jdbc.PluginService;
+import software.amazon.jdbc.util.FullServicesContainer;
+import software.amazon.jdbc.util.events.EventPublisher;
+import software.amazon.jdbc.util.telemetry.TelemetryContext;
+import software.amazon.jdbc.util.telemetry.TelemetryCounter;
+import software.amazon.jdbc.util.telemetry.TelemetryFactory;
+
+class HostMonitorV2ImplTest {
+
+  @Mock PluginService pluginService;
+  @Mock FullServicesContainer servicesContainer;
+  @Mock Connection connection;
+  @Mock HostSpec hostSpec;
+  @Mock HostMonitorConnectionContextV2 context;
+  @Mock TelemetryFactory telemetryFactory;
+  @Mock TelemetryContext telemetryContext;
+  @Mock TelemetryCounter telemetryCounter;
+  @Mock EventPublisher eventPublisher;
+
+  private static final int FAILURE_DETECTION_TIME_MILLIS = 30000;
+  private static final int FAILURE_DETECTION_INTERVAL_MILLIS = 5000;
+  private static final int FAILURE_DETECTION_COUNT = 3;
+
+  private AutoCloseable closeable;
+  private HostMonitorV2Impl monitor;
+
+  @BeforeEach
+  void init() throws SQLException {
+    closeable = MockitoAnnotations.openMocks(this);
+    final Properties properties = new Properties();
+
+    when(pluginService.forceConnect(any(HostSpec.class), any(Properties.class))).thenReturn(connection);
+    when(pluginService.getTelemetryFactory()).thenReturn(telemetryFactory);
+    when(telemetryFactory.openTelemetryContext(anyString(), any())).thenReturn(telemetryContext);
+    when(telemetryFactory.createCounter(anyString())).thenReturn(telemetryCounter);
+    when(servicesContainer.getPluginService()).thenReturn(pluginService);
+    when(servicesContainer.getTelemetryFactory()).thenReturn(telemetryFactory);
+    when(servicesContainer.getEventPublisher()).thenReturn(eventPublisher);
+    when(hostSpec.getHost()).thenReturn("test-host");
+    when(hostSpec.getUrl()).thenReturn("test-url");
+
+    monitor = spy(new HostMonitorV2Impl(
+        servicesContainer,
+        hostSpec,
+        properties,
+        FAILURE_DETECTION_TIME_MILLIS,
+        FAILURE_DETECTION_INTERVAL_MILLIS,
+        FAILURE_DETECTION_COUNT,
+        telemetryCounter));
+  }
+
+  @AfterEach
+  void cleanUp() throws Exception {
+    if (monitor != null) {
+      monitor.stop();
+    }
+    closeable.close();
+  }
+
+  @Test
+  @Timeout(30)
+  void newContextRun_survivesTransientException_andKeepsDraining() throws Exception {
+    // Queue one healthy context into newContexts (uses the real clock).
+    when(context.isActive()).thenReturn(true);
+    monitor.startMonitoring(context);
+    assertEquals(1, newContextsSize());
+
+    // Make the first loop iteration throw; every later call returns a far-future time so the
+    // queued context is past-due and must be drained into activeContexts.
+    final long future = System.nanoTime() + TimeUnit.HOURS.toNanos(1);
+    final AtomicBoolean thrownOnce = new AtomicBoolean(false);
+    doAnswer(inv -> {
+      if (thrownOnce.compareAndSet(false, true)) {
+        throw new RuntimeException("simulated transient monitoring error");
+      }
+      return future;
+    }).when(monitor).getCurrentTimeNano();
+
+    final Thread drainer = new Thread(monitor::newContextRun, "test-newContextRun");
+    drainer.setDaemon(true);
+    drainer.start();
+
+    boolean drained = false;
+    for (int i = 0; i < 100 && !drained; i++) {
+      drained = newContextsSize() == 0 && activeContextsSize() == 1;
+      TimeUnit.MILLISECONDS.sleep(100);
+    }
+    monitor.stop();
+    drainer.join(TimeUnit.SECONDS.toMillis(5));
+
+    assertTrue(drained,
+        "newContextRun() must keep draining newContexts after a transient exception. Observed newContexts="
+            + newContextsSize() + ", activeContexts=" + activeContextsSize());
+  }
+
+  @Test
+  @Timeout(30)
+  void newContextRun_stopsTheMonitorWhenTheThreadExits() throws Exception {
+    // Whenever the drainer thread is gone, nothing drains newContexts anymore. The monitor must be
+    // marked as stopped so that the monitor service replaces it, rather than leaving a monitor that
+    // keeps accepting contexts it will never process.
+    final Thread drainer = new Thread(monitor::newContextRun, "test-newContextRun");
+    drainer.setDaemon(true);
+    drainer.start();
+
+    TimeUnit.MILLISECONDS.sleep(200);
+    drainer.interrupt();
+    drainer.join(TimeUnit.SECONDS.toMillis(5));
+
+    assertFalse(drainer.isAlive(), "the drainer thread should have exited");
+    assertTrue(isStopped(), "newContextRun() must stop the monitor when its thread exits");
+  }
+
+  @Test
+  void startMonitoring_doesNotQueueContextsWhenStopped() throws Exception {
+    monitor.stop();
+
+    monitor.startMonitoring(context);
+
+    assertEquals(0, newContextsSize(),
+        "a stopped monitor never drains newContexts, so it must not queue new contexts");
+  }
+
+  private boolean isStopped() throws Exception {
+    final Field field = getInheritedField("stop");
+    return ((AtomicBoolean) field.get(monitor)).get();
+  }
+
+  @SuppressWarnings("unchecked")
+  private int newContextsSize() throws Exception {
+    final Field field = HostMonitorV2Impl.class.getDeclaredField("newContexts");
+    field.setAccessible(true);
+    final Map<Long, Queue<WeakReference<HostMonitorConnectionContextV2>>> newContexts =
+        (Map<Long, Queue<WeakReference<HostMonitorConnectionContextV2>>>) field.get(monitor);
+    return newContexts.values().stream().mapToInt(Queue::size).sum();
+  }
+
+  @SuppressWarnings("unchecked")
+  private int activeContextsSize() throws Exception {
+    final Field field = HostMonitorV2Impl.class.getDeclaredField("activeContexts");
+    field.setAccessible(true);
+    final Queue<WeakReference<HostMonitorConnectionContextV2>> activeContexts =
+        (Queue<WeakReference<HostMonitorConnectionContextV2>>) field.get(monitor);
+    return activeContexts.size();
+  }
+
+  private Field getInheritedField(final String name) throws Exception {
+    Class<?> clazz = HostMonitorV2Impl.class;
+    while (clazz != null) {
+      try {
+        final Field field = clazz.getDeclaredField(name);
+        field.setAccessible(true);
+        return field;
+      } catch (final NoSuchFieldException ex) {
+        clazz = clazz.getSuperclass();
+      }
+    }
+    throw new NoSuchFieldException(name);
+  }
+}

--- a/wrapper/src/test/java/software/amazon/jdbc/util/monitoring/MonitorServiceImplTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/util/monitoring/MonitorServiceImplTest.java
@@ -16,6 +16,7 @@
 
 package software.amazon.jdbc.util.monitoring;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -311,10 +312,64 @@ class MonitorServiceImplTest {
     assertEquals(MonitorState.STOPPED, monitor.getState());
   }
 
+  @Test
+  public void testCheckMonitors_unexpectedErrorDoesNotStopSupervision() throws SQLException {
+    spyMonitorService.registerMonitorTypeIfAbsent(
+        ThrowingMonitor.class,
+        TimeUnit.MINUTES.toNanos(1),
+        TimeUnit.MINUTES.toNanos(1),
+        EnumSet.noneOf(MonitorErrorResponse.class),
+        null
+    );
+
+    String key = "throwingMonitor";
+    ThrowingMonitor monitor = spyMonitorService.runIfAbsent(
+        ThrowingMonitor.class,
+        key,
+        mockStorageService,
+        mockEventPublisher,
+        mockTelemetryFactory,
+        mockConnectionProvider,
+        "jdbc:postgresql://somehost/somedb",
+        "someProtocol",
+        mockTargetDriverDialect,
+        mockDbDialect,
+        new Properties(),
+        null,
+        (serviceContainer) -> new ThrowingMonitor(30)
+    );
+    assertNotNull(monitor);
+
+    // checkMonitors() runs on a scheduleAtFixedRate task, and such tasks are silently cancelled if they throw. An
+    // unexpected error from a single monitor must not escape, otherwise stuck/expired monitor detection stops for
+    // every monitor type for the lifetime of the JVM.
+    assertDoesNotThrow(() -> spyMonitorService.checkMonitors());
+
+    // A second pass must still run, proving supervision was not left in a broken state.
+    assertDoesNotThrow(() -> spyMonitorService.checkMonitors());
+  }
+
   static class NoOpMonitor extends AbstractMonitor {
     protected NoOpMonitor(
         long terminationTimeoutSec) {
       super(terminationTimeoutSec);
+    }
+
+    @Override
+    public void monitor() {
+      // do nothing.
+    }
+  }
+
+  static class ThrowingMonitor extends AbstractMonitor {
+    protected ThrowingMonitor(
+        long terminationTimeoutSec) {
+      super(terminationTimeoutSec);
+    }
+
+    @Override
+    public MonitorState getState() {
+      throw new RuntimeException("simulated failure while inspecting the monitor state");
     }
 
     @Override


### PR DESCRIPTION
## Summary

Fixes #2061.

`HostMonitorV2Impl.newContextRun()` wrapped its entire drain loop in a single `try/catch`. Any exception was logged at `FINEST` and the thread exited with no restart. `newContexts` is then never drained again while `startMonitoring()` keeps adding a `WeakReference` on every monitored call, so the map grows without bound until the JVM runs out of heap, and no context ever reaches `activeContexts`, silently disabling efm2 failure detection for that host.

Reproduced on `main` with the unit test added here: after a single injected exception the drainer thread exits and the queued context is never drained (`newContexts=1, activeContexts=0`).

### Changes

- **Resilient monitoring loops.** Exception handling moved inside the loops, so a failed iteration is logged and the thread keeps running. `InterruptedException` still ends the loop. Applies to `newContextRun()` and `monitor()` in efm2 (`plugin/efm/v2`) and to `monitor()` in efm (`plugin/efm/v1`). The efm/efm2 `monitor()` bodies were extracted into a `monitorIteration()` method so the loop can wrap a single iteration; those bodies are otherwise unchanged apart from indentation.
- **Stop the monitor when the drainer exits.** `newContextRun()` now sets `stop` in a `finally`, so a monitor whose drainer is gone is replaced by the monitor service instead of lingering and accepting contexts nobody processes.
- **Reject contexts on a stopped monitor.** `startMonitoring()` previously logged a warning and queued the context anyway. It now returns early, since a stopped monitor never drains its queues.
- **Guard `MonitorServiceImpl.checkMonitors()`.** This runs on a `scheduleAtFixedRate` task, and such tasks are silently cancelled if the task throws. A single unexpected exception there permanently disables stuck and expired monitor detection for *every* monitor type for the life of the JVM, which is the most likely reason the stuck-monitor safety net did not bound the reported leak.
- **Visibility.** Unhandled monitoring exceptions are logged at `WARNING` instead of `FINEST`, and the handlers catch `Throwable` so an `Error` in a monitor thread is no longer completely silent. The reporter could not find the exception that killed the thread because it was only logged at `FINEST`.

New message keys `HostMonitorImpl.exceptionDuringMonitoringContinue` and `MonitorServiceImpl.errorCheckingMonitors` were added to the resource bundle.

## Tests

- New `HostMonitorV2ImplTest`: the drainer keeps draining after a transient exception (fails on `main`, passes here), the drainer's exit stops the monitor, and a stopped monitor queues nothing.
- New `MonitorServiceImplTest.testCheckMonitors_unexpectedErrorDoesNotStopSupervision`, using a monitor whose `getState()` throws.
- `HostMonitorV1ImplTest.test_startMonitoring_whenStopped` updated: it asserted the old behavior of queueing a context on a stopped monitor, and now asserts the context is rejected and the queue stays empty.

The full `aws-advanced-jdbc-wrapper` unit test suite, `checkstyleMain` and `checkstyleTest` pass. Integration tests were not run.

## Behavior notes

- A persistent per-iteration failure now produces a repeating `WARNING` (at most one per second for the drainer) rather than a single `FINEST` line and a dead thread. That visibility is the point, but it is a change in log volume for a broken monitor.
- `HostMonitorV1Impl.startMonitoring()` still refreshes `lastActivityTimestampNanos`. Removing it would let the monitor service treat an idle-but-open v1 monitor as stuck, since v1 only refreshes that timestamp when it actually performs a health check. The early return plus the resilient loop closes the leak without that eviction churn.
