### PR TITLE
fix: cache RdsUtilities per region in RegularRdsUtility

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/iam/RegularRdsUtility.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/iam/RegularRdsUtility.java
@@ -16,6 +16,8 @@
 
 package software.amazon.jdbc.plugin.iam;
 
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
@@ -24,13 +26,24 @@ import software.amazon.awssdk.services.rds.RdsUtilities;
 
 public class RegularRdsUtility implements IamTokenUtility {
 
-  private @Nullable RdsUtilities utilities = null;
+  // Cache the RdsUtilities per region. RdsUtilities bakes in the region (and credentials provider)
+  // at build time, so a single cached instance would produce tokens signed for the region seen on
+  // the first call even after the region changes (e.g. cross-region failover). Keying by region
+  // ensures each region uses an RdsUtilities built for that region. The map is naturally bounded by
+  // the small number of regions a single instance can encounter.
+  private final Map<Region, RdsUtilities> utilitiesByRegion = new ConcurrentHashMap<>();
 
-  public RegularRdsUtility() {}
+  // For testing only: when set, this instance is always used regardless of region so tests can
+  // inject an RdsUtilities backed by a fixed clock for deterministic tokens.
+  private final @Nullable RdsUtilities injectedUtilities;
+
+  public RegularRdsUtility() {
+    this.injectedUtilities = null;
+  }
 
   // For testing only
   public RegularRdsUtility(final RdsUtilities utilities) {
-    this.utilities = utilities;
+    this.injectedUtilities = utilities;
   }
 
   @Override
@@ -41,14 +54,15 @@ public class RegularRdsUtility implements IamTokenUtility {
       final int port,
       final @NonNull String username) {
 
-    RdsUtilities localUtilities = this.utilities;
-    if (localUtilities == null) {
-      localUtilities = RdsUtilities.builder()
-          .credentialsProvider(credentialsProvider)
-          .region(region)
-          .build();
-      this.utilities = localUtilities;
-    }
+    final RdsUtilities localUtilities = this.injectedUtilities != null
+        ? this.injectedUtilities
+        : this.utilitiesByRegion.computeIfAbsent(
+            region,
+            r -> RdsUtilities.builder()
+                .credentialsProvider(credentialsProvider)
+                .region(r)
+                .build());
+
     return localUtilities.generateAuthenticationToken((builder) ->
         builder
             .hostname(hostname)


### PR DESCRIPTION
## Summary

`RegularRdsUtility` cached a single `RdsUtilities` instance built from the `region` and
`credentialsProvider` supplied on the *first* `generateAuthenticationToken` call, and reused it for
every subsequent call regardless of the arguments.

Because `RdsUtilities` bakes in the region (and credentials provider) at build time, a later change
of region on the same instance reused a helper signed for the original region and produced a token
for the wrong region. The most plausible trigger is a cross-region failover (region derived from the
host, e.g. an RDS global writer cluster), where the token storage cache key includes the region, so
a region change forces regeneration but the stale cached helper then signs for the old region.

## Change

- Replace the single cached `RdsUtilities` field with a `Map<Region, RdsUtilities>`
  (`ConcurrentHashMap`) populated via `computeIfAbsent(region, ...)`, so each region uses an
  `RdsUtilities` built for that region. The map is naturally bounded by the small number of regions
  a single instance can encounter.
- Keep a separate test-only injected `RdsUtilities` (used by the fixed-clock integration test) that
  is always used when set, preserving deterministic-token behavior.

`LightRdsUtility` (the other `IamTokenUtility` implementation) already reads `region` and
`credentialsProvider` fresh on every call and needs no change.

## Notes

- Region-only keying addresses the region-change scenario. A wholesale credentials-provider swap for
  the same region is not keyed, because `AwsCredentialsManager.getProvider` returns a fresh provider
  instance almost every call and SDK providers lack meaningful equality; ordinary credential rotation
  still works through the retained provider.

## Testing

- `:aws-advanced-jdbc-wrapper:compileJava` succeeds.
- `IamAuthConnectionPluginTest` passes.
- No dedicated unit test exercises `RegularRdsUtility` directly (existing plugin tests mock
  `IamTokenUtility`; the real usage is integration-only).
