### PR TITLE
fix: repair the JMH benchmarks and fill their coverage gaps

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,6 +95,11 @@ jobs:
             ${{ runner.os }}-gradle-
       - name: 'Run checkstyle and spotbugs'
         run: ./gradlew --build-cache checkstyleMain checkstyleTest spotbugsMain spotbugsTest
+      # The JMH benchmarks live in the `jmh` source set of the :benchmarks module, so neither
+      # `test` nor `checkstyleMain` compiles them. They reach into the wrapper's internal APIs
+      # and silently stop compiling when those change, so compile them here.
+      - name: 'Compile JMH benchmarks'
+        run: ./gradlew --build-cache :benchmarks:jmhJar
 
   # Nullness analysis in enforcing mode: any new Checker Framework finding fails the build.
   # This lives in main.yml (rather than only in run-checker-framework.yml) so it is covered by

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,11 +1,62 @@
 # Benchmarks for AWS Advanced JDBC Wrapper
 
-This directory contains a set of benchmarks for the AWS Advanced JDBC Wrapper.
-These benchmarks measure the overhead from executing JBDC method calls with multiple connection plugins enabled.
-The benchmarks do not measure the performance of target JDBC drivers nor the performance of the failover process.
+This directory contains a set of [JMH](https://github.com/openjdk/jmh) benchmarks for the AWS Advanced JDBC Wrapper.
+These benchmarks measure the overhead the wrapper adds to JDBC method calls with multiple connection plugins enabled.
+They do not measure the performance of target JDBC drivers nor the performance of the failover process.
+
+## Benchmark classes
+
+| Class                               | What it measures                                                                              | Needs a database? |
+|-------------------------------------|-----------------------------------------------------------------------------------------------|-------------------|
+| `ConnectionPluginManagerBenchmarks` | Plugin-chain construction and the `connect` / `execute` / `notifyConnectionChanged` pipelines | No (mocked)       |
+| `PluginBenchmarks`                  | `ConnectionWrapper` lifecycle and statement execution through the wrapper                     | No (mocked)       |
+| `PgCacheBenchmarks`                 | The remote query cache plugin against a real PostgreSQL instance and cache server             | Yes               |
 
 ## Usage
-1. Build the benchmarks with the following command `../gradlew jmhJar`.
-    1. the JAR file will be outputted to `build/libs`
-2. Run the benchmarks with the following command `java -jar build/libs/benchmarks-4.3.0-jmh.jar`.
-    1. you may have to update the command based on the exact version of the produced JAR file
+
+1. Build the benchmark JAR:
+
+   ```shell
+   ../gradlew :benchmarks:jmhJar
+   ```
+
+   The shaded JAR is written to `build/libs/benchmarks-<version>-jmh.jar`.
+
+2. Run the benchmarks that do not require infrastructure:
+
+   ```shell
+   java -jar build/libs/benchmarks-<version>-jmh.jar -e PgCacheBenchmarks
+   ```
+
+   `-e PgCacheBenchmarks` excludes the benchmark that needs a live database and cache server. Without
+   it, that class fails during setup and its results are reported as `<failure>`.
+
+Useful JMH flags while iterating: `-f 1 -wi 1 -i 1` for a fast smoke run, `-rf json -rff result.json`
+to capture machine-readable results, and `-prof gc` to add allocation numbers.
+
+### Running `PgCacheBenchmarks`
+
+This class needs a reachable PostgreSQL instance holding the pre-populated `test` table (see the
+class javadoc for the schema) plus a reachable cache server. Endpoints are supplied as system
+properties, so nothing environment-specific is hardcoded:
+
+```shell
+java -Dbenchmarks.pg.url=jdbc:aws-wrapper:postgresql://my-db:5432/postgres \
+     -Dbenchmarks.cache.rw=my-cache:6379 \
+     -Dbenchmarks.cache.ro=my-cache:6380 \
+     -jar build/libs/benchmarks-<version>-jmh.jar PgCacheBenchmarks
+```
+
+If a property is missing, setup fails immediately with a message naming it rather than timing out
+against a placeholder host name.
+
+## Notes
+
+- The mocked benchmarks measure the wrapper's own overhead. `PluginBenchmarks` drives a
+  `ConnectionWrapper` backed by a mocked `ConnectionPluginManager`, so the `wrapperPlugins` values in
+  its property helpers select *which* JDBC pipeline shape is exercised, not a real plugin chain.
+  `ConnectionPluginManagerBenchmarks` is the class that builds real plugin chains (10 instances of a
+  no-op `BenchmarkPlugin`).
+- `../gradlew test` does not compile this module: the benchmarks live in the `jmh` source set, so
+  `:benchmarks:jmhJar` (or `:benchmarks:compileJmhJava`) is what catches drift against the wrapper's
+  internal APIs.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,16 +1,25 @@
 # Benchmarks for AWS Advanced JDBC Wrapper
 
 This directory contains a set of [JMH](https://github.com/openjdk/jmh) benchmarks for the AWS Advanced JDBC Wrapper.
-These benchmarks measure the overhead the wrapper adds to JDBC method calls with multiple connection plugins enabled.
-They do not measure the performance of target JDBC drivers nor the performance of the failover process.
+They measure the overhead the wrapper adds on top of the target JDBC driver, and the per-call cost of
+the driver's own components. They do not measure the performance of target JDBC drivers themselves,
+nor the failover process.
 
 ## Benchmark classes
 
-| Class                               | What it measures                                                                              | Needs a database? |
-|-------------------------------------|-----------------------------------------------------------------------------------------------|-------------------|
-| `ConnectionPluginManagerBenchmarks` | Plugin-chain construction and the `connect` / `execute` / `notifyConnectionChanged` pipelines | No (mocked)       |
-| `PluginBenchmarks`                  | `ConnectionWrapper` lifecycle and statement execution through the wrapper                     | No (mocked)       |
-| `PgCacheBenchmarks`                 | The remote query cache plugin against a real PostgreSQL instance and cache server             | Yes               |
+| Class | What it measures | Needs a database? |
+|---|---|---|
+| `WrapperOverheadBenchmarks` | **Wrapper cost versus the target driver.** Paired `raw*`/`wrapped*` benchmarks per statement, per parameter and per row | No |
+| `RealPluginChainBenchmarks` | Per-call cost of real plugins through `ConnectionPluginManager.execute` | No |
+| `PluginServiceBenchmarks` | The real `PluginServiceImpl` and `SessionStateServiceImpl` | No |
+| `SqlMethodAnalyzerBenchmarks` | SQL inspection run on every statement execution | No |
+| `RdsUtilsBenchmarks` | RDS endpoint classification, cached and uncached | No |
+| `ConnectionUrlParserBenchmarks` | Per-connection URL and property parsing | No |
+| `StorageBenchmarks` | `CacheMap`, `ExpirationCache`, `SlidingExpirationCache`, `StorageServiceImpl`, incl. contended | No |
+| `HostSelectorBenchmarks` | All seven `HostSelector` implementations, incl. contended | No |
+| `ConnectionPluginManagerBenchmarks` | Plugin-chain construction and the connect/execute pipelines with 10 no-op plugins | No |
+| `PluginBenchmarks` | `ConnectionWrapper` lifecycle through a mocked plugin manager | No |
+| `PgCacheBenchmarks` | The remote query cache plugin against real infrastructure | **Yes** |
 
 ## Usage
 
@@ -31,8 +40,16 @@ They do not measure the performance of target JDBC drivers nor the performance o
    `-e PgCacheBenchmarks` excludes the benchmark that needs a live database and cache server. Without
    it, that class fails during setup and its results are reported as `<failure>`.
 
-Useful JMH flags while iterating: `-f 1 -wi 1 -i 1` for a fast smoke run, `-rf json -rff result.json`
-to capture machine-readable results, and `-prof gc` to add allocation numbers.
+Useful flags while iterating: `-f 1 -wi 1 -i 1` for a fast smoke run, `-rf json -rff result.json` to
+capture machine-readable results, `-prof gc` to add allocation numbers, and a class-name regex to
+select a subset, for example:
+
+```shell
+java -jar build/libs/benchmarks-<version>-jmh.jar WrapperOverheadBenchmarks
+```
+
+A smoke run is enough to confirm every benchmark still executes, but **not** enough to draw
+conclusions from. Use the default iteration counts before quoting a number.
 
 ### Running `PgCacheBenchmarks`
 
@@ -50,13 +67,48 @@ java -Dbenchmarks.pg.url=jdbc:aws-wrapper:postgresql://my-db:5432/postgres \
 If a property is missing, setup fails immediately with a message naming it rather than timing out
 against a placeholder host name.
 
-## Notes
+## Interpreting the results
 
-- The mocked benchmarks measure the wrapper's own overhead. `PluginBenchmarks` drives a
-  `ConnectionWrapper` backed by a mocked `ConnectionPluginManager`, so the `wrapperPlugins` values in
-  its property helpers select *which* JDBC pipeline shape is exercised, not a real plugin chain.
-  `ConnectionPluginManagerBenchmarks` is the class that builds real plugin chains (10 instances of a
-  no-op `BenchmarkPlugin`).
-- `../gradlew test` does not compile this module: the benchmarks live in the `jmh` source set, so
-  `:benchmarks:jmhJar` (or `:benchmarks:compileJmhJava`) is what catches drift against the wrapper's
-  internal APIs.
+**Read pairs and differences, not absolute values.** The benchmarks run without a database, so the
+target driver is stood in for by `support/FakeJdbc` - `java.lang.reflect.Proxy` instances that serve
+constant values. That is deliberate: the alternative is Mockito, whose dispatch and invocation
+recording cost more than the wrapper code under test. The stand-in cost sits underneath both sides of
+every `raw*`/`wrapped*` pair and underneath the baseline of every plugin benchmark, so it cancels out
+of the difference. It does not cancel out of an absolute number, and none of these numbers include a
+network round trip.
+
+**Plugin cost is a cliff, not a gradient.** `ConnectionPluginManager` computes whether a JDBC method
+has subscribers while explicitly excluding the terminal `DefaultConnectionPlugin`. When nothing
+subscribes, the whole pipeline is bypassed. So the interesting quantity in
+`RealPluginChainBenchmarks` is the step from `noPlugins` to the first *subscribing* plugin, most of
+which is the default plugin's SQL analysis rather than the plugin itself. Adding further plugins on
+top costs comparatively little.
+
+**Contended benchmarks are separate on purpose.** Several driver caches take a write path on read,
+and the round-robin host selector holds a lock across its whole selection. Those costs are invisible
+single-threaded, so the affected classes carry explicit `contended*` variants annotated with
+`@Threads`.
+
+## What is not covered
+
+- Failover, monitor probes, topology refreshes and credential fetches. These are driven by network
+  events and background threads rather than by a JDBC call, and cannot be triggered from a benchmark
+  without real infrastructure.
+- Connect-only plugins (`iam`, `awsSecretsManager`, `federatedAuth`, `okta`). Their real cost is a
+  network call; on the execute path they would score flat.
+- Dialect detection, which requires a live database. `PluginServiceBenchmarks` supplies a fixed
+  dialect so the rest of `PluginServiceImpl` can be measured.
+
+## Notes for maintainers
+
+- `../gradlew test` does not compile this module: the benchmarks live in the `jmh` source set. CI runs
+  `:benchmarks:jmhJar` in the `lint` job for exactly that reason, so drift against the wrapper's
+  internal APIs fails the build rather than being discovered later.
+- The `support` package holds the shared stand-ins. Where the driver has a real fallback
+  implementation, the real one is used instead of a stand-in - `UnknownDialect`,
+  `GenericTargetDriverDialect`, `MonitorService`, `SimpleConnectionContextServiceImpl` and
+  `ImportantEventService`. Real plugins read these during construction and on the hot path, so
+  standing them in would both crash and misrepresent cost.
+- `PluginBenchmarks` still drives a mocked `ConnectionPluginManager`, so its `wrapperPlugins` values
+  select which JDBC pipeline shape is exercised rather than a real plugin chain. Real chains live in
+  `RealPluginChainBenchmarks`.

--- a/benchmarks/build.gradle.kts
+++ b/benchmarks/build.gradle.kts
@@ -29,6 +29,11 @@ dependencies {
     implementation("org.checkerframework:checker-qual:3.55.1")
     implementation("io.valkey:valkey-glide:2.3.0:$nativeClassifier")
     implementation("org.apache.commons:commons-pool2:2.13.1")
+    // Optional dependency of the wrapper, required at runtime by the sqlParser,
+    // autoReadWriteSplitting and kmsEncryption plugins. Without it on the benchmark classpath those
+    // plugins fail with NoClassDefFoundError instead of being measured. Keep the version aligned
+    // with wrapper/build.gradle.kts.
+    implementation("com.github.jsqlparser:jsqlparser:4.9")
     jmhAnnotationProcessor("org.openjdk.jmh:jmh-generator-annprocess:1.37")
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.14.4")

--- a/benchmarks/src/jmh/java/software/amazon/jdbc/benchmarks/ConnectionPluginManagerBenchmarks.java
+++ b/benchmarks/src/jmh/java/software/amazon/jdbc/benchmarks/ConnectionPluginManagerBenchmarks.java
@@ -70,6 +70,7 @@ import software.amazon.jdbc.profile.ConfigurationProfile;
 import software.amazon.jdbc.profile.ConfigurationProfileBuilder;
 import software.amazon.jdbc.targetdriverdialect.TargetDriverDialect;
 import software.amazon.jdbc.util.FullServicesContainer;
+import software.amazon.jdbc.util.ImportantEventService;
 import software.amazon.jdbc.util.telemetry.DefaultTelemetryFactory;
 import software.amazon.jdbc.util.telemetry.GaugeCallable;
 import software.amazon.jdbc.util.telemetry.TelemetryContext;
@@ -96,8 +97,11 @@ public class ConnectionPluginManagerBenchmarks {
 
   @Mock ConnectionProvider mockConnectionProvider;
   @Mock FullServicesContainer mockServicesContainer;
+  @Mock ImportantEventService mockImportantEventService;
   @Mock PluginService mockPluginService;
   @Mock PluginManagerService mockPluginManagerService;
+  @Mock Dialect mockDialect;
+  @Mock TargetDriverDialect mockTargetDriverDialect;
   @Mock TelemetryFactory mockTelemetryFactory;
   @Mock HostListProviderService mockHostListProvider;
   @Mock Connection mockConnection;
@@ -111,7 +115,7 @@ public class ConnectionPluginManagerBenchmarks {
 
   public static void main(String[] args) throws RunnerException {
     Options opt = new OptionsBuilder()
-        .include(software.amazon.jdbc.benchmarks.PluginBenchmarks.class.getSimpleName())
+        .include(ConnectionPluginManagerBenchmarks.class.getSimpleName())
         .addProfiler(GCProfiler.class)
         .detectJvmArgs()
         .build();
@@ -140,9 +144,17 @@ public class ConnectionPluginManagerBenchmarks {
     when(mockResultSet.getString(eq(FIELD_SESSION_ID))).thenReturn(WRITER_SESSION_ID);
     when(mockResultSet.getString(eq(FIELD_SERVER_ID)))
         .thenReturn("myInstance1.domain.com", "myInstance2.domain.com", "myInstance3.domain.com");
+    when(mockStatement.getConnection()).thenReturn(mockConnection);
     when(mockServicesContainer.getPluginService()).thenReturn(mockPluginService);
+    // DefaultConnectionPlugin's constructor rejects a null PluginManagerService, and its
+    // execute()/connect() paths go through the ImportantEventService. Both are resolved from the
+    // services container, so leaving them unstubbed makes every benchmark here fail during setup.
+    when(mockServicesContainer.getPluginManagerService()).thenReturn(mockPluginManagerService);
+    when(mockServicesContainer.getImportantEventService()).thenReturn(mockImportantEventService);
     when(mockPluginService.getCurrentConnection()).thenReturn(mockConnection);
     when(mockPluginService.getTelemetryFactory()).thenReturn(mockTelemetryFactory);
+    when(mockPluginService.getDialect()).thenReturn(mockDialect);
+    when(mockPluginService.getTargetDriverDialect()).thenReturn(mockTargetDriverDialect);
 
     // Create a plugin chain with 10 custom test plugins.
     final List<Class<? extends ConnectionPluginFactory>> pluginFactories = new ArrayList<>(
@@ -179,7 +191,10 @@ public class ConnectionPluginManagerBenchmarks {
   public ConnectionPluginManager initConnectionPluginManagerWithNoPlugins() throws SQLException {
     final ConnectionPluginManager manager =
         new ConnectionPluginManager(propertiesWithoutPlugins, mockTelemetryFactory, mockConnectionProvider, null);
-    manager.initPlugins(mockServicesContainer, configurationProfile);
+    // The configuration profile must be null here: a non-null profile takes precedence over the
+    // wrapperPlugins property, so passing the "benchmark" profile would build the 10-plugin chain
+    // and make this benchmark a duplicate of initConnectionPluginManagerWithPlugins.
+    manager.initPlugins(mockServicesContainer, null);
     return manager;
   }
 
@@ -252,7 +267,7 @@ public class ConnectionPluginManagerBenchmarks {
         "url",
         propertiesWithoutPlugins,
         mockHostListProvider);
-    return pluginManager;
+    return pluginManagerWithNoPlugins;
   }
 
   @Benchmark
@@ -278,6 +293,6 @@ public class ConnectionPluginManagerBenchmarks {
   @Benchmark
   public ConnectionPluginManager releaseResourcesWithNoPlugins() {
     pluginManagerWithNoPlugins.releaseResources();
-    return pluginManager;
+    return pluginManagerWithNoPlugins;
   }
 }

--- a/benchmarks/src/jmh/java/software/amazon/jdbc/benchmarks/ConnectionUrlParserBenchmarks.java
+++ b/benchmarks/src/jmh/java/software/amazon/jdbc/benchmarks/ConnectionUrlParserBenchmarks.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.jdbc.benchmarks;
+
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import software.amazon.jdbc.HostSpec;
+import software.amazon.jdbc.HostSpecBuilder;
+import software.amazon.jdbc.hostavailability.SimpleHostAvailabilityStrategy;
+import software.amazon.jdbc.util.ConnectionUrlParser;
+import software.amazon.jdbc.util.PropertyUtils;
+
+/**
+ * Micro-benchmarks for {@link ConnectionUrlParser} and {@link PropertyUtils}.
+ *
+ * <p>Everything here runs once per {@code DriverManager.getConnection} call, before any query is
+ * sent. That makes it irrelevant to steady-state query throughput but directly relevant to
+ * connection-establishment latency, which matters for short-lived connections and for pool warm-up
+ * where hundreds of connections are opened at once. None of it was measured before.
+ *
+ * <p>{@code getHostsFromConnectionUrl} is measured against a single host and against a
+ * multi-host list, because it classifies each host through {@link software.amazon.jdbc.util.RdsUtils}
+ * and therefore scales with host count rather than URL length.
+ */
+@State(Scope.Benchmark)
+@Fork(1)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class ConnectionUrlParserBenchmarks {
+
+  private static final String SINGLE_HOST_URL =
+      "jdbc:aws-wrapper:postgresql://my-cluster.cluster-XYZ.us-east-2.rds.amazonaws.com:5432/postgres";
+  private static final String MULTI_HOST_URL =
+      "jdbc:aws-wrapper:postgresql://instance-1.XYZ.us-east-2.rds.amazonaws.com:5432,"
+          + "instance-2.XYZ.us-east-2.rds.amazonaws.com:5432,"
+          + "instance-3.XYZ.us-east-2.rds.amazonaws.com:5432,"
+          + "instance-4.XYZ.us-east-2.rds.amazonaws.com:5432,"
+          + "instance-5.XYZ.us-east-2.rds.amazonaws.com:5432/postgres";
+  private static final String URL_WITH_PROPERTIES =
+      SINGLE_HOST_URL + "?user=someUser&password=somePassword&wrapperPlugins=failover2,efm2"
+          + "&connectTimeout=10000&socketTimeout=30000&ApplicationName=benchmark";
+
+  private final ConnectionUrlParser parser = new ConnectionUrlParser();
+  private final Supplier<HostSpecBuilder> hostSpecBuilderSupplier =
+      () -> new HostSpecBuilder(new SimpleHostAvailabilityStrategy());
+
+  private Properties sourceProperties;
+
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder()
+        .include(ConnectionUrlParserBenchmarks.class.getSimpleName())
+        .addProfiler(GCProfiler.class)
+        .detectJvmArgs()
+        .build();
+
+    new Runner(opt).run();
+  }
+
+  @Setup(Level.Trial)
+  public void setUp() {
+    this.sourceProperties = new Properties();
+    this.sourceProperties.setProperty("user", "someUser");
+    this.sourceProperties.setProperty("password", "somePassword");
+    this.sourceProperties.setProperty("wrapperPlugins", "failover2,efm2");
+    this.sourceProperties.setProperty("connectTimeout", "10000");
+    this.sourceProperties.setProperty("socketTimeout", "30000");
+  }
+
+  @Benchmark
+  public List<HostSpec> getHostsSingleHost() {
+    return parser.getHostsFromConnectionUrl(SINGLE_HOST_URL, false, hostSpecBuilderSupplier);
+  }
+
+  @Benchmark
+  public List<HostSpec> getHostsFiveHosts() {
+    return parser.getHostsFromConnectionUrl(MULTI_HOST_URL, false, hostSpecBuilderSupplier);
+  }
+
+  @Benchmark
+  public List<HostSpec> getHostsFiveHostsSingleWriter() {
+    return parser.getHostsFromConnectionUrl(MULTI_HOST_URL, true, hostSpecBuilderSupplier);
+  }
+
+  @Benchmark
+  public HostSpec parseHostPortPair() {
+    return ConnectionUrlParser.parseHostPortPair(
+        "instance-1.XYZ.us-east-2.rds.amazonaws.com:5432", hostSpecBuilderSupplier);
+  }
+
+  @Benchmark
+  public String parseDatabaseFromUrl() {
+    return ConnectionUrlParser.parseDatabaseFromUrl(URL_WITH_PROPERTIES);
+  }
+
+  @Benchmark
+  public String getProtocol() {
+    return parser.getProtocol(SINGLE_HOST_URL);
+  }
+
+  @Benchmark
+  public Properties parsePropertiesFromUrl() {
+    final Properties props = new Properties();
+    ConnectionUrlParser.parsePropertiesFromUrl(URL_WITH_PROPERTIES, props);
+    return props;
+  }
+
+  /**
+   * Property copying happens several times per connection (URL properties, profile properties,
+   * per-plugin copies), so its cost is multiplied even though a single call is trivial.
+   */
+  @Benchmark
+  public Properties copyProperties() {
+    return PropertyUtils.copyProperties(sourceProperties);
+  }
+}

--- a/benchmarks/src/jmh/java/software/amazon/jdbc/benchmarks/HostSelectorBenchmarks.java
+++ b/benchmarks/src/jmh/java/software/amazon/jdbc/benchmarks/HostSelectorBenchmarks.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.jdbc.benchmarks;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import software.amazon.jdbc.HighestLoadHostSelector;
+import software.amazon.jdbc.HighestWeightHostSelector;
+import software.amazon.jdbc.HostRole;
+import software.amazon.jdbc.HostSpec;
+import software.amazon.jdbc.HostSpecBuilder;
+import software.amazon.jdbc.LeastConnectionsHostSelector;
+import software.amazon.jdbc.LowestLoadHostSelector;
+import software.amazon.jdbc.RandomHostSelector;
+import software.amazon.jdbc.RoundRobinHostSelector;
+import software.amazon.jdbc.WeightedRandomHostSelector;
+import software.amazon.jdbc.hostavailability.SimpleHostAvailabilityStrategy;
+import software.amazon.jdbc.util.Pair;
+import software.amazon.jdbc.util.storage.SlidingExpirationCache;
+
+/**
+ * Benchmarks for every {@link software.amazon.jdbc.HostSelector} implementation.
+ *
+ * <p>A selector runs once per reader acquisition, which under read/write splitting with query-level
+ * load balancing means once per read query rather than once per connection. None of them had
+ * coverage, and their implementations differ enough that the cost is not obviously uniform: some
+ * stream and collect, one sorts, one takes a lock, and one copies a map per candidate host.
+ *
+ * <p>All selectors are measured against the same five-reader topology so the numbers are directly
+ * comparable. Where a selector has a second cost driver it gets extra benchmarks:
+ *
+ * <ul>
+ *   <li>{@code roundRobin*} holds a {@link software.amazon.jdbc.util.ResourceLock} for the whole
+ *       selection and sorts the eligible list on every call, so it is also measured under contention.
+ *   <li>{@code leastConnections*} calls {@code SlidingExpirationCache.getEntries()} once per
+ *       candidate host, and that method copies the whole pool map. It is measured with an empty pool
+ *       cache and with 20 pools to show whether the cost scales with pool count.
+ *   <li>{@code weightedRandom*} is measured using {@code HostSpec} weights and using the
+ *       {@code weightedRandomHostWeightPairs} property, which takes a different, parsing path.
+ * </ul>
+ */
+@State(Scope.Benchmark)
+@Fork(1)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class HostSelectorBenchmarks {
+
+  private static final int READER_COUNT = 5;
+  private static final int POOL_COUNT = 20;
+  private static final String DOMAIN = ".XYZ.us-east-2.rds.amazonaws.com";
+
+  private List<HostSpec> hosts;
+  private Properties emptyProps;
+  private Properties weightedRandomProps;
+  private Properties roundRobinWeightedProps;
+
+  private RandomHostSelector randomSelector;
+  private RoundRobinHostSelector roundRobinSelector;
+  private WeightedRandomHostSelector weightedRandomSelector;
+  private HighestWeightHostSelector highestWeightSelector;
+  private LowestLoadHostSelector lowestLoadSelector;
+  private HighestLoadHostSelector highestLoadSelector;
+  private LeastConnectionsHostSelector leastConnectionsEmptyPools;
+  private LeastConnectionsHostSelector leastConnectionsManyPools;
+
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder()
+        .include(HostSelectorBenchmarks.class.getSimpleName())
+        .addProfiler(GCProfiler.class)
+        .detectJvmArgs()
+        .build();
+
+    new Runner(opt).run();
+  }
+
+  @Setup(Level.Trial)
+  public void setUp() {
+    // One writer plus five readers, each carrying distinct weight/cpu/lag so the load- and
+    // weight-based selectors have something to discriminate on rather than hitting a tie.
+    this.hosts = new ArrayList<>(READER_COUNT + 1);
+    this.hosts.add(host("instance-writer", HostRole.WRITER, 1, 10f, 0f));
+    for (int i = 0; i < READER_COUNT; i++) {
+      this.hosts.add(host("instance-" + i, HostRole.READER, i + 1L, 20f + i * 10, 5f + i * 5));
+    }
+
+    this.emptyProps = new Properties();
+
+    this.weightedRandomProps = new Properties();
+    this.weightedRandomProps.setProperty(
+        WeightedRandomHostSelector.WEIGHTED_RANDOM_HOST_WEIGHT_PAIRS.name,
+        weightPairs());
+
+    this.roundRobinWeightedProps = new Properties();
+    RoundRobinHostSelector.setRoundRobinHostWeightPairsProperty(
+        this.roundRobinWeightedProps, this.hosts);
+
+    this.randomSelector = new RandomHostSelector();
+    this.roundRobinSelector = new RoundRobinHostSelector();
+    this.weightedRandomSelector = new WeightedRandomHostSelector();
+    this.highestWeightSelector = new HighestWeightHostSelector();
+    this.lowestLoadSelector = new LowestLoadHostSelector();
+    this.highestLoadSelector = new HighestLoadHostSelector();
+
+    this.leastConnectionsEmptyPools =
+        new LeastConnectionsHostSelector(new SlidingExpirationCache<>());
+
+    // Pool entries are keyed by host URL; the values are deliberately not HikariDataSource so the
+    // selector walks and skips them. That isolates the per-candidate map copy in getEntries() from
+    // the cost of querying a real Hikari pool's MXBean.
+    final SlidingExpirationCache<Pair, AutoCloseable> pools = new SlidingExpirationCache<>();
+    final long ttl = TimeUnit.MINUTES.toNanos(10);
+    for (int i = 0; i < POOL_COUNT; i++) {
+      pools.put(Pair.create("instance-" + (i % READER_COUNT) + DOMAIN + ":5432", "pool-" + i),
+          () -> { }, ttl);
+    }
+    this.leastConnectionsManyPools = new LeastConnectionsHostSelector(pools);
+
+    RoundRobinHostSelector.clearCache();
+  }
+
+  @TearDown(Level.Trial)
+  public void tearDown() {
+    // The round-robin cache is static and keyed by host name, so leaving entries behind would let
+    // one benchmark class influence another within the same fork.
+    RoundRobinHostSelector.clearCache();
+  }
+
+  private HostSpec host(
+      final String name, final HostRole role, final long weight, final float cpu, final float lag) {
+    return new HostSpecBuilder(new SimpleHostAvailabilityStrategy())
+        .host(name + DOMAIN)
+        .hostId(name)
+        .port(5432)
+        .role(role)
+        .weight(weight)
+        .cpuPercent(cpu)
+        .lagMs(lag)
+        .build();
+  }
+
+  private String weightPairs() {
+    final StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < READER_COUNT; i++) {
+      if (i > 0) {
+        sb.append(',');
+      }
+      sb.append("instance-").append(i).append(DOMAIN).append(':').append(i + 1);
+    }
+    return sb.toString();
+  }
+
+  @Benchmark
+  public HostSpec random() throws SQLException {
+    return this.randomSelector.getHost(this.hosts, HostRole.READER, this.emptyProps);
+  }
+
+  @Benchmark
+  public HostSpec roundRobin() throws SQLException {
+    return this.roundRobinSelector.getHost(this.hosts, HostRole.READER, this.emptyProps);
+  }
+
+  @Benchmark
+  public HostSpec roundRobinWeighted() throws SQLException {
+    return this.roundRobinSelector.getHost(this.hosts, HostRole.READER, this.roundRobinWeightedProps);
+  }
+
+  /**
+   * Round robin serialises on a {@link software.amazon.jdbc.util.ResourceLock} for the whole
+   * selection, including the sort. This is the only way to see that.
+   */
+  @Benchmark
+  @Threads(4)
+  public HostSpec contendedRoundRobin() throws SQLException {
+    return this.roundRobinSelector.getHost(this.hosts, HostRole.READER, this.emptyProps);
+  }
+
+  @Benchmark
+  public HostSpec weightedRandomFromHostSpec() throws SQLException {
+    return this.weightedRandomSelector.getHost(this.hosts, HostRole.READER, this.emptyProps);
+  }
+
+  @Benchmark
+  public HostSpec weightedRandomFromProperty() throws SQLException {
+    return this.weightedRandomSelector.getHost(this.hosts, HostRole.READER, this.weightedRandomProps);
+  }
+
+  @Benchmark
+  public HostSpec highestWeight() throws SQLException {
+    return this.highestWeightSelector.getHost(this.hosts, HostRole.READER, this.emptyProps);
+  }
+
+  @Benchmark
+  public HostSpec lowestLoad() throws SQLException {
+    return this.lowestLoadSelector.getHost(this.hosts, HostRole.READER, this.emptyProps);
+  }
+
+  @Benchmark
+  public HostSpec highestLoad() throws SQLException {
+    return this.highestLoadSelector.getHost(this.hosts, HostRole.READER, this.emptyProps);
+  }
+
+  @Benchmark
+  public HostSpec leastConnectionsNoPools() throws SQLException {
+    return this.leastConnectionsEmptyPools.getHost(this.hosts, HostRole.READER, this.emptyProps);
+  }
+
+  /**
+   * With pools registered, {@code getEntries()} copies the pool map once per candidate host. The gap
+   * against {@link #leastConnectionsNoPools()} is the cost of those copies.
+   */
+  @Benchmark
+  public HostSpec leastConnectionsTwentyPools() throws SQLException {
+    return this.leastConnectionsManyPools.getHost(this.hosts, HostRole.READER, this.emptyProps);
+  }
+
+  /** No role filter, so every host is eligible - the widest candidate list. */
+  @Benchmark
+  public HostSpec randomAnyRole() throws SQLException {
+    return this.randomSelector.getHost(this.hosts, null, this.emptyProps);
+  }
+}

--- a/benchmarks/src/jmh/java/software/amazon/jdbc/benchmarks/PgCacheBenchmarks.java
+++ b/benchmarks/src/jmh/java/software/amazon/jdbc/benchmarks/PgCacheBenchmarks.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package software.amazon.jdbc.benchmarks;
 
 import java.sql.Connection;
@@ -43,6 +59,19 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
  * ----+---------+-------------+----------+---------+----------+----------+---------+--------+-------+--------------
  * (0 rows)
  *
+ * <p>Unlike the other benchmarks in this module, this one needs live infrastructure: a reachable
+ * PostgreSQL instance holding the pre-populated {@code test} table plus a reachable cache server.
+ * The endpoints are therefore not hardcoded - supply them as system properties, for example:
+ *
+ * <pre>
+ * java -Dbenchmarks.pg.url=jdbc:aws-wrapper:postgresql://my-db:5432/postgres \
+ *      -Dbenchmarks.cache.rw=my-cache:6379 \
+ *      -Dbenchmarks.cache.ro=my-cache:6380 \
+ *      -jar build/libs/benchmarks-&lt;version&gt;-jmh.jar PgCacheBenchmarks
+ * </pre>
+ *
+ * <p>With no properties set, setup fails fast with a clear message instead of timing out against a
+ * placeholder host name. This class is excluded from the default benchmark run for that reason.
  */
 @State(Scope.Thread)
 @Fork(1)
@@ -51,9 +80,9 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 public class PgCacheBenchmarks {
-  private static final String DB_CONNECTION_STRING = "jdbc:aws-wrapper:postgresql://db-0.XYZ.us-east-2.rds.amazonaws.com:5432/postgres";
-  private static final String CACHE_RW_SERVER_ADDR = "cache-0.XYZ.us-east-2.rds.amazonaws.com:6379";
-  private static final String CACHE_RO_SERVER_ADDR = "cache-0.XYZ.us-east-2.rds.amazonaws.com:6380";
+  private static final String DB_URL_PROPERTY = "benchmarks.pg.url";
+  private static final String CACHE_RW_PROPERTY = "benchmarks.cache.rw";
+  private static final String CACHE_RO_PROPERTY = "benchmarks.cache.ro";
 
   private Connection connection;
   private int counter;
@@ -71,6 +100,9 @@ public class PgCacheBenchmarks {
 
   @Setup(Level.Trial)
   public void setup() throws SQLException {
+    final String dbUrl = requiredProperty(DB_URL_PROPERTY);
+    final String cacheRw = requiredProperty(CACHE_RW_PROPERTY);
+    final String cacheRo = requiredProperty(CACHE_RO_PROPERTY);
     try {
       software.amazon.jdbc.Driver.register();
     } catch (IllegalStateException e) {
@@ -78,17 +110,31 @@ public class PgCacheBenchmarks {
     }
     Properties properties = new Properties();
     properties.setProperty("wrapperPlugins", "remoteQueryCache");
-    properties.setProperty("cacheEndpointAddrRw", CACHE_RW_SERVER_ADDR);
-    properties.setProperty("cacheEndpointAddrRo", CACHE_RO_SERVER_ADDR);
+    properties.setProperty("cacheEndpointAddrRw", cacheRw);
+    properties.setProperty("cacheEndpointAddrRo", cacheRo);
     properties.setProperty("wrapperLogUnclosedConnections", "true");
     counter = 0;
-    connection = DriverManager.getConnection(DB_CONNECTION_STRING, properties);
+    connection = DriverManager.getConnection(dbUrl, properties);
     startTime = System.currentTimeMillis();
+  }
+
+  private static String requiredProperty(final String name) {
+    final String value = System.getProperty(name);
+    if (value == null || value.trim().isEmpty()) {
+      throw new IllegalStateException(
+          "PgCacheBenchmarks requires a live database and cache server. Set the system property '"
+              + name + "'. See the class javadoc and benchmarks/README.md for details.");
+    }
+    return value;
   }
 
   @TearDown(Level.Trial)
   public void tearDown() throws SQLException {
-    connection.close();
+    // setup() can fail before the connection is opened (e.g. missing endpoint properties); a plain
+    // connection.close() would then mask the real cause with an NPE from the teardown.
+    if (connection != null) {
+      connection.close();
+    }
   }
 
   // Code to warm up the data in the table

--- a/benchmarks/src/jmh/java/software/amazon/jdbc/benchmarks/PluginBenchmarks.java
+++ b/benchmarks/src/jmh/java/software/amazon/jdbc/benchmarks/PluginBenchmarks.java
@@ -20,6 +20,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 
 import com.zaxxer.hikari.HikariConfig;
@@ -29,6 +30,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -58,12 +60,15 @@ import software.amazon.jdbc.hostlistprovider.HostListProviderService;
 import software.amazon.jdbc.HostSpec;
 import software.amazon.jdbc.HostSpecBuilder;
 import software.amazon.jdbc.JdbcMethod;
+import software.amazon.jdbc.PluginCallContext;
 import software.amazon.jdbc.PluginManagerService;
 import software.amazon.jdbc.PluginService;
 import software.amazon.jdbc.benchmarks.testplugin.TestConnectionWrapper;
 import software.amazon.jdbc.dialect.Dialect;
 import software.amazon.jdbc.hostavailability.SimpleHostAvailabilityStrategy;
+import software.amazon.jdbc.states.SessionStateService;
 import software.amazon.jdbc.targetdriverdialect.TargetDriverDialect;
+import software.amazon.jdbc.util.FullServicesContainer;
 import software.amazon.jdbc.util.telemetry.GaugeCallable;
 import software.amazon.jdbc.util.telemetry.TelemetryContext;
 import software.amazon.jdbc.util.telemetry.TelemetryCounter;
@@ -92,8 +97,10 @@ public class PluginBenchmarks {
   private final HostSpec writerHostSpec = new HostSpecBuilder(new SimpleHostAvailabilityStrategy())
       .host(TEST_HOST).port(TEST_PORT).build();
 
+  @Mock private FullServicesContainer mockServicesContainer;
   @Mock private PluginService mockPluginService;
   @Mock private Dialect mockDialect;
+  @Mock private TargetDriverDialect mockTargetDriverDialect;
   @Mock private ConnectionPluginManager mockConnectionPluginManager;
   @Mock private TelemetryFactory mockTelemetryFactory;
   @Mock TelemetryContext mockTelemetryContext;
@@ -102,9 +109,12 @@ public class PluginBenchmarks {
   @Mock private HostListProviderService mockHostListProviderService;
   @Mock private PluginManagerService mockPluginManagerService;
   @Mock ConnectionProvider mockConnectionProvider;
+  @Mock PluginCallContext mockPluginCallContext;
+  @Mock SessionStateService mockSessionStateService;
   @Mock Connection mockConnection;
   @Mock Statement mockStatement;
   @Mock ResultSet mockResultSet;
+  private final AtomicReference<Connection> currentConnection = new AtomicReference<>();
   private AutoCloseable closeable;
 
   public static void main(String[] args) throws RunnerException {
@@ -120,11 +130,18 @@ public class PluginBenchmarks {
   @Setup(Level.Iteration)
   public void setUpIteration() throws Exception {
     closeable = MockitoAnnotations.openMocks(this);
+    when(mockServicesContainer.getConnectionPluginManager()).thenReturn(mockConnectionPluginManager);
+    when(mockServicesContainer.getPluginService()).thenReturn(mockPluginService);
+    when(mockServicesContainer.getHostListProviderService()).thenReturn(mockHostListProviderService);
+    when(mockServicesContainer.getPluginManagerService()).thenReturn(mockPluginManagerService);
     when(mockConnectionPluginManager.connect(any(), any(), any(Properties.class), anyBoolean(), any()))
         .thenReturn(mockConnection);
     when(mockConnectionPluginManager.execute(
         any(), any(), any(), eq(JdbcMethod.CONNECTION_CREATESTATEMENT), any(), any()))
         .thenReturn(mockStatement);
+    when(mockConnectionPluginManager.execute(
+        any(), any(), any(), eq(JdbcMethod.STATEMENT_EXECUTEQUERY), any(), any()))
+        .thenReturn(mockResultSet);
     when(mockConnectionPluginManager.getTelemetryFactory()).thenReturn(mockTelemetryFactory);
     when(mockTelemetryFactory.openTelemetryContext(anyString(), any())).thenReturn(mockTelemetryContext);
     when(mockTelemetryFactory.openTelemetryContext(eq(null), any())).thenReturn(mockTelemetryContext);
@@ -145,9 +162,27 @@ public class PluginBenchmarks {
         .thenReturn("instance-0", "instance-1");
     when(mockResultSet.getStatement()).thenReturn(mockStatement);
     when(mockStatement.getConnection()).thenReturn(mockConnection);
+    // Model the current connection as real state instead of a fixed value: ConnectionWrapper.init()
+    // only opens a connection when getCurrentConnection() is null, and everything afterwards
+    // (createStatement, close, ...) dereferences it. A constant null breaks close(); a constant
+    // non-null makes init() a no-op and stops the benchmark from measuring the connect pipeline.
+    this.currentConnection.set(null);
+    when(this.mockPluginService.getCurrentConnection()).thenAnswer(inv -> this.currentConnection.get());
+    doAnswer(inv -> {
+      this.currentConnection.set(inv.getArgument(0));
+      return null;
+    }).when(this.mockPluginService).setCurrentConnection(any(Connection.class), any());
+    when(this.mockPluginService.getSessionStateService()).thenReturn(mockSessionStateService);
+    // Statement.executeQuery() publishes a rebind handle on the per-call context.
+    when(this.mockPluginService.getCallContext()).thenReturn(mockPluginCallContext);
     when(this.mockPluginService.acceptsStrategy(any(), eq("random"))).thenReturn(true);
     when(this.mockPluginService.getCurrentHostSpec()).thenReturn(writerHostSpec);
+    when(this.mockPluginService.getInitialConnectionHostSpec()).thenReturn(writerHostSpec);
     when(this.mockPluginService.getDialect()).thenReturn(mockDialect);
+    // ConnectionWrapper.init() calls getTargetDriverDialect().updateInternalState(...) on the
+    // freshly opened connection. Without this stub every benchmark that builds a
+    // ConnectionWrapper fails in its warmup iteration with an NPE.
+    when(this.mockPluginService.getTargetDriverDialect()).thenReturn(mockTargetDriverDialect);
   }
 
   @TearDown(Level.Iteration)
@@ -168,14 +203,7 @@ public class PluginBenchmarks {
   }
 
   private ConnectionWrapper getConnectionWrapper(Properties props, String connString) throws SQLException {
-    return new TestConnectionWrapper(
-        props,
-        connString,
-        PG_PROTOCOL,
-        mockConnectionPluginManager,
-        mockPluginService,
-        mockHostListProviderService,
-        mockPluginManagerService);
+    return new TestConnectionWrapper(mockServicesContainer, props, connString, PG_PROTOCOL);
   }
 
   @Benchmark

--- a/benchmarks/src/jmh/java/software/amazon/jdbc/benchmarks/PluginServiceBenchmarks.java
+++ b/benchmarks/src/jmh/java/software/amazon/jdbc/benchmarks/PluginServiceBenchmarks.java
@@ -1,0 +1,343 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.jdbc.benchmarks;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import software.amazon.jdbc.AllowedAndBlockedHosts;
+import software.amazon.jdbc.ConnectionPluginManager;
+import software.amazon.jdbc.HostRole;
+import software.amazon.jdbc.HostSpec;
+import software.amazon.jdbc.HostSpecBuilder;
+import software.amazon.jdbc.PluginCallContext;
+import software.amazon.jdbc.PluginService;
+import software.amazon.jdbc.PluginServiceImpl;
+import software.amazon.jdbc.PropertyDefinition;
+import software.amazon.jdbc.benchmarks.support.BenchmarkServices;
+import software.amazon.jdbc.benchmarks.support.FakeConnectionProvider;
+import software.amazon.jdbc.benchmarks.support.FakeJdbc;
+import software.amazon.jdbc.benchmarks.support.FixedDialectProvider;
+import software.amazon.jdbc.benchmarks.support.StaticTopologyProvider;
+import software.amazon.jdbc.dialect.UnknownDialect;
+import software.amazon.jdbc.exceptions.ExceptionManager;
+import software.amazon.jdbc.hostavailability.HostAvailability;
+import software.amazon.jdbc.hostavailability.SimpleHostAvailabilityStrategy;
+import software.amazon.jdbc.states.SessionStateService;
+import software.amazon.jdbc.states.SessionStateServiceImpl;
+import software.amazon.jdbc.targetdriverdialect.GenericTargetDriverDialect;
+import software.amazon.jdbc.util.FullServicesContainer;
+import software.amazon.jdbc.util.storage.StorageService;
+import software.amazon.jdbc.util.telemetry.DefaultTelemetryFactory;
+import software.amazon.jdbc.util.telemetry.TelemetryFactory;
+
+/**
+ * Benchmarks for the real {@link PluginServiceImpl} and {@link SessionStateServiceImpl}.
+ *
+ * <p>{@code PluginServiceImpl} is the busiest object in the driver - every plugin and every wrapper
+ * call reaches it - and it was mocked out of every previous benchmark, so its own cost was invisible.
+ * The real class is constructed here; only dialect detection is bypassed, via a fixed
+ * {@link FixedDialectProvider}, because detection requires a live database and happens once at
+ * connect rather than on any measured path.
+ *
+ * <p>The methods measured are the ones called repeatedly:
+ *
+ * <ul>
+ *   <li>{@code getCurrentConnection} and {@code getAllHosts} are field reads, included as the floor.
+ *   <li>{@code getHosts} is not. It looks up {@link AllowedAndBlockedHosts} in the storage service on
+ *       every call and, when a permission entry exists, filters the topology through two stream
+ *       pipelines. It runs on every host selection, so it is measured both without permissions (the
+ *       common case) and with an allow-list (the custom-endpoint and blue/green case).
+ *   <li>{@code setAvailability} streams the whole topology and may notify plugins; it runs whenever a
+ *       connection succeeds or fails.
+ *   <li>{@code resetCallContext} runs once per JDBC call.
+ * </ul>
+ *
+ * <p>{@link SessionStateServiceImpl} is measured separately: {@code begin}/{@code complete}/
+ * {@code reset} run on every connection close, and {@code applyPristineSessionState} runs on close
+ * and on every failover, reading and restoring up to eight session attributes.
+ */
+@State(Scope.Benchmark)
+@Fork(1)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class PluginServiceBenchmarks {
+
+  private static final String URL = "jdbc:aws-wrapper:postgresql://instance-0.XYZ.us-east-2.rds.amazonaws.com";
+  private static final String PROTOCOL = "jdbc:postgresql://";
+  private static final String DOMAIN = ".XYZ.us-east-2.rds.amazonaws.com";
+  private static final int HOST_COUNT = 5;
+
+  private PluginServiceImpl pluginService;
+  private PluginServiceImpl pluginServiceWithHostPermissions;
+  private SessionStateService sessionStateService;
+  private Connection targetConnection;
+  private HostSpec readerHostSpec;
+
+  private final List<ConnectionPluginManager> pluginManagers = new ArrayList<>();
+  private final List<StorageService> storageServices = new ArrayList<>();
+
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder()
+        .include(PluginServiceBenchmarks.class.getSimpleName())
+        .addProfiler(GCProfiler.class)
+        .detectJvmArgs()
+        .build();
+
+    new Runner(opt).run();
+  }
+
+  @Setup(Level.Trial)
+  public void setUp() throws SQLException {
+    final Properties props = new Properties();
+    props.setProperty(PropertyDefinition.PLUGINS.name, "");
+    props.setProperty(PropertyDefinition.ENABLE_TELEMETRY.name, "false");
+
+    this.targetConnection = FakeJdbc.connection(true, 1);
+
+    final List<HostSpec> hosts = topology();
+    this.readerHostSpec = hosts.get(1);
+
+    this.pluginService = newPluginService(props, hosts, null);
+
+    // An allow-list entry forces getHosts() down its filtering path, which is what the custom
+    // endpoint and blue/green plugins produce.
+    this.pluginServiceWithHostPermissions = newPluginService(
+        props,
+        hosts,
+        new AllowedAndBlockedHosts(
+            new HashSet<>(Arrays.asList("instance-1", "instance-2", "instance-3")), null, null));
+
+    this.sessionStateService = new SessionStateServiceImpl(this.pluginService, props);
+  }
+
+  private List<HostSpec> topology() {
+    final List<HostSpec> hosts = new ArrayList<>(HOST_COUNT);
+    hosts.add(new HostSpecBuilder(new SimpleHostAvailabilityStrategy())
+        .host("instance-0" + DOMAIN).hostId("instance-0").port(5432).role(HostRole.WRITER).build());
+    for (int i = 1; i < HOST_COUNT; i++) {
+      hosts.add(new HostSpecBuilder(new SimpleHostAvailabilityStrategy())
+          .host("instance-" + i + DOMAIN).hostId("instance-" + i).port(5432).role(HostRole.READER).build());
+    }
+    return hosts;
+  }
+
+  private PluginServiceImpl newPluginService(
+      final Properties props,
+      final List<HostSpec> hosts,
+      final AllowedAndBlockedHosts hostPermissions) throws SQLException {
+
+    final TelemetryFactory telemetryFactory = new DefaultTelemetryFactory(props);
+    final BenchmarkServices.State state =
+        BenchmarkServices.state(this.targetConnection, telemetryFactory);
+
+    final StorageService storageService = BenchmarkServices.storageService();
+    this.storageServices.add(storageService);
+
+    final ConnectionPluginManager pluginManager = new ConnectionPluginManager(
+        props, telemetryFactory, new FakeConnectionProvider(this.targetConnection), null);
+    this.pluginManagers.add(pluginManager);
+
+    final FullServicesContainer container = BenchmarkServices.servicesContainer(
+        state,
+        BenchmarkServices.pluginService(state),
+        BenchmarkServices.pluginManagerService(state),
+        pluginManager,
+        storageService);
+    pluginManager.initPlugins(container, null);
+
+    final PluginServiceImpl service = new PluginServiceImpl(
+        container,
+        new ExceptionManager(),
+        props,
+        URL,
+        PROTOCOL,
+        new FixedDialectProvider(new UnknownDialect()),
+        new GenericTargetDriverDialect(),
+        null,
+        null);
+
+    service.setInitialConnectionHostSpec(hosts.get(0));
+    // Populate the host list through the real refresh path rather than reaching into the field, so
+    // setNodeList runs and the service ends up in the state production would leave it in.
+    service.setHostListProvider(new StaticTopologyProvider(hosts));
+    service.refreshHostList();
+    service.setCurrentConnection(this.targetConnection, hosts.get(0));
+
+    if (hostPermissions != null) {
+      storageService.set(hosts.get(0).getUrl(), hostPermissions);
+    }
+
+    return service;
+  }
+
+  @TearDown(Level.Trial)
+  public void tearDown() {
+    for (final ConnectionPluginManager pluginManager : this.pluginManagers) {
+      pluginManager.releaseResources();
+    }
+    for (final StorageService storageService : this.storageServices) {
+      BenchmarkServices.releaseStorage(storageService);
+    }
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // PluginServiceImpl
+  // ---------------------------------------------------------------------------------------------
+
+  /** Field read; the floor for everything else here. */
+  @Benchmark
+  public Connection getCurrentConnection() {
+    return this.pluginService.getCurrentConnection();
+  }
+
+  @Benchmark
+  public HostSpec getCurrentHostSpec() {
+    return this.pluginService.getCurrentHostSpec();
+  }
+
+  @Benchmark
+  public List<HostSpec> getAllHosts() {
+    return this.pluginService.getAllHosts();
+  }
+
+  /** Storage lookup on every call, but no filtering because no permissions are registered. */
+  @Benchmark
+  public List<HostSpec> getHostsNoPermissions() {
+    return this.pluginService.getHosts();
+  }
+
+  /** Storage lookup plus two stream pipelines over the topology. */
+  @Benchmark
+  public List<HostSpec> getHostsWithAllowList() {
+    return this.pluginServiceWithHostPermissions.getHosts();
+  }
+
+  @Benchmark
+  public boolean isInTransaction() {
+    return this.pluginService.isInTransaction();
+  }
+
+  @Benchmark
+  public PluginCallContext getCallContext() {
+    return this.pluginService.getCallContext();
+  }
+
+  /** Once per JDBC call. */
+  @Benchmark
+  public PluginService resetCallContext() {
+    this.pluginService.resetCallContext();
+    return this.pluginService;
+  }
+
+  /**
+   * Streams the topology looking for matching hosts and writes the availability cache. Called
+   * whenever a connection attempt succeeds or fails, so it is on the connect path rather than the
+   * query path. Availability is set to the value the host already has, so this measures the lookup
+   * without triggering the plugin notification branch.
+   */
+  @Benchmark
+  public PluginService setAvailability() {
+    this.pluginService.setAvailability(this.readerHostSpec, HostAvailability.AVAILABLE);
+    return this.pluginService;
+  }
+
+  @Benchmark
+  public boolean isNetworkExceptionBySqlState() {
+    return this.pluginService.isNetworkException("08006");
+  }
+
+  @Benchmark
+  public boolean isNetworkExceptionNotMatching() {
+    return this.pluginService.isNetworkException("00000");
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // SessionStateServiceImpl
+  // ---------------------------------------------------------------------------------------------
+
+  /** The pair run on every connection close. */
+  @Benchmark
+  public SessionStateService beginAndComplete() throws SQLException {
+    this.sessionStateService.begin();
+    this.sessionStateService.complete();
+    return this.sessionStateService;
+  }
+
+  @Benchmark
+  public SessionStateService reset() {
+    this.sessionStateService.reset();
+    return this.sessionStateService;
+  }
+
+  /**
+   * Runs on every close and on every failover. With no pristine values recorded this is the
+   * short-circuit path; the {@code Pristine} variant records them first so the restore actually runs.
+   */
+  @Benchmark
+  public SessionStateService applyPristineSessionState() throws SQLException {
+    this.sessionStateService.begin();
+    try {
+      this.sessionStateService.applyPristineSessionState(this.targetConnection);
+    } finally {
+      this.sessionStateService.complete();
+      this.sessionStateService.reset();
+    }
+    return this.sessionStateService;
+  }
+
+  @Benchmark
+  public SessionStateService applyPristineSessionStateWithRecordedState() throws SQLException {
+    this.sessionStateService.setupPristineAutoCommit(true);
+    this.sessionStateService.setupPristineReadOnly(false);
+    this.sessionStateService.setupPristineCatalog("benchmark");
+    this.sessionStateService.setupPristineSchema("public");
+    this.sessionStateService.setupPristineTransactionIsolation(Connection.TRANSACTION_READ_COMMITTED);
+    this.sessionStateService.begin();
+    try {
+      this.sessionStateService.applyPristineSessionState(this.targetConnection);
+    } finally {
+      this.sessionStateService.complete();
+      this.sessionStateService.reset();
+    }
+    return this.sessionStateService;
+  }
+}

--- a/benchmarks/src/jmh/java/software/amazon/jdbc/benchmarks/RdsUtilsBenchmarks.java
+++ b/benchmarks/src/jmh/java/software/amazon/jdbc/benchmarks/RdsUtilsBenchmarks.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.jdbc.benchmarks;
+
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import software.amazon.jdbc.util.RdsUrlType;
+import software.amazon.jdbc.util.RdsUtils;
+
+/**
+ * Micro-benchmarks for {@link RdsUtils}, the regex-driven endpoint classifier.
+ *
+ * <p>It runs on connect, on every host-list refresh, and inside {@code ConnectionUrlParser}, so its
+ * cost is paid per connection rather than per query - but host-list refreshes are frequent enough
+ * under failover and read/write splitting that it is worth knowing the number. It was not measured
+ * before.
+ *
+ * <p>{@code RdsUtils} keeps a static cache of {@link java.util.regex.Matcher} results keyed by host.
+ * That makes the cached and uncached costs differ by orders of magnitude, and it means a naive
+ * benchmark measures only the cache. Both are measured here:
+ *
+ * <ul>
+ *   <li>{@code cachedHit*} - repeat lookups of one host, the steady state.
+ *   <li>{@code uncached*} - a fresh host name per invocation, the cost actually paid the first time
+ *       an endpoint is seen. The counter is part of the host name, so these also show how the cache
+ *       behaves when it is being filled rather than read.
+ * </ul>
+ *
+ * <p>{@code contendedCachedHit} runs the cached path on several threads to check that the shared
+ * static cache does not serialise callers, which a single-threaded benchmark cannot show.
+ */
+@State(Scope.Benchmark)
+@Fork(1)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class RdsUtilsBenchmarks {
+
+  private static final String INSTANCE =
+      "instance-1.XYZ.us-east-2.rds.amazonaws.com";
+  private static final String WRITER_CLUSTER =
+      "my-cluster.cluster-XYZ.us-east-2.rds.amazonaws.com";
+  private static final String READER_CLUSTER =
+      "my-cluster.cluster-ro-XYZ.us-east-2.rds.amazonaws.com";
+  private static final String CUSTOM_CLUSTER =
+      "my-custom.cluster-custom-XYZ.us-east-2.rds.amazonaws.com";
+  private static final String PROXY =
+      "my-proxy.proxy-XYZ.us-east-2.rds.amazonaws.com";
+  private static final String NON_RDS = "my-database.example.com";
+
+  private final RdsUtils rdsUtils = new RdsUtils();
+
+  /**
+   * Distinguishes host names produced by this benchmark run so a previous run's cache entries (the
+   * cache is static and lives for the whole JVM) cannot be mistaken for cache misses.
+   */
+  private long counter;
+
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder()
+        .include(RdsUtilsBenchmarks.class.getSimpleName())
+        .addProfiler(GCProfiler.class)
+        .detectJvmArgs()
+        .build();
+
+    new Runner(opt).run();
+  }
+
+  @Setup(Level.Trial)
+  public void setUp() {
+    RdsUtils.clearCache();
+    this.counter = 0;
+    // Prime the cache for the fixed host names so the cachedHit benchmarks never include a miss.
+    this.rdsUtils.identifyRdsType(INSTANCE);
+    this.rdsUtils.identifyRdsType(WRITER_CLUSTER);
+    this.rdsUtils.identifyRdsType(READER_CLUSTER);
+    this.rdsUtils.identifyRdsType(CUSTOM_CLUSTER);
+    this.rdsUtils.identifyRdsType(PROXY);
+    this.rdsUtils.identifyRdsType(NON_RDS);
+  }
+
+  @Benchmark
+  public RdsUrlType cachedHitIdentifyInstance() {
+    return rdsUtils.identifyRdsType(INSTANCE);
+  }
+
+  @Benchmark
+  public RdsUrlType cachedHitIdentifyWriterCluster() {
+    return rdsUtils.identifyRdsType(WRITER_CLUSTER);
+  }
+
+  @Benchmark
+  public RdsUrlType cachedHitIdentifyReaderCluster() {
+    return rdsUtils.identifyRdsType(READER_CLUSTER);
+  }
+
+  @Benchmark
+  public RdsUrlType cachedHitIdentifyCustomCluster() {
+    return rdsUtils.identifyRdsType(CUSTOM_CLUSTER);
+  }
+
+  @Benchmark
+  public RdsUrlType cachedHitIdentifyProxy() {
+    return rdsUtils.identifyRdsType(PROXY);
+  }
+
+  /**
+   * A non-RDS host matches none of the patterns, so it is the worst case for the classifier: every
+   * pattern is tried before it gives up.
+   */
+  @Benchmark
+  public RdsUrlType cachedHitIdentifyNonRds() {
+    return rdsUtils.identifyRdsType(NON_RDS);
+  }
+
+  @Benchmark
+  @Threads(4)
+  public RdsUrlType contendedCachedHitIdentifyInstance() {
+    return rdsUtils.identifyRdsType(INSTANCE);
+  }
+
+  @Benchmark
+  public RdsUrlType uncachedIdentifyInstance() {
+    return rdsUtils.identifyRdsType("instance-" + (counter++) + ".XYZ.us-east-2.rds.amazonaws.com");
+  }
+
+  @Benchmark
+  public RdsUrlType uncachedIdentifyNonRds() {
+    return rdsUtils.identifyRdsType("host-" + (counter++) + ".example.com");
+  }
+
+  @Benchmark
+  public String cachedHitGetRdsInstanceId() {
+    return rdsUtils.getRdsInstanceId(INSTANCE);
+  }
+
+  @Benchmark
+  public String cachedHitGetRdsClusterId() {
+    return rdsUtils.getRdsClusterId(WRITER_CLUSTER);
+  }
+
+  @Benchmark
+  public String cachedHitGetRdsRegion() {
+    return rdsUtils.getRdsRegion(INSTANCE);
+  }
+
+  @Benchmark
+  public String cachedHitGetRdsInstanceHostPattern() {
+    return rdsUtils.getRdsInstanceHostPattern(INSTANCE);
+  }
+
+  @Benchmark
+  public boolean cachedHitIsWriterClusterDns() {
+    return rdsUtils.isWriterClusterDns(WRITER_CLUSTER);
+  }
+
+  @Benchmark
+  public boolean cachedHitIsReaderClusterDns() {
+    return rdsUtils.isReaderClusterDns(READER_CLUSTER);
+  }
+
+  @Benchmark
+  public boolean isIPv4Address() {
+    return rdsUtils.isIPv4("10.20.30.40");
+  }
+
+  @Benchmark
+  public boolean isIPv4OnHostName() {
+    return rdsUtils.isIPv4(INSTANCE);
+  }
+
+  @Benchmark
+  public String removePort() {
+    return rdsUtils.removePort(INSTANCE + ":5432");
+  }
+
+  /**
+   * Blue/green routing calls this on every host it evaluates, and unlike the classifier results it
+   * is not backed by the matcher cache.
+   */
+  @Benchmark
+  public boolean isGreenInstance() {
+    return rdsUtils.isGreenInstance(INSTANCE);
+  }
+}

--- a/benchmarks/src/jmh/java/software/amazon/jdbc/benchmarks/RealPluginChainBenchmarks.java
+++ b/benchmarks/src/jmh/java/software/amazon/jdbc/benchmarks/RealPluginChainBenchmarks.java
@@ -1,0 +1,279 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.jdbc.benchmarks;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import software.amazon.jdbc.ConnectionPluginManager;
+import software.amazon.jdbc.JdbcMethod;
+import software.amazon.jdbc.PropertyDefinition;
+import software.amazon.jdbc.benchmarks.support.BenchmarkServices;
+import software.amazon.jdbc.benchmarks.support.FakeConnectionProvider;
+import software.amazon.jdbc.benchmarks.support.FakeJdbc;
+import software.amazon.jdbc.util.storage.StorageService;
+import software.amazon.jdbc.util.telemetry.DefaultTelemetryFactory;
+import software.amazon.jdbc.util.telemetry.TelemetryFactory;
+
+/**
+ * Per-call cost of the driver's real plugins.
+ *
+ * <p>Previously no benchmark instantiated a real plugin. {@code ConnectionPluginManagerBenchmarks}
+ * builds chains of a no-op {@code BenchmarkPlugin}, and {@code PluginBenchmarks} passes
+ * {@code wrapperPlugins} values to a mocked plugin manager, where they have no effect. So the
+ * question "what does enabling failover2 cost per query" had no answer.
+ *
+ * <p>Each benchmark runs {@code ConnectionPluginManager.execute} for {@code Statement.executeQuery}
+ * through a chain containing exactly one real plugin, against a {@code noPlugins} baseline that
+ * contains only the terminal {@code DefaultConnectionPlugin}. The difference is that plugin's
+ * per-call cost. {@code allObservability} combines the plugins commonly enabled together, to show
+ * whether their costs simply add up.
+ *
+ * <p>What this does and does not measure:
+ *
+ * <ul>
+ *   <li>It measures the steady-state {@code execute} path - the cost a plugin adds to every query
+ *       while nothing is going wrong. That is the cost customers pay continuously.
+ *   <li>It does not measure failover, monitor probes, topology refreshes or token fetches. Those are
+ *       triggered by network events and background threads, not by {@code execute}, and cannot be
+ *       driven from a benchmark without real infrastructure.
+ *   <li>Plugins that only act on {@code connect} (iam, awsSecretsManager, federatedAuth, okta) are
+ *       excluded: they would show a flat zero here and their real cost is a network call.
+ * </ul>
+ *
+ * <h2>Reading the results: there are two regimes, not a gradient</h2>
+ *
+ * <p>{@code ConnectionPluginManager.makePluginChainFunc} computes {@code isSubscribed} while
+ * explicitly excluding {@code DefaultConnectionPlugin}. So when no plugin subscribes to the method
+ * being called, {@code executeWithSubscribedPlugins} bypasses the entire pipeline - including the
+ * default plugin and its SQL analysis - and invokes the JDBC callable directly.
+ *
+ * <p>The consequence is that benchmarks here fall into two groups:
+ *
+ * <ul>
+ *   <li>Plugins that do not subscribe to {@code Statement.executeQuery} score the same as
+ *       {@code noPlugins}, because the pipeline never runs. That is a real result confirming the
+ *       subscription filter works, not a broken benchmark.
+ *   <li>The moment any plugin subscribes, the full pipeline runs and the default plugin's per-call
+ *       SQL analysis is paid. So the interesting quantity is the step from {@code noPlugins} to the
+ *       first subscribing plugin, which is mostly not the plugin's own work - compare it against
+ *       {@code SqlMethodAnalyzerBenchmarks}. Adding further plugins on top costs comparatively
+ *       little, which is what {@code typicalAurora} and {@code allObservability} show.
+ * </ul>
+ */
+@State(Scope.Benchmark)
+@Fork(1)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class RealPluginChainBenchmarks {
+
+  private static final String SQL = "SELECT id, name FROM users WHERE id = 42";
+
+  /**
+   * Plugin codes measured here, in the order they are reported. Each entry becomes one benchmark via
+   * the corresponding method below; the map keeps the code and the chain together so adding a plugin
+   * means touching one line plus one method.
+   */
+  private static final Map<String, String> CHAINS = new LinkedHashMap<>();
+
+  static {
+    CHAINS.put("noPlugins", "");
+    CHAINS.put("executionTime", "executionTime");
+    CHAINS.put("connectTime", "connectTime");
+    CHAINS.put("logQuery", "logQuery");
+    CHAINS.put("driverMetaData", "driverMetaData");
+    CHAINS.put("dataCache", "dataCache");
+    CHAINS.put("sqlParser", "sqlParser");
+    CHAINS.put("auroraConnectionTracker", "auroraConnectionTracker");
+    CHAINS.put("auroraStaleDns", "auroraStaleDns");
+    CHAINS.put("efm2", "efm2");
+    CHAINS.put("failover2", "failover2");
+    CHAINS.put("dev", "dev");
+    CHAINS.put("allObservability", "executionTime,connectTime,logQuery,driverMetaData");
+    CHAINS.put("typicalAurora", "auroraConnectionTracker,failover2,efm2");
+  }
+
+  private final Map<String, ConnectionPluginManager> managers = new LinkedHashMap<>();
+  private final List<StorageService> storageServices = new ArrayList<>();
+
+  private Statement targetStatement;
+
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder()
+        .include(RealPluginChainBenchmarks.class.getSimpleName())
+        .addProfiler(GCProfiler.class)
+        .detectJvmArgs()
+        .build();
+
+    new Runner(opt).run();
+  }
+
+  @Setup(Level.Trial)
+  public void setUp() throws SQLException {
+    final Connection target = FakeJdbc.connection(true, 1);
+    this.targetStatement = target.createStatement();
+
+    for (final Map.Entry<String, String> entry : CHAINS.entrySet()) {
+      this.managers.put(entry.getKey(), buildManager(entry.getValue()));
+    }
+  }
+
+  private ConnectionPluginManager buildManager(final String pluginCodes) throws SQLException {
+    final Properties props = new Properties();
+    props.setProperty(PropertyDefinition.PLUGINS.name, pluginCodes);
+    props.setProperty(PropertyDefinition.ENABLE_TELEMETRY.name, "false");
+    // Plugin order is fixed by the chain under test, so leave it alone rather than letting the
+    // builder re-sort it - a reordered chain would not be the chain the benchmark name claims.
+    props.setProperty(PropertyDefinition.AUTO_SORT_PLUGIN_ORDER.name, "false");
+
+    final TelemetryFactory telemetryFactory = new DefaultTelemetryFactory(props);
+    final BenchmarkServices.State state =
+        BenchmarkServices.state(FakeJdbc.connection(true, 1), telemetryFactory);
+    state.props = props;
+
+    final StorageService storageService = BenchmarkServices.storageService();
+    this.storageServices.add(storageService);
+
+    final ConnectionPluginManager manager = new ConnectionPluginManager(
+        props, telemetryFactory, new FakeConnectionProvider(state.currentConnection), null);
+    manager.initPlugins(
+        BenchmarkServices.servicesContainer(
+            state,
+            BenchmarkServices.pluginService(state),
+            BenchmarkServices.pluginManagerService(state),
+            manager,
+            storageService),
+        null);
+    return manager;
+  }
+
+  @TearDown(Level.Trial)
+  public void tearDown() {
+    for (final ConnectionPluginManager manager : this.managers.values()) {
+      manager.releaseResources();
+    }
+    for (final StorageService storageService : this.storageServices) {
+      BenchmarkServices.releaseStorage(storageService);
+    }
+  }
+
+  private Integer executeThrough(final String chain) {
+    return this.managers.get(chain).execute(
+        Integer.class,
+        RuntimeException.class,
+        this.targetStatement,
+        JdbcMethod.STATEMENT_EXECUTEQUERY,
+        () -> 1,
+        new Object[] {SQL});
+  }
+
+  @Benchmark
+  public Integer noPlugins() {
+    return executeThrough("noPlugins");
+  }
+
+  @Benchmark
+  public Integer executionTime() {
+    return executeThrough("executionTime");
+  }
+
+  @Benchmark
+  public Integer connectTime() {
+    return executeThrough("connectTime");
+  }
+
+  @Benchmark
+  public Integer logQuery() {
+    return executeThrough("logQuery");
+  }
+
+  @Benchmark
+  public Integer driverMetaData() {
+    return executeThrough("driverMetaData");
+  }
+
+  @Benchmark
+  public Integer dataCache() {
+    return executeThrough("dataCache");
+  }
+
+  @Benchmark
+  public Integer sqlParser() {
+    return executeThrough("sqlParser");
+  }
+
+  @Benchmark
+  public Integer auroraConnectionTracker() {
+    return executeThrough("auroraConnectionTracker");
+  }
+
+  @Benchmark
+  public Integer auroraStaleDns() {
+    return executeThrough("auroraStaleDns");
+  }
+
+  @Benchmark
+  public Integer efm2() {
+    return executeThrough("efm2");
+  }
+
+  @Benchmark
+  public Integer failover2() {
+    return executeThrough("failover2");
+  }
+
+  @Benchmark
+  public Integer dev() {
+    return executeThrough("dev");
+  }
+
+  @Benchmark
+  public Integer allObservability() {
+    return executeThrough("allObservability");
+  }
+
+  /** The plugin set a typical Aurora deployment enables, measured as one chain. */
+  @Benchmark
+  public Integer typicalAurora() {
+    return executeThrough("typicalAurora");
+  }
+}

--- a/benchmarks/src/jmh/java/software/amazon/jdbc/benchmarks/SqlMethodAnalyzerBenchmarks.java
+++ b/benchmarks/src/jmh/java/software/amazon/jdbc/benchmarks/SqlMethodAnalyzerBenchmarks.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.jdbc.benchmarks;
+
+import java.sql.Connection;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import software.amazon.jdbc.JdbcMethod;
+import software.amazon.jdbc.benchmarks.support.FakeJdbc;
+import software.amazon.jdbc.util.SqlMethodAnalyzer;
+
+/**
+ * Micro-benchmarks for {@link SqlMethodAnalyzer}.
+ *
+ * <p>This class sits on the hottest path in the driver: {@code DefaultConnectionPlugin.execute}
+ * consults it two to four times for every single JDBC call that carries SQL, and the SQL-inspecting
+ * paths are not cheap - each one strips comments character by character, collapses whitespace with a
+ * regex, splits on {@code ;}, then upper-cases the result. Nothing here was measured before.
+ *
+ * <p>The benchmarks are split by the shape of the input rather than by method, because the cost is
+ * driven almost entirely by whether the analyzer takes an early return or falls through to parsing:
+ *
+ * <ul>
+ *   <li>{@code *NonSqlMethod} - the common case for non-SQL JDBC calls, expected to short-circuit.
+ *   <li>{@code *SimpleSelect} - a typical single statement, the full parse path.
+ *   <li>{@code *WithComments} - the same statement carrying line and block comments, which exercises
+ *       the character-by-character comment stripper.
+ *   <li>{@code *MultiStatement} - a batch, which additionally exercises the split.
+ * </ul>
+ *
+ * <p>Results are directly comparable across those four inputs, which is what makes them useful:
+ * a large gap between {@code SimpleSelect} and {@code NonSqlMethod} is the per-call tax paid by
+ * every statement execution.
+ */
+@State(Scope.Benchmark)
+@Fork(1)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class SqlMethodAnalyzerBenchmarks {
+
+  private static final String SIMPLE_SELECT = "SELECT id, name FROM users WHERE id = 42";
+  private static final String COMMENTED_SELECT =
+      "-- pick a user\n/* by primary key */ SELECT id, name FROM users WHERE id = 42 -- trailing";
+  private static final String MULTI_STATEMENT =
+      "BEGIN; UPDATE users SET name = 'a' WHERE id = 1; UPDATE users SET name = 'b' WHERE id = 2; COMMIT";
+  private static final String SET_AUTOCOMMIT = "SET AUTOCOMMIT = 1";
+
+  private static final String EXECUTE_METHOD = JdbcMethod.STATEMENT_EXECUTE.methodName;
+  private static final String NON_SQL_METHOD = JdbcMethod.CONNECTION_GETMETADATA.methodName;
+  private static final String SET_AUTOCOMMIT_METHOD = JdbcMethod.CONNECTION_SETAUTOCOMMIT.methodName;
+
+  private final SqlMethodAnalyzer analyzer = new SqlMethodAnalyzer();
+
+  private Connection autoCommitOn;
+  private Connection autoCommitOff;
+
+  private Object[] simpleSelectArgs;
+  private Object[] commentedSelectArgs;
+  private Object[] multiStatementArgs;
+  private Object[] setAutoCommitArgs;
+  private Object[] setAutoCommitTrueArgs;
+
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder()
+        .include(SqlMethodAnalyzerBenchmarks.class.getSimpleName())
+        .addProfiler(GCProfiler.class)
+        .detectJvmArgs()
+        .build();
+
+    new Runner(opt).run();
+  }
+
+  @Setup(Level.Trial)
+  public void setUp() {
+    this.autoCommitOn = FakeJdbc.connection(true, 0);
+    this.autoCommitOff = FakeJdbc.connection(false, 0);
+    this.simpleSelectArgs = new Object[] {SIMPLE_SELECT};
+    this.commentedSelectArgs = new Object[] {COMMENTED_SELECT};
+    this.multiStatementArgs = new Object[] {MULTI_STATEMENT};
+    this.setAutoCommitArgs = new Object[] {SET_AUTOCOMMIT};
+    this.setAutoCommitTrueArgs = new Object[] {Boolean.TRUE};
+  }
+
+  @Benchmark
+  public boolean doesOpenTransactionNonSqlMethod() {
+    return analyzer.doesOpenTransaction(autoCommitOn, NON_SQL_METHOD, null);
+  }
+
+  @Benchmark
+  public boolean doesOpenTransactionSimpleSelect() {
+    return analyzer.doesOpenTransaction(autoCommitOff, EXECUTE_METHOD, simpleSelectArgs);
+  }
+
+  @Benchmark
+  public boolean doesOpenTransactionWithComments() {
+    return analyzer.doesOpenTransaction(autoCommitOff, EXECUTE_METHOD, commentedSelectArgs);
+  }
+
+  @Benchmark
+  public boolean doesOpenTransactionMultiStatement() {
+    return analyzer.doesOpenTransaction(autoCommitOff, EXECUTE_METHOD, multiStatementArgs);
+  }
+
+  @Benchmark
+  public boolean doesCloseTransactionNonSqlMethod() {
+    return analyzer.doesCloseTransaction(autoCommitOn, NON_SQL_METHOD, null);
+  }
+
+  @Benchmark
+  public boolean doesCloseTransactionSimpleSelect() {
+    return analyzer.doesCloseTransaction(autoCommitOff, EXECUTE_METHOD, simpleSelectArgs);
+  }
+
+  @Benchmark
+  public boolean doesCloseTransactionMultiStatement() {
+    return analyzer.doesCloseTransaction(autoCommitOff, EXECUTE_METHOD, multiStatementArgs);
+  }
+
+  /**
+   * The path taken by every SQL execution regardless of content: an early {@code false} when the
+   * statement is not an autocommit change.
+   */
+  @Benchmark
+  public boolean doesSwitchAutoCommitFalseTrueSimpleSelect() {
+    return analyzer.doesSwitchAutoCommitFalseTrue(autoCommitOff, EXECUTE_METHOD, simpleSelectArgs);
+  }
+
+  @Benchmark
+  public boolean doesSwitchAutoCommitFalseTrueViaSql() {
+    return analyzer.doesSwitchAutoCommitFalseTrue(autoCommitOff, EXECUTE_METHOD, setAutoCommitArgs);
+  }
+
+  @Benchmark
+  public boolean doesSwitchAutoCommitFalseTrueViaSetter() {
+    return analyzer.doesSwitchAutoCommitFalseTrue(
+        autoCommitOff, SET_AUTOCOMMIT_METHOD, setAutoCommitTrueArgs);
+  }
+
+  @Benchmark
+  public boolean isStatementSettingAutoCommit() {
+    return analyzer.isStatementSettingAutoCommit(EXECUTE_METHOD, setAutoCommitArgs);
+  }
+
+  @Benchmark
+  public Boolean getAutoCommitValueFromSqlStatement() {
+    return analyzer.getAutoCommitValueFromSqlStatement(setAutoCommitArgs);
+  }
+
+  /** Pure set lookup, included as the floor for the other measurements. */
+  @Benchmark
+  public boolean isMethodClosingSqlObject() {
+    return analyzer.isMethodClosingSqlObject(EXECUTE_METHOD);
+  }
+}

--- a/benchmarks/src/jmh/java/software/amazon/jdbc/benchmarks/StorageBenchmarks.java
+++ b/benchmarks/src/jmh/java/software/amazon/jdbc/benchmarks/StorageBenchmarks.java
@@ -1,0 +1,359 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.jdbc.benchmarks;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import software.amazon.jdbc.HostSpec;
+import software.amazon.jdbc.HostSpecBuilder;
+import software.amazon.jdbc.benchmarks.support.NoOpEventPublisher;
+import software.amazon.jdbc.hostavailability.SimpleHostAvailabilityStrategy;
+import software.amazon.jdbc.hostlistprovider.Topology;
+import software.amazon.jdbc.util.storage.CacheMap;
+import software.amazon.jdbc.util.storage.ExpirationCache;
+import software.amazon.jdbc.util.storage.SlidingExpirationCache;
+import software.amazon.jdbc.util.storage.SlidingExpirationCacheWithCleanupThread;
+import software.amazon.jdbc.util.storage.StorageServiceImpl;
+
+/**
+ * Benchmarks for the driver's caching layer: {@link CacheMap}, {@link ExpirationCache},
+ * {@link SlidingExpirationCache}, {@link SlidingExpirationCacheWithCleanupThread} and
+ * {@link StorageServiceImpl}.
+ *
+ * <p>These caches sit in front of topology lookups, monitor registries, blue/green status and
+ * connection pools, so they are read on connect, on every host-list refresh and by every monitoring
+ * tick. None of them had benchmark coverage.
+ *
+ * <p>Two properties matter here and neither is visible from a single-threaded average:
+ *
+ * <ul>
+ *   <li><b>Every read mutates.</b> {@code SlidingExpirationCache.get} extends the entry's expiry and
+ *       {@code CacheMap.get} runs {@code computeIfPresent}, so reads take a write path on a
+ *       {@link java.util.concurrent.ConcurrentHashMap} bin. The {@code contended*} benchmarks run the
+ *       same reads on four threads against a single key, which is the shape the driver actually
+ *       produces when several connections share one topology entry.
+ *   <li><b>Cleanup is amortised onto callers.</b> {@code CacheMap} and {@code SlidingExpirationCache}
+ *       sweep the whole map from inside {@code get}/{@code put} once the cleanup deadline passes, so
+ *       an occasional call pays for every entry. {@code cleanupSweep} forces that path by setting a
+ *       zero cleanup interval, which is why it is reported separately - it is the tail, not the mean.
+ * </ul>
+ *
+ * <p>Caches are sized at {@code ENTRY_COUNT} entries to keep bin collisions and sweep costs
+ * representative rather than measuring a one-entry map.
+ */
+@State(Scope.Benchmark)
+@Fork(1)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class StorageBenchmarks {
+
+  private static final int ENTRY_COUNT = 100;
+  private static final long FIVE_MINUTES_NANOS = TimeUnit.MINUTES.toNanos(5);
+  private static final String HOT_KEY = "key-0";
+
+  private CacheMap<String, String> cacheMap;
+  private ExpirationCache<String, String> expirationCache;
+  private ExpirationCache<String, String> renewableExpirationCache;
+  private SlidingExpirationCache<String, String> slidingCache;
+  private SlidingExpirationCacheWithCleanupThread<String, String> slidingCacheWithThread;
+  private CacheMap<String, String> sweepingCacheMap;
+  private SlidingExpirationCache<String, String> sweepingSlidingCache;
+  private StorageServiceImpl storageService;
+  private Topology topology;
+
+  private String[] keys;
+  private int cursor;
+
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder()
+        .include(StorageBenchmarks.class.getSimpleName())
+        .addProfiler(GCProfiler.class)
+        .detectJvmArgs()
+        .build();
+
+    new Runner(opt).run();
+  }
+
+  @Setup(Level.Trial)
+  public void setUp() {
+    this.keys = new String[ENTRY_COUNT];
+    for (int i = 0; i < ENTRY_COUNT; i++) {
+      this.keys[i] = "key-" + i;
+    }
+
+    this.cacheMap = new CacheMap<>();
+    this.expirationCache = new ExpirationCache<>();
+    this.renewableExpirationCache = new ExpirationCache<>(true, FIVE_MINUTES_NANOS, null, null);
+    this.slidingCache = new SlidingExpirationCache<>();
+    this.slidingCacheWithThread = new SlidingExpirationCacheWithCleanupThread<>();
+
+    for (int i = 0; i < ENTRY_COUNT; i++) {
+      final String key = this.keys[i];
+      final String value = "value-" + i;
+      this.cacheMap.put(key, value, FIVE_MINUTES_NANOS);
+      this.expirationCache.put(key, value);
+      this.renewableExpirationCache.put(key, value);
+      this.slidingCache.put(key, value, FIVE_MINUTES_NANOS);
+      this.slidingCacheWithThread.put(key, value, FIVE_MINUTES_NANOS);
+    }
+
+    // Caches whose cleanup deadline is always in the past, so every access performs a full sweep.
+    // Entries are given a long TTL so the sweep walks them without removing anything - the point is
+    // to price the sweep, not the eviction.
+    this.sweepingCacheMap = new ZeroIntervalCacheMap<>();
+    this.sweepingSlidingCache = new SlidingExpirationCache<>();
+    this.sweepingSlidingCache.setCleanupIntervalNanos(0);
+    for (int i = 0; i < ENTRY_COUNT; i++) {
+      this.sweepingCacheMap.put(this.keys[i], "value-" + i, FIVE_MINUTES_NANOS);
+      this.sweepingSlidingCache.put(this.keys[i], "value-" + i, FIVE_MINUTES_NANOS);
+    }
+
+    // A five-host topology, the size of a default Aurora cluster, is what the topology cache holds.
+    final List<HostSpec> hosts = new ArrayList<>(5);
+    for (int i = 0; i < 5; i++) {
+      hosts.add(new HostSpecBuilder(new SimpleHostAvailabilityStrategy())
+          .host("instance-" + i + ".XYZ.us-east-2.rds.amazonaws.com")
+          .port(5432)
+          .build());
+    }
+    this.topology = new Topology(hosts);
+
+    this.storageService = new StorageServiceImpl(new NoOpEventPublisher());
+    for (int i = 0; i < ENTRY_COUNT; i++) {
+      this.storageService.set(this.keys[i], this.topology);
+    }
+
+    this.cursor = 0;
+  }
+
+  @TearDown(Level.Trial)
+  public void tearDown() {
+    // StorageServiceImpl and SlidingExpirationCacheWithCleanupThread both own background executors.
+    // Leaving them running leaks a thread per fork and lets cleanup work land in the middle of a
+    // later measurement.
+    this.storageService.releaseResources();
+    this.slidingCacheWithThread.clear();
+  }
+
+  private String nextKey() {
+    final int index = this.cursor++;
+    return this.keys[(index & Integer.MAX_VALUE) % ENTRY_COUNT];
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // CacheMap
+  // ---------------------------------------------------------------------------------------------
+
+  @Benchmark
+  public String cacheMapGetHit() {
+    return this.cacheMap.get(nextKey());
+  }
+
+  @Benchmark
+  public String cacheMapGetMiss() {
+    return this.cacheMap.get("absent");
+  }
+
+  @Benchmark
+  public String cacheMapGetWithDefault() {
+    return this.cacheMap.get(HOT_KEY, "default", FIVE_MINUTES_NANOS);
+  }
+
+  @Benchmark
+  public CacheMap<String, String> cacheMapPut() {
+    this.cacheMap.put(nextKey(), "value", FIVE_MINUTES_NANOS);
+    return this.cacheMap;
+  }
+
+  @Benchmark
+  @Threads(4)
+  public String contendedCacheMapGetHit() {
+    return this.cacheMap.get(HOT_KEY);
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // ExpirationCache
+  // ---------------------------------------------------------------------------------------------
+
+  @Benchmark
+  public String expirationCacheGetHit() {
+    return this.expirationCache.get(nextKey());
+  }
+
+  @Benchmark
+  public String expirationCacheGetMiss() {
+    return this.expirationCache.get("absent");
+  }
+
+  /**
+   * A renewable cache rewrites the entry's expiry on read, so this is the read-that-writes variant
+   * of {@link #expirationCacheGetHit()}. The gap between the two is the cost of renewal.
+   */
+  @Benchmark
+  public String renewableExpirationCacheGetHit() {
+    return this.renewableExpirationCache.get(nextKey());
+  }
+
+  @Benchmark
+  public boolean expirationCacheExists() {
+    return this.expirationCache.exists(HOT_KEY);
+  }
+
+  @Benchmark
+  public String expirationCacheComputeIfAbsentHit() {
+    return this.expirationCache.computeIfAbsent(HOT_KEY, k -> "value");
+  }
+
+  @Benchmark
+  @Threads(4)
+  public String contendedExpirationCacheGetHit() {
+    return this.expirationCache.get(HOT_KEY);
+  }
+
+  @Benchmark
+  @Threads(4)
+  public String contendedRenewableExpirationCacheGetHit() {
+    return this.renewableExpirationCache.get(HOT_KEY);
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // SlidingExpirationCache
+  // ---------------------------------------------------------------------------------------------
+
+  @Benchmark
+  public String slidingCacheGetHit() {
+    return this.slidingCache.get(nextKey(), FIVE_MINUTES_NANOS);
+  }
+
+  @Benchmark
+  public String slidingCacheGetMiss() {
+    return this.slidingCache.get("absent", FIVE_MINUTES_NANOS);
+  }
+
+  @Benchmark
+  public String slidingCacheComputeIfAbsentHit() {
+    return this.slidingCache.computeIfAbsent(HOT_KEY, k -> "value", FIVE_MINUTES_NANOS);
+  }
+
+  /**
+   * The cleanup-thread variant overrides {@code cleanUp()} to do nothing, so its reads never check
+   * the cleanup deadline. The gap against {@link #slidingCacheGetHit()} is what callers of the plain
+   * cache pay for that deadline check on every read.
+   */
+  @Benchmark
+  public String slidingCacheWithCleanupThreadGetHit() {
+    return this.slidingCacheWithThread.get(nextKey(), FIVE_MINUTES_NANOS);
+  }
+
+  @Benchmark
+  @Threads(4)
+  public String contendedSlidingCacheGetHit() {
+    return this.slidingCache.get(HOT_KEY, FIVE_MINUTES_NANOS);
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Amortised cleanup sweeps
+  // ---------------------------------------------------------------------------------------------
+
+  /** Prices the full-map sweep that {@link CacheMap#put} runs once its cleanup deadline passes. */
+  @Benchmark
+  public CacheMap<String, String> cleanupSweepCacheMapPut() {
+    this.sweepingCacheMap.put(HOT_KEY, "value", FIVE_MINUTES_NANOS);
+    return this.sweepingCacheMap;
+  }
+
+  /** Prices the same sweep on {@link SlidingExpirationCache#get}, which sweeps on read as well. */
+  @Benchmark
+  public String cleanupSweepSlidingCacheGet() {
+    return this.sweepingSlidingCache.get(HOT_KEY, FIVE_MINUTES_NANOS);
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // StorageService
+  // ---------------------------------------------------------------------------------------------
+
+  /**
+   * The real topology lookup: a class-keyed cache dispatch, an inner cache read, an
+   * {@code isInstance} check and a {@code DataAccessEvent} allocation.
+   */
+  @Benchmark
+  public Topology storageServiceGetTopology() {
+    return this.storageService.get(Topology.class, nextKey());
+  }
+
+  /** Same lookup with event registration suppressed, which isolates the event allocation cost. */
+  @Benchmark
+  public Topology storageServiceGetTopologyNoDataAccess() {
+    return this.storageService.get(Topology.class, nextKey(), false);
+  }
+
+  @Benchmark
+  public Topology storageServiceGetMiss() {
+    return this.storageService.get(Topology.class, "absent");
+  }
+
+  @Benchmark
+  public boolean storageServiceExists() {
+    return this.storageService.exists(Topology.class, HOT_KEY);
+  }
+
+  @Benchmark
+  public StorageServiceImpl storageServiceSetTopology() {
+    this.storageService.set(nextKey(), this.topology);
+    return this.storageService;
+  }
+
+  @Benchmark
+  @Threads(4)
+  public Topology contendedStorageServiceGetTopology() {
+    return this.storageService.get(Topology.class, HOT_KEY);
+  }
+
+  /**
+   * A {@link CacheMap} whose cleanup deadline has always passed, so every mutating call performs a
+   * full sweep. {@code cleanupIntervalNanos} is final in the parent, so the deadline is pushed into
+   * the past instead of shortening the interval.
+   */
+  private static class ZeroIntervalCacheMap<K, V> extends CacheMap<K, V> {
+    @Override
+    protected void cleanUp() {
+      this.cleanupTimeNanos.set(Long.MIN_VALUE);
+      super.cleanUp();
+    }
+  }
+}

--- a/benchmarks/src/jmh/java/software/amazon/jdbc/benchmarks/WrapperOverheadBenchmarks.java
+++ b/benchmarks/src/jmh/java/software/amazon/jdbc/benchmarks/WrapperOverheadBenchmarks.java
@@ -1,0 +1,334 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.jdbc.benchmarks;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import software.amazon.jdbc.ConnectionPluginManager;
+import software.amazon.jdbc.PropertyDefinition;
+import software.amazon.jdbc.benchmarks.support.BenchmarkServices;
+import software.amazon.jdbc.benchmarks.support.FakeConnectionProvider;
+import software.amazon.jdbc.benchmarks.support.FakeJdbc;
+import software.amazon.jdbc.benchmarks.testplugin.TestConnectionWrapper;
+import software.amazon.jdbc.util.FullServicesContainer;
+import software.amazon.jdbc.util.storage.StorageService;
+import software.amazon.jdbc.util.telemetry.DefaultTelemetryFactory;
+import software.amazon.jdbc.util.telemetry.TelemetryFactory;
+import software.amazon.jdbc.wrapper.ConnectionWrapper;
+
+/**
+ * The wrapper's own overhead, measured against the target driver it wraps.
+ *
+ * <p>This is the number the module's README claims to provide and previously could not: every other
+ * benchmark here compares the wrapper against itself with a different plugin list, which cannot
+ * answer "what does the wrapper cost". Each {@code wrapped*} benchmark has a {@code raw*} twin that
+ * performs the identical operation directly against the same {@link FakeJdbc} target, so the
+ * difference between the pair is the wrapper's contribution and the target's cost cancels.
+ *
+ * <p>Read the pairs, not the absolute values. The target is a {@link java.lang.reflect.Proxy}, not a
+ * real driver, so absolute numbers are not a database round trip; but the target is identical on
+ * both sides of every pair, which is what makes the difference meaningful.
+ *
+ * <p>Three cost centres are covered, in increasing order of how often they run:
+ *
+ * <ul>
+ *   <li><b>Per statement</b> - {@code createStatement}, {@code prepareStatement}, {@code executeQuery}.
+ *       Each goes through {@code WrapperUtils.executeWithPlugins}: a telemetry context, a call-context
+ *       reset, a bound-connection check, the plugin chain, then a proxy wrapper allocation for the
+ *       result.
+ *   <li><b>Per parameter</b> - {@code PreparedStatement} setters. A statement with many parameters
+ *       pays the wrapper's dispatch once per parameter, which had no coverage at all.
+ *   <li><b>Per row</b> - {@code ResultSet.next()} plus column reads. This is the highest-multiplier
+ *       path in the driver and the largest previous gap: a query returning 10,000 rows pays it
+ *       10,000 times. Measured over 1, 100 and 1,000 rows so the fixed and per-row parts separate.
+ * </ul>
+ *
+ * <p>Plugins are deliberately excluded ({@code wrapperPlugins} is empty) so this isolates the
+ * wrapper's own machinery. Plugin costs are measured in {@code RealPluginChainBenchmarks}.
+ */
+@State(Scope.Benchmark)
+@Fork(1)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class WrapperOverheadBenchmarks {
+
+  private static final String SQL = "SELECT id, name FROM users WHERE id = 42";
+  private static final String URL = "jdbc:aws-wrapper:postgresql://instance-0.XYZ.us-east-2.rds.amazonaws.com";
+  private static final String PROTOCOL = "jdbc:postgresql://";
+  private static final int SMALL_ROWS = 1;
+  private static final int MEDIUM_ROWS = 100;
+  private static final int LARGE_ROWS = 1000;
+
+  private Connection rawConnection;
+  private ConnectionWrapper wrappedConnection;
+  private ConnectionWrapper wrappedConnectionNoEvents;
+  private Statement rawStatement;
+  private Statement wrappedStatement;
+  private Statement wrappedStatementNoEvents;
+  private PreparedStatement rawPreparedStatement;
+  private PreparedStatement wrappedPreparedStatement;
+
+  private final List<ConnectionPluginManager> pluginManagers = new ArrayList<>();
+  private final List<StorageService> storageServices = new ArrayList<>();
+
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder()
+        .include(WrapperOverheadBenchmarks.class.getSimpleName())
+        .addProfiler(GCProfiler.class)
+        .detectJvmArgs()
+        .build();
+
+    new Runner(opt).run();
+  }
+
+  @Setup(Level.Trial)
+  public void setUp() throws SQLException {
+    final Properties props = new Properties();
+    props.setProperty(PropertyDefinition.PLUGINS.name, "");
+    props.setProperty(PropertyDefinition.ENABLE_TELEMETRY.name, "false");
+
+    // The row count is a property of the target connection, so a separate raw target is created for
+    // each row-count variant below; this one backs the statement-level benchmarks.
+    this.rawConnection = FakeJdbc.connection(true, LARGE_ROWS);
+    this.rawStatement = this.rawConnection.createStatement();
+    this.rawPreparedStatement = this.rawConnection.prepareStatement(SQL);
+
+    this.wrappedConnection = newWrappedConnection(props, true);
+    this.wrappedStatement = this.wrappedConnection.createStatement();
+    this.wrappedPreparedStatement = this.wrappedConnection.prepareStatement(SQL);
+
+    this.wrappedConnectionNoEvents = newWrappedConnection(props, false);
+    this.wrappedStatementNoEvents = this.wrappedConnectionNoEvents.createStatement();
+  }
+
+  /**
+   * Builds a wrapper over a {@link FakeJdbc} target with a real, plugin-free
+   * {@link ConnectionPluginManager}.
+   *
+   * @param importantEventsEnabled matches production default when true
+   */
+  private ConnectionWrapper newWrappedConnection(
+      final Properties props, final boolean importantEventsEnabled) throws SQLException {
+    final TelemetryFactory telemetryFactory = new DefaultTelemetryFactory(props);
+    final BenchmarkServices.State state =
+        BenchmarkServices.state(FakeJdbc.connection(true, LARGE_ROWS), telemetryFactory);
+
+    final StorageService storageService = BenchmarkServices.storageService();
+    this.storageServices.add(storageService);
+
+    final ConnectionPluginManager pluginManager = new ConnectionPluginManager(
+        props, telemetryFactory, new FakeConnectionProvider(state.currentConnection), null);
+    this.pluginManagers.add(pluginManager);
+
+    final FullServicesContainer container = BenchmarkServices.servicesContainer(
+        state,
+        BenchmarkServices.pluginService(state),
+        BenchmarkServices.pluginManagerService(state),
+        pluginManager,
+        storageService,
+        importantEventsEnabled);
+    pluginManager.initPlugins(container, null);
+
+    return new TestConnectionWrapper(container, props, URL, PROTOCOL);
+  }
+
+  @TearDown(Level.Trial)
+  public void tearDown() {
+    for (final ConnectionPluginManager pluginManager : this.pluginManagers) {
+      pluginManager.releaseResources();
+    }
+    for (final StorageService storageService : this.storageServices) {
+      BenchmarkServices.releaseStorage(storageService);
+    }
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Per statement
+  // ---------------------------------------------------------------------------------------------
+
+  @Benchmark
+  public Statement rawCreateStatement() throws SQLException {
+    return this.rawConnection.createStatement();
+  }
+
+  @Benchmark
+  public Statement wrappedCreateStatement() throws SQLException {
+    return this.wrappedConnection.createStatement();
+  }
+
+  @Benchmark
+  public PreparedStatement rawPrepareStatement() throws SQLException {
+    return this.rawConnection.prepareStatement(SQL);
+  }
+
+  @Benchmark
+  public PreparedStatement wrappedPrepareStatement() throws SQLException {
+    return this.wrappedConnection.prepareStatement(SQL);
+  }
+
+  @Benchmark
+  public ResultSet rawExecuteQuery() throws SQLException {
+    return this.rawStatement.executeQuery(SQL);
+  }
+
+  @Benchmark
+  public ResultSet wrappedExecuteQuery() throws SQLException {
+    return this.wrappedStatement.executeQuery(SQL);
+  }
+
+  /**
+   * Same call with {@code ImportantEventService} disabled. It is on by default, and
+   * {@code DefaultConnectionPlugin.execute} records an event - allocating an {@code ImportantEvent}
+   * and an {@code Instant}, and sweeping the expiry queue - on every JDBC call. The gap against
+   * {@link #wrappedExecuteQuery()} is what that costs per query.
+   */
+  @Benchmark
+  public ResultSet wrappedExecuteQueryEventsDisabled() throws SQLException {
+    return this.wrappedStatementNoEvents.executeQuery(SQL);
+  }
+
+  @Benchmark
+  public boolean rawGetAutoCommit() throws SQLException {
+    return this.rawConnection.getAutoCommit();
+  }
+
+  @Benchmark
+  public boolean wrappedGetAutoCommit() throws SQLException {
+    return this.wrappedConnection.getAutoCommit();
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Per parameter
+  // ---------------------------------------------------------------------------------------------
+
+  @Benchmark
+  public PreparedStatement rawSetParameters() throws SQLException {
+    final PreparedStatement statement = this.rawPreparedStatement;
+    for (int i = 1; i <= 10; i++) {
+      statement.setInt(i, i);
+    }
+    return statement;
+  }
+
+  @Benchmark
+  public PreparedStatement wrappedSetParameters() throws SQLException {
+    final PreparedStatement statement = this.wrappedPreparedStatement;
+    for (int i = 1; i <= 10; i++) {
+      statement.setInt(i, i);
+    }
+    return statement;
+  }
+
+  @Benchmark
+  public PreparedStatement rawSetStringParameters() throws SQLException {
+    final PreparedStatement statement = this.rawPreparedStatement;
+    for (int i = 1; i <= 10; i++) {
+      statement.setString(i, FakeJdbc.STRING_VALUE);
+    }
+    return statement;
+  }
+
+  @Benchmark
+  public PreparedStatement wrappedSetStringParameters() throws SQLException {
+    final PreparedStatement statement = this.wrappedPreparedStatement;
+    for (int i = 1; i <= 10; i++) {
+      statement.setString(i, FakeJdbc.STRING_VALUE);
+    }
+    return statement;
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Per row
+  // ---------------------------------------------------------------------------------------------
+
+  @Benchmark
+  public void rawTraverseOneRow(final Blackhole blackhole) throws SQLException {
+    traverse(this.rawStatement.executeQuery(SQL), blackhole, SMALL_ROWS);
+  }
+
+  @Benchmark
+  public void wrappedTraverseOneRow(final Blackhole blackhole) throws SQLException {
+    traverse(this.wrappedStatement.executeQuery(SQL), blackhole, SMALL_ROWS);
+  }
+
+  @Benchmark
+  public void rawTraverseHundredRows(final Blackhole blackhole) throws SQLException {
+    traverse(this.rawStatement.executeQuery(SQL), blackhole, MEDIUM_ROWS);
+  }
+
+  @Benchmark
+  public void wrappedTraverseHundredRows(final Blackhole blackhole) throws SQLException {
+    traverse(this.wrappedStatement.executeQuery(SQL), blackhole, MEDIUM_ROWS);
+  }
+
+  @Benchmark
+  public void rawTraverseThousandRows(final Blackhole blackhole) throws SQLException {
+    traverse(this.rawStatement.executeQuery(SQL), blackhole, LARGE_ROWS);
+  }
+
+  @Benchmark
+  public void wrappedTraverseThousandRows(final Blackhole blackhole) throws SQLException {
+    traverse(this.wrappedStatement.executeQuery(SQL), blackhole, LARGE_ROWS);
+  }
+
+  /**
+   * Reads at most {@code maxRows} rows and closes the result set.
+   *
+   * <p>Both targets are built with {@code LARGE_ROWS} available, so the row count is bounded here
+   * rather than by the target. That keeps every raw/wrapped pair doing the same number of
+   * {@code next()} and column reads, which is what makes the difference attributable to the wrapper.
+   * The enclosing {@code executeQuery} is included on both sides so the pair stays symmetric; it is
+   * priced on its own by {@code raw/wrappedExecuteQuery}.
+   */
+  private void traverse(final ResultSet resultSet, final Blackhole blackhole, final int maxRows)
+      throws SQLException {
+    int rows = 0;
+    while (rows < maxRows && resultSet.next()) {
+      blackhole.consume(resultSet.getInt(1));
+      blackhole.consume(resultSet.getString(2));
+      rows++;
+    }
+    resultSet.close();
+  }
+}

--- a/benchmarks/src/jmh/java/software/amazon/jdbc/benchmarks/support/BenchmarkServices.java
+++ b/benchmarks/src/jmh/java/software/amazon/jdbc/benchmarks/support/BenchmarkServices.java
@@ -1,0 +1,400 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.jdbc.benchmarks.support;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Properties;
+import java.util.function.Supplier;
+import software.amazon.jdbc.ConnectionPluginManager;
+import software.amazon.jdbc.ConnectionProvider;
+import software.amazon.jdbc.HostRole;
+import software.amazon.jdbc.HostSpec;
+import software.amazon.jdbc.HostSpecBuilder;
+import software.amazon.jdbc.NodeChangeOptions;
+import software.amazon.jdbc.PluginCallContext;
+import software.amazon.jdbc.PluginManagerService;
+import software.amazon.jdbc.PluginService;
+import software.amazon.jdbc.dialect.Dialect;
+import software.amazon.jdbc.dialect.UnknownDialect;
+import software.amazon.jdbc.hostavailability.SimpleHostAvailabilityStrategy;
+import software.amazon.jdbc.hostlistprovider.HostListProviderService;
+import software.amazon.jdbc.plugin.efm.base.ConnectionContextService;
+import software.amazon.jdbc.plugin.efm.base.SimpleConnectionContextServiceImpl;
+import software.amazon.jdbc.states.SessionStateService;
+import software.amazon.jdbc.targetdriverdialect.GenericTargetDriverDialect;
+import software.amazon.jdbc.targetdriverdialect.TargetDriverDialect;
+import software.amazon.jdbc.util.CoreServicesContainer;
+import software.amazon.jdbc.util.FullServicesContainer;
+import software.amazon.jdbc.util.ImportantEventService;
+import software.amazon.jdbc.util.events.EventPublisher;
+import software.amazon.jdbc.util.monitoring.MonitorService;
+import software.amazon.jdbc.util.storage.StorageService;
+import software.amazon.jdbc.util.storage.StorageServiceImpl;
+import software.amazon.jdbc.util.telemetry.TelemetryFactory;
+
+/**
+ * Lightweight stand-ins for the driver's service layer, so the wrapper's real code paths can be
+ * benchmarked without a database and without Mockito.
+ *
+ * <p>The wrapper reaches the service layer several times per JDBC call
+ * ({@code getCurrentConnection}, {@code resetCallContext}, {@code isXaTransactionActive}, ...). With
+ * Mockito those calls cost more than the wrapper code being measured. These stand-ins are
+ * {@link Proxy} instances that read and write plain fields for the methods the hot paths use and
+ * return type-appropriate defaults for everything else, so what is measured is the wrapper.
+ *
+ * <p>{@code PluginServiceImpl} itself is therefore not what is measured here - it is stood in for.
+ * Benchmarking the real {@code PluginServiceImpl} needs a real host list provider and dialect
+ * detection; see {@code PluginServiceBenchmarks} for the parts of it that can be measured directly.
+ *
+ * <p>Not thread-safe by design: the state is plain fields. Every benchmark using this must run
+ * single-threaded or hold one instance per thread.
+ */
+public final class BenchmarkServices {
+
+  private BenchmarkServices() {
+  }
+
+  /** Mutable state shared by the service stand-ins, mirroring what PluginServiceImpl would hold. */
+  public static final class State {
+    public Connection currentConnection;
+    public HostSpec currentHostSpec;
+    public HostSpec initialHostSpec;
+    public HostSpec routedHostSpec;
+    public List<HostSpec> hosts = new ArrayList<>();
+    public boolean inTransaction;
+    public boolean xaTransactionActive;
+    public Boolean pooledConnection = Boolean.FALSE;
+    public Properties props = new Properties();
+    public Dialect dialect;
+    public TargetDriverDialect targetDriverDialect;
+    public SessionStateService sessionStateService;
+    public TelemetryFactory telemetryFactory;
+    public final PluginCallContext callContext = new PluginCallContext();
+
+    /** Counts host-list refreshes so a benchmark can assert the pipeline actually ran. */
+    public long refreshCount;
+
+    /** Supplies connections for {@code connect}/{@code forceConnect}, used by monitoring plugins. */
+    public Supplier<Connection> monitoringConnectionSupplier = () -> FakeJdbc.connection(true, 1);
+
+    /**
+     * Returned by {@code PluginService.getDefaultConnectionProvider()}.
+     *
+     * <p>Needed because {@code MonitorServiceImpl} builds its own minimal services container - with a
+     * real {@code PartialPluginService} and a real plugin chain - from this provider the first time a
+     * monitor is created. Leaving it null makes any monitoring plugin fail at that point.
+     */
+    public ConnectionProvider defaultConnectionProvider;
+  }
+
+  /**
+   * Builds a state object for a single-host topology on the given connection.
+   */
+  public static State state(final Connection connection, final TelemetryFactory telemetryFactory) {
+    final State state = new State();
+    state.currentConnection = connection;
+    state.dialect = dialect();
+    state.targetDriverDialect = targetDriverDialect();
+    state.sessionStateService = sessionStateService();
+    state.telemetryFactory = telemetryFactory;
+    state.defaultConnectionProvider = new FakeConnectionProvider(connection);
+    state.currentHostSpec = new HostSpecBuilder(new SimpleHostAvailabilityStrategy())
+        .host("instance-0.XYZ.us-east-2.rds.amazonaws.com")
+        .hostId("instance-0")
+        .port(5432)
+        .role(HostRole.WRITER)
+        .build();
+    state.initialHostSpec = state.currentHostSpec;
+    state.hosts = Collections.singletonList(state.currentHostSpec);
+    return state;
+  }
+
+  /** A {@link PluginService} backed by {@code state}. */
+  public static PluginService pluginService(final State state) {
+    return proxy(PluginService.class, (proxy, method, args) -> {
+      switch (method.getName()) {
+        case "getCurrentConnection":
+          return state.currentConnection;
+        case "setCurrentConnection":
+          state.currentConnection = (Connection) args[0];
+          state.currentHostSpec = (HostSpec) args[1];
+          // The three-argument overload returns the set of observed changes.
+          return method.getReturnType() == EnumSet.class
+              ? EnumSet.noneOf(NodeChangeOptions.class)
+              : null;
+        case "getCurrentHostSpec":
+          return state.currentHostSpec;
+        case "getInitialConnectionHostSpec":
+          return state.initialHostSpec;
+        case "getRoutedHostSpec":
+          return state.routedHostSpec;
+        case "setRoutedHostSpec":
+          state.routedHostSpec = (HostSpec) args[0];
+          return null;
+        case "getHosts":
+        case "getAllHosts":
+          return state.hosts;
+        case "refreshHostList":
+          state.refreshCount++;
+          return null;
+        case "getDialect":
+          return state.dialect;
+        case "getTargetDriverDialect":
+          return state.targetDriverDialect;
+        case "getSessionStateService":
+          return state.sessionStateService;
+        case "getCallContext":
+          return state.callContext;
+        case "getTelemetryFactory":
+          return state.telemetryFactory;
+        case "getProperties":
+          return state.props;
+        case "isInTransaction":
+          return state.inTransaction;
+        case "setInTransaction":
+          state.inTransaction = (Boolean) args[0];
+          return null;
+        case "isXaTransactionActive":
+          return state.xaTransactionActive;
+        case "isPooledConnection":
+          return state.pooledConnection;
+        case "setIsPooledConnection":
+          state.pooledConnection = (Boolean) args[0];
+          return null;
+        case "getHostSpecBuilder":
+          return new HostSpecBuilder(new SimpleHostAvailabilityStrategy());
+        case "getDefaultConnectionProvider":
+          return state.defaultConnectionProvider;
+        case "getTargetName":
+          return "fake";
+        case "getDriverProtocol":
+          return "jdbc:postgresql://";
+        case "getOriginalUrl":
+          return "jdbc:aws-wrapper:postgresql://instance-0.XYZ.us-east-2.rds.amazonaws.com";
+        case "isDialectConfirmed":
+          return true;
+        case "isStaticHostListProvider":
+          return true;
+        case "connect":
+        case "forceConnect":
+          // Monitoring plugins (efm, efm2) open their own probe connection from a background thread
+          // through here. Handing back a fake connection keeps the benchmark free of network I/O and
+          // of DNS timeouts that would otherwise show up as measurement noise.
+          return state.monitoringConnectionSupplier.get();
+        default:
+          return Defaults.forProxyMethod(proxy, method, args);
+      }
+    });
+  }
+
+  /** A {@link PluginManagerService} backed by {@code state}. */
+  public static PluginManagerService pluginManagerService(final State state) {
+    return proxy(PluginManagerService.class, (proxy, method, args) -> {
+      switch (method.getName()) {
+        case "setInTransaction":
+          state.inTransaction = (Boolean) args[0];
+          return null;
+        case "setIsPooledConnection":
+          state.pooledConnection = (Boolean) args[0];
+          return null;
+        case "resetCallContext":
+          state.callContext.reset();
+          return null;
+        default:
+          return Defaults.forProxyMethod(proxy, method, args);
+      }
+    });
+  }
+
+  /**
+   * A {@link FullServicesContainer} wiring the given services together. The storage service is the
+   * real {@link StorageServiceImpl}; callers must release it (see {@link #releaseStorage}).
+   */
+  public static FullServicesContainer servicesContainer(
+      final State state,
+      final PluginService pluginService,
+      final PluginManagerService pluginManagerService,
+      final ConnectionPluginManager pluginManager,
+      final StorageService storageService) {
+    return servicesContainer(
+        state, pluginService, pluginManagerService, pluginManager, storageService, true);
+  }
+
+  /**
+   * As above, but lets the caller disable the {@link ImportantEventService}.
+   *
+   * <p>Worth a parameter because the service is enabled by default in production and
+   * {@code DefaultConnectionPlugin.execute} calls {@code registerEvent} on every JDBC call, which
+   * allocates an event and an {@link java.time.Instant}. Benchmarking both settings prices that.
+   */
+  public static FullServicesContainer servicesContainer(
+      final State state,
+      final PluginService pluginService,
+      final PluginManagerService pluginManagerService,
+      final ConnectionPluginManager pluginManager,
+      final StorageService storageService,
+      final boolean importantEventsEnabled) {
+    final ImportantEventService eventService = importantEventService(importantEventsEnabled);
+    final HostListProviderService hostListProviderService =
+        proxy(HostListProviderService.class, Defaults::forProxyMethod);
+    // Real implementations: the monitoring plugins register monitor types and acquire connection
+    // contexts on their execute path, so standing these in would remove the very work being measured.
+    // The monitor service is the driver's process-wide singleton, matching production.
+    final MonitorService monitorService = CoreServicesContainer.getInstance().getMonitorService();
+    final ConnectionContextService connectionContextService = new SimpleConnectionContextServiceImpl();
+    final EventPublisher eventPublisher = new NoOpEventPublisher();
+    return proxy(FullServicesContainer.class, (proxy, method, args) -> {
+      switch (method.getName()) {
+        case "getPluginService":
+          return pluginService;
+        case "getPluginManagerService":
+          return pluginManagerService;
+        case "getConnectionPluginManager":
+          return pluginManager;
+        case "getHostListProviderService":
+          return hostListProviderService;
+        case "getImportantEventService":
+          return eventService;
+        case "getStorageService":
+          return storageService;
+        case "getMonitorService":
+          return monitorService;
+        case "getConnectionContextService":
+          return connectionContextService;
+        case "getEventPublisher":
+          return eventPublisher;
+        case "getDefaultConnectionProvider":
+          return state.defaultConnectionProvider;
+        case "getTelemetryFactory":
+          return state.telemetryFactory;
+        default:
+          return Defaults.forProxyMethod(proxy, method, args);
+      }
+    });
+  }
+
+  public static StorageService storageService() {
+    return new StorageServiceImpl(new NoOpEventPublisher());
+  }
+
+  public static void releaseStorage(final StorageService storageService) {
+    if (storageService instanceof StorageServiceImpl) {
+      ((StorageServiceImpl) storageService).releaseResources();
+    }
+  }
+
+  /**
+   * The real {@link ImportantEventService}. It is a concrete class, not an interface, and it is
+   * enabled by default in production, so the real one is used rather than a stand-in: its
+   * {@code registerEvent} call on every execute is part of the cost being measured.
+   *
+   * @param enabled whether events are recorded; false matches
+   *                {@code -Daws.jdbc.config.exception.context.enabled=false}
+   */
+  public static ImportantEventService importantEventService(final boolean enabled) {
+    return new ImportantEventService(enabled, 60_000L);
+  }
+
+  public static SessionStateService sessionStateService() {
+    return proxy(SessionStateService.class, Defaults::forProxyMethod);
+  }
+
+  /**
+   * The driver's own fallback dialects, not stand-ins.
+   *
+   * <p>Real plugins read these during construction and on the hot path - the Aurora connection
+   * tracker builds its subscription set from
+   * {@code TargetDriverDialect.getNetworkBoundMethodNames}, for example - so a proxy returning null
+   * would both crash and misrepresent the cost. {@code UnknownDialect} and
+   * {@code GenericTargetDriverDialect} are what the driver itself falls back to for an unrecognised
+   * target, which makes them the honest choice here.
+   */
+  public static Dialect dialect() {
+    return new UnknownDialect();
+  }
+
+  public static TargetDriverDialect targetDriverDialect() {
+    return new GenericTargetDriverDialect();
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> T proxy(final Class<T> iface, final InvocationHandler handler) {
+    return (T) Proxy.newProxyInstance(
+        BenchmarkServices.class.getClassLoader(), new Class<?>[] {iface}, handler);
+  }
+
+  /** Shared proxy fallback: {@link Object} methods plus type-appropriate defaults. */
+  static final class Defaults {
+    private Defaults() {
+    }
+
+    static Object forProxyMethod(final Object proxy, final Method method, final Object[] args) {
+      switch (method.getName()) {
+        case "hashCode":
+          return System.identityHashCode(proxy);
+        case "equals":
+          return proxy == (args == null ? null : args[0]);
+        case "toString":
+          return "BenchmarkServices:" + method.getDeclaringClass().getSimpleName();
+        case "isWrapperFor":
+          return false;
+        case "unwrap":
+          return proxy;
+        default:
+          return zero(method.getReturnType());
+      }
+    }
+
+    private static Object zero(final Class<?> type) {
+      if (!type.isPrimitive()) {
+        return null;
+      }
+      if (type == boolean.class) {
+        return false;
+      }
+      if (type == char.class) {
+        return (char) 0;
+      }
+      if (type == byte.class) {
+        return (byte) 0;
+      }
+      if (type == short.class) {
+        return (short) 0;
+      }
+      if (type == int.class) {
+        return 0;
+      }
+      if (type == long.class) {
+        return 0L;
+      }
+      if (type == float.class) {
+        return 0f;
+      }
+      if (type == double.class) {
+        return 0d;
+      }
+      return null;
+    }
+  }
+}

--- a/benchmarks/src/jmh/java/software/amazon/jdbc/benchmarks/support/FakeConnectionProvider.java
+++ b/benchmarks/src/jmh/java/software/amazon/jdbc/benchmarks/support/FakeConnectionProvider.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.jdbc.benchmarks.support;
+
+import java.sql.Connection;
+import java.util.List;
+import java.util.Properties;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import software.amazon.jdbc.ConnectionInfo;
+import software.amazon.jdbc.ConnectionProvider;
+import software.amazon.jdbc.HostRole;
+import software.amazon.jdbc.HostSpec;
+import software.amazon.jdbc.ConnectionProviderManager;
+import software.amazon.jdbc.dialect.Dialect;
+import software.amazon.jdbc.targetdriverdialect.TargetDriverDialect;
+import software.amazon.jdbc.util.Pair;
+
+/**
+ * A {@link ConnectionProvider} that hands out a pre-built {@link FakeJdbc} connection instead of
+ * opening a socket.
+ *
+ * <p>This is what lets the wrapper's real {@code connect} pipeline - plugin chain,
+ * {@link ConnectionProviderManager} dispatch, dialect handling - be benchmarked end to end with no
+ * database. Connection establishment itself is a constant here, so differences between benchmarks
+ * are attributable to the wrapper.
+ */
+public class FakeConnectionProvider implements ConnectionProvider {
+
+  private final Connection connection;
+  private final @Nullable HostSpec hostByStrategy;
+
+  public FakeConnectionProvider(final Connection connection) {
+    this(connection, null);
+  }
+
+  public FakeConnectionProvider(final Connection connection, final @Nullable HostSpec hostByStrategy) {
+    this.connection = connection;
+    this.hostByStrategy = hostByStrategy;
+  }
+
+  @Override
+  public boolean acceptsUrl(
+      final @NonNull String protocol, final @NonNull HostSpec hostSpec, final @NonNull Properties props) {
+    return true;
+  }
+
+  @Override
+  public boolean acceptsStrategy(final @Nullable HostRole role, final @NonNull String strategy) {
+    return this.hostByStrategy != null;
+  }
+
+  @Override
+  public @Nullable HostSpec getHostSpecByStrategy(
+      final @NonNull List<HostSpec> hosts,
+      final @Nullable HostRole role,
+      final @NonNull String strategy,
+      final @Nullable Properties props) {
+    return this.hostByStrategy;
+  }
+
+  @Override
+  public @NonNull ConnectionInfo connect(
+      final @NonNull String protocol,
+      final @NonNull Dialect dialect,
+      final @NonNull TargetDriverDialect targetDriverDialect,
+      final @NonNull HostSpec hostSpec,
+      final @NonNull Properties props) {
+    return new ConnectionInfo(this.connection, false);
+  }
+
+  @Override
+  public String getTargetName() {
+    return "fake";
+  }
+
+  @Override
+  public @Nullable List<Pair<String, Object>> getSnapshotState() {
+    return null;
+  }
+}

--- a/benchmarks/src/jmh/java/software/amazon/jdbc/benchmarks/support/FakeJdbc.java
+++ b/benchmarks/src/jmh/java/software/amazon/jdbc/benchmarks/support/FakeJdbc.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.jdbc.benchmarks.support;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.Statement;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Minimal in-memory stand-ins for the target driver's JDBC objects.
+ *
+ * <p>Why this exists: the pre-existing benchmarks mock the target driver with Mockito, whose
+ * dynamic-proxy dispatch and invocation recording cost far more than the wrapper code being
+ * measured, so the scores say more about Mockito than about the driver. These fakes are plain
+ * {@link Proxy} instances backed by a switch on the method name. They allocate nothing per call on
+ * the hot methods and record nothing, which keeps the measured delta attributable to the wrapper.
+ *
+ * <p>They are deliberately not a correct JDBC implementation. Unhandled methods return the
+ * zero/null value for their return type rather than throwing, because benchmark code paths probe a
+ * long tail of getters and a thrown exception would abort the iteration instead of just being
+ * ignored. Do not use these to assert behaviour - they exist to be cheap and predictable.
+ *
+ * <p>A {@link Proxy} still costs an interface dispatch plus an argument array. That cost sits
+ * underneath both sides of every raw-versus-wrapped comparison in this module, so it cancels out of
+ * the difference; it does not cancel out of the absolute numbers.
+ */
+public final class FakeJdbc {
+
+  /** Fixed column value, pre-allocated so row reads do not measure String construction. */
+  public static final String STRING_VALUE = "benchmark-value";
+
+  private FakeJdbc() {
+  }
+
+  /**
+   * Returns a connection that reports the given autocommit state and hands out statements which
+   * produce result sets of {@code rowCount} rows.
+   */
+  public static Connection connection(final boolean autoCommit, final int rowCount) {
+    final AtomicBoolean autoCommitState = new AtomicBoolean(autoCommit);
+    final Connection[] self = new Connection[1];
+    self[0] = proxy(Connection.class, (proxy, method, args) -> {
+      switch (method.getName()) {
+        case "getAutoCommit":
+          return autoCommitState.get();
+        case "setAutoCommit":
+          autoCommitState.set((Boolean) args[0]);
+          return null;
+        case "createStatement":
+          return statement(self[0], rowCount);
+        case "prepareStatement":
+          return preparedStatement(self[0], rowCount);
+        case "isClosed":
+        case "isReadOnly":
+          return false;
+        case "getCatalog":
+        case "getSchema":
+          return "benchmark";
+        case "getTransactionIsolation":
+          return Connection.TRANSACTION_READ_COMMITTED;
+        case "getNetworkTimeout":
+          return 0;
+        case "getHoldability":
+          return ResultSet.HOLD_CURSORS_OVER_COMMIT;
+        default:
+          return fallback(proxy, method, args);
+      }
+    });
+    return self[0];
+  }
+
+  /** Returns a statement bound to {@code connection} that produces {@code rowCount}-row results. */
+  public static Statement statement(final Connection connection, final int rowCount) {
+    final Statement[] self = new Statement[1];
+    self[0] = proxy(Statement.class, (proxy, method, args) -> {
+      switch (method.getName()) {
+        case "getConnection":
+          return connection;
+        case "executeQuery":
+        case "getResultSet":
+          return resultSet(self[0], rowCount);
+        case "execute":
+          return true;
+        case "executeUpdate":
+        case "getUpdateCount":
+          return 1;
+        case "isClosed":
+          return false;
+        default:
+          return fallback(proxy, method, args);
+      }
+    });
+    return self[0];
+  }
+
+  /** Returns a prepared statement bound to {@code connection}; parameter setters are no-ops. */
+  public static PreparedStatement preparedStatement(final Connection connection, final int rowCount) {
+    final PreparedStatement[] self = new PreparedStatement[1];
+    self[0] = proxy(PreparedStatement.class, (proxy, method, args) -> {
+      switch (method.getName()) {
+        case "getConnection":
+          return connection;
+        case "executeQuery":
+        case "getResultSet":
+          return resultSet(self[0], rowCount);
+        case "execute":
+          return true;
+        case "executeUpdate":
+        case "getUpdateCount":
+          return 1;
+        case "isClosed":
+          return false;
+        default:
+          return fallback(proxy, method, args);
+      }
+    });
+    return self[0];
+  }
+
+  /**
+   * Returns a forward-only result set over {@code rowCount} synthetic rows. Column values are
+   * constants so that per-row benchmarks measure traversal and wrapping rather than value decoding.
+   */
+  public static ResultSet resultSet(final Statement statement, final int rowCount) {
+    final int[] cursor = {0};
+    return proxy(ResultSet.class, (proxy, method, args) -> {
+      switch (method.getName()) {
+        case "next":
+          if (cursor[0] >= rowCount) {
+            return false;
+          }
+          cursor[0]++;
+          return true;
+        case "getInt":
+          return cursor[0];
+        case "getLong":
+          return (long) cursor[0];
+        case "getDouble":
+          return (double) cursor[0];
+        case "getString":
+          return STRING_VALUE;
+        case "getObject":
+          return STRING_VALUE;
+        case "wasNull":
+        case "isClosed":
+          return false;
+        case "getRow":
+          return cursor[0];
+        case "getStatement":
+          return statement;
+        case "getMetaData":
+          return metaData();
+        default:
+          return fallback(proxy, method, args);
+      }
+    });
+  }
+
+  private static ResultSetMetaData metaData() {
+    return proxy(ResultSetMetaData.class, (proxy, method, args) -> {
+      switch (method.getName()) {
+        case "getColumnCount":
+          return 4;
+        case "getColumnName":
+        case "getColumnLabel":
+          return "col";
+        case "getColumnType":
+          return java.sql.Types.VARCHAR;
+        default:
+          return fallback(proxy, method, args);
+      }
+    });
+  }
+
+  /**
+   * Handles the {@link Object} methods a proxy also receives, the {@code Wrapper} contract, and
+   * anything else with a type-appropriate default.
+   */
+  private static Object fallback(final Object proxy, final Method method, final Object[] args) {
+    switch (method.getName()) {
+      case "hashCode":
+        return System.identityHashCode(proxy);
+      case "equals":
+        return proxy == (args == null ? null : args[0]);
+      case "toString":
+        return "FakeJdbc:" + method.getDeclaringClass().getSimpleName() + "@"
+            + Integer.toHexString(System.identityHashCode(proxy));
+      case "unwrap":
+        return proxy;
+      case "isWrapperFor":
+        return false;
+      default:
+        return defaultValue(method.getReturnType());
+    }
+  }
+
+  private static Object defaultValue(final Class<?> type) {
+    if (!type.isPrimitive()) {
+      return null;
+    }
+    if (type == boolean.class) {
+      return false;
+    }
+    if (type == char.class) {
+      return (char) 0;
+    }
+    if (type == byte.class) {
+      return (byte) 0;
+    }
+    if (type == short.class) {
+      return (short) 0;
+    }
+    if (type == int.class) {
+      return 0;
+    }
+    if (type == long.class) {
+      return 0L;
+    }
+    if (type == float.class) {
+      return 0f;
+    }
+    if (type == double.class) {
+      return 0d;
+    }
+    // void
+    return null;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> T proxy(final Class<T> iface, final InvocationHandler handler) {
+    return (T) Proxy.newProxyInstance(FakeJdbc.class.getClassLoader(), new Class<?>[] {iface}, handler);
+  }
+}

--- a/benchmarks/src/jmh/java/software/amazon/jdbc/benchmarks/support/FixedDialectProvider.java
+++ b/benchmarks/src/jmh/java/software/amazon/jdbc/benchmarks/support/FixedDialectProvider.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.jdbc.benchmarks.support;
+
+import java.sql.Connection;
+import java.util.Properties;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import software.amazon.jdbc.HostSpec;
+import software.amazon.jdbc.dialect.Dialect;
+import software.amazon.jdbc.dialect.DialectProvider;
+
+/**
+ * A {@link DialectProvider} that always returns the same dialect and reports it as confirmed.
+ *
+ * <p>Lets {@code PluginServiceImpl} be constructed in a benchmark. The default
+ * {@code DialectManager} performs endpoint- and query-based dialect detection during construction,
+ * which needs a real database; supplying a fixed dialect skips detection without changing any of the
+ * per-call paths being measured afterwards.
+ */
+public class FixedDialectProvider implements DialectProvider {
+
+  private final Dialect dialect;
+
+  public FixedDialectProvider(final Dialect dialect) {
+    this.dialect = dialect;
+  }
+
+  @Override
+  public Dialect getDialect(
+      final @NonNull String driverProtocol, final @NonNull String url, final @NonNull Properties props) {
+    return this.dialect;
+  }
+
+  @Override
+  public Dialect getDialect(
+      final @NonNull String originalUrl,
+      final @NonNull HostSpec hostSpec,
+      final @NonNull Connection connection) {
+    return this.dialect;
+  }
+
+  @Override
+  public boolean isConfirmedDialect() {
+    return true;
+  }
+}

--- a/benchmarks/src/jmh/java/software/amazon/jdbc/benchmarks/support/NoOpEventPublisher.java
+++ b/benchmarks/src/jmh/java/software/amazon/jdbc/benchmarks/support/NoOpEventPublisher.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.jdbc.benchmarks.support;
+
+import java.util.Set;
+import software.amazon.jdbc.util.events.Event;
+import software.amazon.jdbc.util.events.EventPublisher;
+import software.amazon.jdbc.util.events.EventSubscriber;
+
+/**
+ * An {@link EventPublisher} that drops everything.
+ *
+ * <p>Used so storage-service benchmarks measure the cache, not the event fan-out. Note that
+ * {@code StorageServiceImpl.get} publishes a {@code DataAccessEvent} on every hit, so the
+ * allocation of that event is still included in those measurements - only the delivery is not.
+ */
+public class NoOpEventPublisher implements EventPublisher {
+
+  @Override
+  public void subscribe(final EventSubscriber subscriber, final Set<Class<? extends Event>> eventClasses) {
+    // no-op
+  }
+
+  @Override
+  public void unsubscribe(final EventSubscriber subscriber, final Set<Class<? extends Event>> eventClasses) {
+    // no-op
+  }
+
+  @Override
+  public void publish(final Event event) {
+    // no-op
+  }
+}

--- a/benchmarks/src/jmh/java/software/amazon/jdbc/benchmarks/support/StaticTopologyProvider.java
+++ b/benchmarks/src/jmh/java/software/amazon/jdbc/benchmarks/support/StaticTopologyProvider.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.jdbc.benchmarks.support;
+
+import java.sql.Connection;
+import java.util.List;
+import software.amazon.jdbc.HostSpec;
+import software.amazon.jdbc.hostlistprovider.HostListProvider;
+import software.amazon.jdbc.hostlistprovider.StaticHostListProvider;
+
+/**
+ * A {@link HostListProvider} that returns a fixed topology without querying anything.
+ *
+ * <p>Used to populate {@code PluginServiceImpl}'s host list through its real
+ * {@code refreshHostList()} path, rather than reaching into the field. That keeps the setup faithful
+ * - {@code setNodeList} runs and computes node-change notifications exactly as it would in
+ * production - while requiring no database.
+ *
+ * <p>Implements {@link StaticHostListProvider} so {@code isStaticHostListProvider()} reports true,
+ * matching a provider built from a fixed URL host list.
+ */
+public class StaticTopologyProvider implements HostListProvider, StaticHostListProvider {
+
+  private final List<HostSpec> hosts;
+
+  public StaticTopologyProvider(final List<HostSpec> hosts) {
+    this.hosts = hosts;
+  }
+
+  @Override
+  public List<HostSpec> getCurrentTopology(final Connection conn, final HostSpec initialHostSpec) {
+    return this.hosts;
+  }
+
+  @Override
+  public List<HostSpec> refresh() {
+    return this.hosts;
+  }
+
+  @Override
+  public List<HostSpec> forceRefresh() {
+    return this.hosts;
+  }
+
+  @Override
+  public List<HostSpec> forceRefresh(final boolean verifyTopology, final long timeoutMs) {
+    return this.hosts;
+  }
+
+  @Override
+  public String getClusterId() {
+    return "benchmark-cluster";
+  }
+
+  @Override
+  public void stopMonitor() {
+    // no monitor to stop
+  }
+}

--- a/benchmarks/src/jmh/java/software/amazon/jdbc/benchmarks/testplugin/TestConnectionWrapper.java
+++ b/benchmarks/src/jmh/java/software/amazon/jdbc/benchmarks/testplugin/TestConnectionWrapper.java
@@ -19,30 +19,26 @@ package software.amazon.jdbc.benchmarks.testplugin;
 import java.sql.SQLException;
 import java.util.Properties;
 import org.checkerframework.checker.nullness.qual.NonNull;
-import software.amazon.jdbc.ConnectionPluginManager;
-import software.amazon.jdbc.hostlistprovider.HostListProviderService;
-import software.amazon.jdbc.PluginManagerService;
-import software.amazon.jdbc.PluginService;
+import software.amazon.jdbc.util.FullServicesContainer;
 import software.amazon.jdbc.wrapper.ConnectionWrapper;
 
-// Test class allowing for mocks to be used with ConnectionWrapper logic
+/**
+ * Test class allowing mocks to be used with {@link ConnectionWrapper} logic.
+ *
+ * <p>This delegates to the production constructor and supplies a (mocked) services container
+ * rather than using the {@code protected} "for testing purposes only" constructor. That
+ * constructor leaves {@code ConnectionWrapper.servicesContainer} null, and every JDBC call now
+ * routes through {@code WrapperUtils.doExecuteWithPlugins}, which dereferences
+ * {@code getServicesContainer()}. Going through the production constructor keeps the benchmarks
+ * aligned with the code path real connections take.
+ */
 public class TestConnectionWrapper extends ConnectionWrapper {
   public TestConnectionWrapper(
+      @NonNull final FullServicesContainer servicesContainer,
       @NonNull final Properties props,
       @NonNull final String url,
-      @NonNull final String protocol,
-      @NonNull final ConnectionPluginManager connectionPluginManager,
-      @NonNull final PluginService pluginService,
-      @NonNull final HostListProviderService hostListProviderService,
-      @NonNull final PluginManagerService pluginManagerService)
+      @NonNull final String protocol)
       throws SQLException {
-    super(
-        props,
-        url,
-        protocol,
-        connectionPluginManager,
-        pluginService,
-        hostListProviderService,
-        pluginManagerService);
+    super(servicesContainer, props, url, protocol, null);
   }
 }


### PR DESCRIPTION
## Summary

The JMH benchmarks compiled but did not run. A full-suite run produced **one** result out of 24, and that one was `PluginBenchmarks.initAndReleaseBaseLine` - an empty method body. Every other benchmark aborted in setup or warmup. Nothing in CI compiles this module, so the breakage was invisible.

This PR repairs the suite, wires it into CI so it cannot rot again, and fills the coverage gaps that were left. The suite goes from **24 benchmarks (23 failing)** to **149 benchmarks, all reporting, zero exceptions**.

Six commits, each one compiled and smoke-run before being committed.

## Part 1: the repair

Three independent breakages, all caused by wrapper internals moving on without the benchmark harness.

| Symptom | Cause |
|---|---|
| All 12 `ConnectionPluginManagerBenchmarks` aborted with `IllegalArgumentException: pluginManagerService` | `DefaultConnectionPlugin` now resolves `PluginManagerService` and `ImportantEventService` from the services container; only `getPluginService()` was stubbed |
| All 11 non-empty `PluginBenchmarks` failed with NPEs | Three separate points: `ConnectionWrapper.init` calling `getTargetDriverDialect()`, `WrapperUtils.doExecuteWithPlugins` calling `getServicesContainer()`, and `ConnectionWrapper.close` calling `getSessionStateService()` |
| `PgCacheBenchmarks` could only ever fail | Endpoints were hardcoded placeholder host names (`db-0.XYZ.us-east-2...`) |

`TestConnectionWrapper` now builds through the production `ConnectionWrapper` constructor with a services container, instead of the `protected` "for testing purposes only" constructor. That constructor leaves `servicesContainer` null, which every JDBC call now dereferences, and it has no remaining callers anywhere in the repo - it is the thing that drifted, and is a candidate for removal in a follow-up.

`PgCacheBenchmarks` endpoints now come from system properties (`benchmarks.pg.url`, `benchmarks.cache.rw`, `benchmarks.cache.ro`) and setup fails fast naming the missing one. It also gained the license header it was missing and a null-safe teardown, so a failed setup is no longer masked by an NPE.

Three correctness bugs found while fixing the above:

- `initConnectionPluginManagerWithNoPlugins` passed the 10-plugin configuration profile. A profile overrides the `wrapperPlugins` property, so the benchmark was a duplicate of the `WithPlugins` case rather than a no-plugin baseline.
- `initHostProvidersWithNoPlugins` and `releaseResourcesWithNoPlugins` returned the wrong plugin manager.
- `ConnectionPluginManagerBenchmarks.main()` ran `PluginBenchmarks`.

### Why CI missed it

The benchmarks live in the `jmh` source set, so `./gradlew test` reports `:benchmarks:compileTestJava NO-SOURCE`, and checkstyle/spotbugs are configured only on the `wrapper` module. `:benchmarks:jmhJar` is now part of the `lint` job, which sits behind the `ci-gate` required status check.

## Part 2: filling the coverage gaps

Two gaps mattered most. There was no target-driver baseline, so the module could not answer "what does the wrapper cost" - every benchmark compared the wrapper against itself with a different plugin list. And no benchmark instantiated a real plugin: `ConnectionPluginManagerBenchmarks` uses chains of a no-op `BenchmarkPlugin`, and `PluginBenchmarks` passes `wrapperPlugins` values to a mocked plugin manager where they have no effect.

New classes:

- **`WrapperOverheadBenchmarks`** - the missing baseline. Every `wrapped*` benchmark has a `raw*` twin performing the identical operation directly against the same target, so the difference is the wrapper's contribution. Covers per statement, per parameter (`PreparedStatement` setters) and per row (`ResultSet.next()` plus column reads over 1, 100 and 1000 rows - the highest-multiplier path in the driver and the largest previous gap). Also prices `ImportantEventService`, which is enabled by default and records an event on every JDBC call.
- **`RealPluginChainBenchmarks`** - `ConnectionPluginManager.execute` through chains holding one real plugin each: `executionTime`, `connectTime`, `logQuery`, `driverMetaData`, `dataCache`, `sqlParser`, `auroraConnectionTracker`, `auroraStaleDns`, `efm2`, `failover2`, `dev`, plus two combined chains.
- **`PluginServiceBenchmarks`** - the real `PluginServiceImpl` and `SessionStateServiceImpl`, both previously mocked out of every benchmark.
- **`SqlMethodAnalyzerBenchmarks`** - consulted two to four times per SQL-carrying JDBC call; splits by input shape so the early-return and full-parse costs are directly comparable.
- **`RdsUtilsBenchmarks`** - measured on the cached path and with a fresh host name per invocation, since the static matcher cache otherwise hides the real first-seen cost.
- **`ConnectionUrlParserBenchmarks`** - per-connection URL and property work.
- **`StorageBenchmarks`** - `CacheMap`, `ExpirationCache`, `SlidingExpirationCache`, `SlidingExpirationCacheWithCleanupThread`, `StorageServiceImpl`.
- **`HostSelectorBenchmarks`** - all seven `HostSelector` implementations against one shared topology.

`StorageBenchmarks`, `HostSelectorBenchmarks` and `RdsUtilsBenchmarks` carry explicit `contended*` variants under `@Threads`, because several driver caches take a write path on read and the round-robin selector holds a lock across its whole selection - costs that are invisible single-threaded.

### Measurement approach

The target driver is stood in for by `support/FakeJdbc`: plain `java.lang.reflect.Proxy` instances serving constant values. This is deliberate. The pre-existing benchmarks mock the target with Mockito, whose dispatch and invocation recording cost more than the wrapper code under test - which is why they reported milliseconds for work that takes nanoseconds. The stand-in cost sits underneath both sides of every pair, so it cancels out of the difference. It does not cancel out of an absolute number, and the README says so.

Where the driver has a real fallback implementation, the real one is used rather than a stand-in: `UnknownDialect`, `GenericTargetDriverDialect`, the process-wide `MonitorService`, `SimpleConnectionContextServiceImpl` and `ImportantEventService`. Real plugins read these during construction and on the hot path, so standing them in would both crash and misrepresent cost.

`jsqlparser` is added to the benchmark classpath. It is an optional wrapper dependency required at runtime by `sqlParser`, `autoReadWriteSplitting` and `kmsEncryption`; without it those plugins fail with `NoClassDefFoundError` instead of being measured. Version pinned to match `wrapper/build.gradle.kts`.

### Deliberately not covered

Documented in the classes and the README rather than faked:

- Failover, monitor probes, topology refreshes and credential fetches - driven by network events and background threads, not by a JDBC call.
- Connect-only plugins (`iam`, `awsSecretsManager`, `federatedAuth`, `okta`) - their real cost is a network call; on the execute path they would score flat.
- Dialect detection - needs a live database. `PluginServiceBenchmarks` supplies a fixed dialect so the rest of `PluginServiceImpl` can be measured.

## Findings

These came out of the new benchmarks. They are from single-iteration smoke runs, so they are **leads for follow-up, not conclusions**, and nothing here is acted on in this PR.

- **Plugin cost is a cliff, not a gradient.** `makePluginChainFunc` computes `isSubscribed` while explicitly excluding `DefaultConnectionPlugin`, so when nothing subscribes the whole pipeline is bypassed and `executeQuery` costs about 9 ns. The first plugin that subscribes brings it to about 2.5 us, and most of that is the default plugin's SQL analysis rather than the plugin itself. Three plugins together cost about 4.3 us, barely more than one.
- **`sqlParser` costs on the order of 1.7 ms per query**, three orders of magnitude above every other plugin, because jsqlparser re-parses the statement on every execute with no cache.
- **A non-RDS host name costs about 22 us to classify**, roughly 100x the cached RDS path, and the cached and uncached numbers are indistinguishable - the static matcher cache appears not to help the no-match case. Anyone connecting through a custom DNS name pays this repeatedly.
- **`CacheMap.get` degrades about 21x under four threads** on a single hot key (52 ns to 1090 ns), because the read goes through `computeIfPresent` and takes the `ConcurrentHashMap` bin lock. `ExpirationCache.get`, a plain read, stays flat.
- **Round robin costs about 1.5 us against about 0.11 us for random, and about 9.2 us on four threads** - it holds a `ResourceLock` across its whole selection including a sort. Under query-level load balancing that makes selector choice a throughput decision, not just a distribution one.
- **`PluginServiceImpl.getHosts` goes from about 13 ns to about 246 ns once a host-permission entry exists**, which both the custom endpoint and blue/green plugins install.
- **Wrapper overhead itself is modest**: about 76 to 195 ns for `createStatement`, about 129 to 228 ns for `executeQuery`. `PluginServiceImpl`'s query-path methods are 2 to 4 ns field reads - worth stating plainly, since that was previously assumed rather than measured.

## Testing

- `./gradlew :benchmarks:jmhJar` - BUILD SUCCESSFUL.
- Full-suite run excluding `PgCacheBenchmarks`: **149 benchmarks, 0 exceptions, 0 `<failure>` markers**. Before this PR the same command yielded 1 result out of 24.
- Each of the six commits was compiled and smoke-run individually before being committed.

Not verified:

- `PgCacheBenchmarks` was not executed - it needs a live PostgreSQL instance and cache server. Its endpoint handling and fail-fast path were exercised, but not a real run.
- The per-row traversal numbers are still within noise of their raw twins at one iteration and occasionally invert. They need a full-length run before anything is concluded from them; the README warns against quoting smoke-run numbers.
- No unit tests were added. This module has no test source set, and the benchmarks are themselves the verification artefact.

## Notes

No production code under `wrapper/` was changed. Every finding above is recorded in the commit messages for follow-up rather than acted on here.
