### PR TITLE
chore: fix IntelliJ warnings in integration tests

### DIFF
--- a/wrapper/src/test/java/integration/GenericTypedParameterResolver.java
+++ b/wrapper/src/test/java/integration/GenericTypedParameterResolver.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junit.jupiter.api.extension.ParameterResolver;
 
 public class GenericTypedParameterResolver<T> implements ParameterResolver {
-  T data;
+  final T data;
 
   public GenericTypedParameterResolver(T data) {
     this.data = data;

--- a/wrapper/src/test/java/integration/TestInstanceInfo.java
+++ b/wrapper/src/test/java/integration/TestInstanceInfo.java
@@ -49,7 +49,6 @@ public class TestInstanceInfo {
   }
 
   public String getUrl() {
-    String url = host + ":" + port + "/";
-    return url;
+    return host + ":" + port + "/";
   }
 }

--- a/wrapper/src/test/java/integration/container/ConnectionStringHelper.java
+++ b/wrapper/src/test/java/integration/container/ConnectionStringHelper.java
@@ -57,14 +57,13 @@ public class ConnectionStringHelper {
       String databaseName) {
     final DatabaseEngine databaseEngine = TestEnvironment.getCurrent().getInfo().getRequest().getDatabaseEngine();
     final String requiredParameters = DriverHelper.getDriverRequiredParameters(databaseEngine, testDriver);
-    final String url = DriverHelper.getDriverProtocol(databaseEngine, testDriver)
+    return DriverHelper.getDriverProtocol(databaseEngine, testDriver)
         + host
         + ":"
         + port
         + "/"
         + databaseName
         + requiredParameters;
-    return url;
   }
 
   public static String getWrapperUrlWithPlugins(String host, int port, String databaseName, String wrapperPlugins) {

--- a/wrapper/src/test/java/integration/container/TestDriverProvider.java
+++ b/wrapper/src/test/java/integration/container/TestDriverProvider.java
@@ -17,6 +17,7 @@
 package integration.container;
 
 import static java.util.Arrays.asList;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.platform.commons.util.AnnotationUtils.isAnnotated;
@@ -258,7 +259,7 @@ public class TestDriverProvider implements TestTemplateInvocationContextProvider
           instanceIDs = new ArrayList<>();
         }
       }
-      assertTrue(instanceIDs.size() > 0);
+      assertFalse(instanceIDs.isEmpty());
       assertTrue(
           auroraUtil.isDBInstanceWriter(
               testInfo.getRdsDbName(),

--- a/wrapper/src/test/java/integration/container/TestEnvironment.java
+++ b/wrapper/src/test/java/integration/container/TestEnvironment.java
@@ -41,13 +41,10 @@ import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Logger;
 import software.amazon.jdbc.Driver;
 import software.amazon.jdbc.util.StringUtils;
 
 public class TestEnvironment {
-
-  private static final Logger LOGGER = Logger.getLogger(TestEnvironment.class.getName());
 
   private static TestEnvironment env;
 
@@ -270,10 +267,7 @@ public class TestEnvironment {
         throw new UnsupportedOperationException(testDriver.toString());
     }
 
-    if (disabledByFeature || !driverCompatibleToDatabaseEngine) {
-      // this driver is disabled
-      return false;
-    }
-    return true;
+    // the driver is disabled when a feature disables it or it is incompatible with the engine
+    return !disabledByFeature && driverCompatibleToDatabaseEngine;
   }
 }

--- a/wrapper/src/test/java/integration/container/condition/EnableBasedOnEnvironmentFeatureExtension.java
+++ b/wrapper/src/test/java/integration/container/condition/EnableBasedOnEnvironmentFeatureExtension.java
@@ -18,15 +18,11 @@ package integration.container.condition;
 
 import integration.container.TestDriver;
 import integration.container.TestEnvironment;
-import java.util.logging.Logger;
 import org.junit.jupiter.api.extension.ConditionEvaluationResult;
 import org.junit.jupiter.api.extension.ExecutionCondition;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 public class EnableBasedOnEnvironmentFeatureExtension implements ExecutionCondition {
-
-  private static final Logger LOGGER =
-      Logger.getLogger(EnableBasedOnEnvironmentFeatureExtension.class.getName());
 
   private final TestDriver testDriver;
 

--- a/wrapper/src/test/java/integration/container/condition/EnableOnDatabaseEngineCondition.java
+++ b/wrapper/src/test/java/integration/container/condition/EnableOnDatabaseEngineCondition.java
@@ -21,15 +21,11 @@ import static org.junit.platform.commons.util.AnnotationUtils.findAnnotation;
 import integration.DatabaseEngine;
 import integration.container.TestEnvironment;
 import java.util.Arrays;
-import java.util.logging.Logger;
 import org.junit.jupiter.api.extension.ConditionEvaluationResult;
 import org.junit.jupiter.api.extension.ExecutionCondition;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 public class EnableOnDatabaseEngineCondition implements ExecutionCondition {
-
-  private static final Logger LOGGER =
-      Logger.getLogger(EnableOnDatabaseEngineCondition.class.getName());
 
   public EnableOnDatabaseEngineCondition() {}
 
@@ -46,7 +42,7 @@ public class EnableOnDatabaseEngineCondition implements ExecutionCondition {
                   if (annotation == null || annotation.value() == null) {
                     return true;
                   }
-                  return Arrays.stream(annotation.value()).anyMatch(v -> databaseEngine.equals(v));
+                  return Arrays.stream(annotation.value()).anyMatch(databaseEngine::equals);
                 }) //
             .orElse(true);
 

--- a/wrapper/src/test/java/integration/container/condition/EnableOnDatabaseEngineDeploymentCondition.java
+++ b/wrapper/src/test/java/integration/container/condition/EnableOnDatabaseEngineDeploymentCondition.java
@@ -21,15 +21,11 @@ import static org.junit.platform.commons.util.AnnotationUtils.findAnnotation;
 import integration.DatabaseEngineDeployment;
 import integration.container.TestEnvironment;
 import java.util.Arrays;
-import java.util.logging.Logger;
 import org.junit.jupiter.api.extension.ConditionEvaluationResult;
 import org.junit.jupiter.api.extension.ExecutionCondition;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 public class EnableOnDatabaseEngineDeploymentCondition implements ExecutionCondition {
-
-  private static final Logger LOGGER =
-      Logger.getLogger(EnableOnDatabaseEngineDeploymentCondition.class.getName());
 
   public EnableOnDatabaseEngineDeploymentCondition() {}
 
@@ -47,7 +43,7 @@ public class EnableOnDatabaseEngineDeploymentCondition implements ExecutionCondi
                     return true;
                   }
                   return Arrays.stream(annotation.value())
-                      .anyMatch(v -> databaseEngineDeployment.equals(v));
+                      .anyMatch(databaseEngineDeployment::equals);
                 }) //
             .orElse(true);
 

--- a/wrapper/src/test/java/integration/container/condition/EnableOnNumOfInstancesCondition.java
+++ b/wrapper/src/test/java/integration/container/condition/EnableOnNumOfInstancesCondition.java
@@ -19,15 +19,11 @@ package integration.container.condition;
 import static org.junit.platform.commons.util.AnnotationUtils.findAnnotation;
 
 import integration.container.TestEnvironment;
-import java.util.logging.Logger;
 import org.junit.jupiter.api.extension.ConditionEvaluationResult;
 import org.junit.jupiter.api.extension.ExecutionCondition;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 class EnableOnNumOfInstancesCondition implements ExecutionCondition {
-
-  private static final Logger LOGGER =
-      Logger.getLogger(EnableOnTestFeatureCondition.class.getName());
 
   public EnableOnNumOfInstancesCondition() {}
 
@@ -47,10 +43,7 @@ class EnableOnNumOfInstancesCondition implements ExecutionCondition {
                   if (annotation.min() > 0 && actualNumOfInstances < annotation.min()) {
                     return false;
                   }
-                  if (annotation.max() > 0 && actualNumOfInstances > annotation.max()) {
-                    return false;
-                  }
-                  return true;
+                  return !(annotation.max() > 0 && actualNumOfInstances > annotation.max());
                 }) //
             .orElse(true);
 

--- a/wrapper/src/test/java/integration/container/condition/EnableOnTestFeatureCondition.java
+++ b/wrapper/src/test/java/integration/container/condition/EnableOnTestFeatureCondition.java
@@ -22,15 +22,11 @@ import integration.TestEnvironmentFeatures;
 import integration.container.TestEnvironment;
 import java.util.Arrays;
 import java.util.EnumSet;
-import java.util.logging.Logger;
 import org.junit.jupiter.api.extension.ConditionEvaluationResult;
 import org.junit.jupiter.api.extension.ExecutionCondition;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 class EnableOnTestFeatureCondition implements ExecutionCondition {
-
-  private static final Logger LOGGER =
-      Logger.getLogger(EnableOnTestFeatureCondition.class.getName());
 
   public EnableOnTestFeatureCondition() {}
 
@@ -47,7 +43,7 @@ class EnableOnTestFeatureCondition implements ExecutionCondition {
                   if (annotation == null || annotation.value() == null) {
                     return true;
                   }
-                  return Arrays.stream(annotation.value()).allMatch(v -> features.contains(v));
+                  return Arrays.stream(annotation.value()).allMatch(features::contains);
                 })
             .orElse(true);
 

--- a/wrapper/src/test/java/integration/container/tests/AutoReadWriteSplittingTests.java
+++ b/wrapper/src/test/java/integration/container/tests/AutoReadWriteSplittingTests.java
@@ -93,21 +93,21 @@ public class AutoReadWriteSplittingTests extends ReadWriteSplittingTests {
   @Disabled("SQL routing reroutes 'START TRANSACTION READ ONLY' before the transaction is active, "
       + "so this setReadOnly-oriented expectation does not apply to autoReadWriteSplitting.")
   @Override
-  public void test_setReadOnlyFalseInReadOnlyTransaction() throws SQLException {
+  public void test_setReadOnlyFalseInReadOnlyTransaction() {
   }
 
   @TestTemplate
   @Disabled("SQL routing may reroute the post-write SELECT to a reader (subject to replication lag), "
       + "so this setReadOnly-oriented expectation does not apply to autoReadWriteSplitting.")
   @Override
-  public void test_setReadOnlyTrueInTransaction() throws SQLException {
+  public void test_setReadOnlyTrueInTransaction() {
   }
 
   @TestTemplate
   @Disabled("SQL routing reroutes the raw SELECT to a reader, changing the stale-statement semantics "
       + "this test relies on; not applicable to autoReadWriteSplitting.")
   @Override
-  public void test_executeWithOldConnection() throws SQLException {
+  public void test_executeWithOldConnection() {
   }
 
   @TestTemplate
@@ -115,7 +115,7 @@ public class AutoReadWriteSplittingTests extends ReadWriteSplittingTests {
       + "setReadOnly(false) does not switch back to the writer here; this setReadOnly-oriented "
       + "expectation does not apply to autoReadWriteSplitting.")
   @Override
-  public void test_setReadOnlyFalseInTransaction_setAutocommitFalse() throws SQLException {
+  public void test_setReadOnlyFalseInTransaction_setAutocommitFalse() {
   }
 
   @TestTemplate

--- a/wrapper/src/test/java/integration/container/tests/AutoSimpleReadWriteSplittingTests.java
+++ b/wrapper/src/test/java/integration/container/tests/AutoSimpleReadWriteSplittingTests.java
@@ -62,21 +62,21 @@ public class AutoSimpleReadWriteSplittingTests extends SimpleReadWriteSplittingT
   @Disabled("SQL routing reroutes 'START TRANSACTION READ ONLY' before the transaction is active, "
       + "so this setReadOnly-oriented expectation does not apply to autoSimpleReadWriteSplitting.")
   @Override
-  public void test_setReadOnlyFalseInReadOnlyTransaction() throws SQLException {
+  public void test_setReadOnlyFalseInReadOnlyTransaction() {
   }
 
   @TestTemplate
   @Disabled("SQL routing may reroute the post-write SELECT to the read endpoint (subject to "
       + "replication lag), so this expectation does not apply to autoSimpleReadWriteSplitting.")
   @Override
-  public void test_setReadOnlyTrueInTransaction() throws SQLException {
+  public void test_setReadOnlyTrueInTransaction() {
   }
 
   @TestTemplate
   @Disabled("SQL routing reroutes the raw SELECT to the read endpoint, changing the stale-statement "
       + "semantics this test relies on; not applicable to autoSimpleReadWriteSplitting.")
   @Override
-  public void test_executeWithOldConnection() throws SQLException {
+  public void test_executeWithOldConnection() {
   }
 
   @TestTemplate
@@ -84,13 +84,13 @@ public class AutoSimpleReadWriteSplittingTests extends SimpleReadWriteSplittingT
       + "setReadOnly(false) does not switch back to the writer here; this setReadOnly-oriented "
       + "expectation does not apply to autoSimpleReadWriteSplitting.")
   @Override
-  public void test_setReadOnlyFalseInTransaction_setAutocommitFalse() throws SQLException {
+  public void test_setReadOnlyFalseInTransaction_setAutocommitFalse() {
   }
 
   @TestTemplate
   @Disabled("With autocommit disabled the connection is pinned, so setReadOnly(true) does not "
       + "switch to the read endpoint; this expectation does not apply to autoSimpleReadWriteSplitting.")
   @Override
-  public void test_autoCommitStatePreserved_acrossConnectionSwitches() throws SQLException {
+  public void test_autoCommitStatePreserved_acrossConnectionSwitches() {
   }
 }

--- a/wrapper/src/test/java/integration/container/tests/AwsIamIntegrationTest.java
+++ b/wrapper/src/test/java/integration/container/tests/AwsIamIntegrationTest.java
@@ -17,6 +17,7 @@
 package integration.container.tests;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import integration.DatabaseEngine;
@@ -40,7 +41,6 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Logger;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.MethodOrderer;
@@ -89,8 +89,6 @@ import software.amazon.jdbc.profile.DriverConfigurationProfiles;
 // rather than a clear password, to a DB server and that leads to 'Access denied' error.
 // So taking that into account, all IAM tests are disabled for MariaDb driver.
 public class AwsIamIntegrationTest {
-
-  private static final Logger LOGGER = Logger.getLogger(AwsIamIntegrationTest.class.getName());
 
   @BeforeEach
   public void beforeEach() {
@@ -304,7 +302,7 @@ public class AwsIamIntegrationTest {
     // isolating the assertion to the topology monitor's own connections.
     ConfigurationProfileBuilder.get()
         .withName(profileName)
-        .withPluginFactories(Arrays.<Class<? extends ConnectionPluginFactory>>asList(
+        .withPluginFactories(Arrays.asList(
             IamAuthConnectionPluginFactory.class,
             AuroraConnectionTrackerPluginFactory.class,
             software.amazon.jdbc.plugin.failover2.FailoverConnectionPluginFactory.class))
@@ -344,8 +342,8 @@ public class AwsIamIntegrationTest {
             "The cluster topology monitor failed to refresh topology on an IAM-only database. This indicates the "
                 + "monitor did not inherit the IAM plugin from the class-based ConfigurationProfile and fell back to "
                 + "the default plugin list.");
-        assertTrue(
-            pluginService.getAllHosts().size() >= 1,
+        assertFalse(
+            pluginService.getAllHosts().isEmpty(),
             "Expected the topology monitor to have discovered at least one cluster host.");
       }
     } finally {

--- a/wrapper/src/test/java/integration/container/tests/BasicConnectivityTests.java
+++ b/wrapper/src/test/java/integration/container/tests/BasicConnectivityTests.java
@@ -18,6 +18,7 @@ package integration.container.tests;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -241,7 +242,7 @@ public class BasicConnectivityTests {
     try (Connection conn =
         DriverManager.getConnection(url, ConnectionStringHelper.getDefaultPropertiesWithNoPlugins())) {
 
-      assertTrue(conn instanceof ConnectionWrapper);
+      assertInstanceOf(ConnectionWrapper.class, conn);
       assertTrue(conn.isValid(10));
     }
   }

--- a/wrapper/src/test/java/integration/container/tests/BlueGreenDeploymentTests.java
+++ b/wrapper/src/test/java/integration/container/tests/BlueGreenDeploymentTests.java
@@ -507,7 +507,7 @@ public class BlueGreenDeploymentTests {
         while (!stop.get()) {
           try  {
             final Statement statement = conn.createStatement();
-            final ResultSet result = statement.executeQuery("SELECT 1");
+            statement.executeQuery("SELECT 1");
             TimeUnit.SECONDS.sleep(1);
           } catch (SQLException throwable) {
             LOGGER.finest(String.format("[DirectBlueConnectivity @ %s] thread exception: %s", hostId, throwable));
@@ -611,7 +611,7 @@ public class BlueGreenDeploymentTests {
     return new Thread(() -> {
 
       Connection conn = null;
-      BlueGreenConnectionPlugin bgPlugin = null;
+      BlueGreenConnectionPlugin bgPlugin;
 
       String query;
       switch (TestEnvironment.getCurrent().getInfo().getRequest().getDatabaseEngine()) {
@@ -738,7 +738,7 @@ public class BlueGreenDeploymentTests {
     return new Thread(() -> {
 
       Connection conn = null;
-      BlueGreenConnectionPlugin bgPlugin = null;
+      BlueGreenConnectionPlugin bgPlugin;
       try {
         final Properties props = this.getWrapperConnectionProperties();
 
@@ -833,7 +833,7 @@ public class BlueGreenDeploymentTests {
     return new Thread(() -> {
 
       Connection conn = null;
-      String originalBlueIp = null;
+      String originalBlueIp;
       try {
         final Properties props = this.getWrapperConnectionProperties();
         final String url = ConnectionStringHelper.getWrapperUrlWithPlugins(
@@ -950,7 +950,7 @@ public class BlueGreenDeploymentTests {
         while (!stop.get()) {
           TimeUnit.SECONDS.sleep(1);
           try {
-            String tmp = InetAddress.getByName(host).getHostAddress();
+            InetAddress.getByName(host).getHostAddress();
           } catch (UnknownHostException unknownHostException) {
             results.dnsGreenRemovedTime.set(System.nanoTime());
             break;
@@ -1180,7 +1180,7 @@ public class BlueGreenDeploymentTests {
           try  {
             final Statement statement = conn.createStatement();
             startTime = System.nanoTime();
-            final ResultSet result = statement.executeQuery("SELECT 1");
+            statement.executeQuery("SELECT 1");
             long endTime = System.nanoTime();
             results.greenWrapperExecuteTimes.add(new TimeHolder(startTime, endTime, bgPlugin.getHoldTimeNano()));
             TimeUnit.SECONDS.sleep(1);

--- a/wrapper/src/test/java/integration/container/tests/DataSourceTests.java
+++ b/wrapper/src/test/java/integration/container/tests/DataSourceTests.java
@@ -17,6 +17,7 @@
 package integration.container.tests;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -35,7 +36,6 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Hashtable;
 import java.util.Properties;
-import java.util.logging.Logger;
 import javax.naming.Context;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
@@ -59,8 +59,6 @@ import software.amazon.jdbc.wrapper.ConnectionWrapper;
     TestEnvironmentFeatures.RUN_DB_METRICS_ONLY})
 @Order(6)
 public class DataSourceTests {
-
-  private static final Logger LOGGER = Logger.getLogger(DataSourceTests.class.getName());
 
   @TestTemplate
   @DisableOnTestDriver(TestDriver.MARIADB)
@@ -164,7 +162,7 @@ public class DataSourceTests {
             TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getUsername(),
             TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getPassword())) {
 
-      assertTrue(conn instanceof ConnectionWrapper);
+      assertInstanceOf(ConnectionWrapper.class, conn);
       assertTrue(conn.isWrapperFor(DriverHelper.getConnectionClass()));
       assertEquals(
           conn.getCatalog(),

--- a/wrapper/src/test/java/integration/container/tests/DriverConfigurationProfileTests.java
+++ b/wrapper/src/test/java/integration/container/tests/DriverConfigurationProfileTests.java
@@ -17,6 +17,7 @@
 package integration.container.tests;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -87,19 +88,19 @@ public class DriverConfigurationProfileTests {
 
     Connection conn = DriverManager.getConnection(ConnectionStringHelper.getWrapperUrl(), props);
 
-    assertTrue(conn instanceof ConnectionWrapper);
+    assertInstanceOf(ConnectionWrapper.class, conn);
     assertTrue(conn.isWrapperFor(DriverHelper.getConnectionClass()));
 
     assertTrue(conn.isValid(10));
 
     Statement statement = conn.createStatement();
     assertNotNull(statement);
-    assertTrue(statement instanceof StatementWrapper);
+    assertInstanceOf(StatementWrapper.class, statement);
 
     int rnd = new Random().nextInt(100);
     ResultSet resultSet = statement.executeQuery("SELECT " + rnd);
     assertNotNull(resultSet);
-    assertTrue(resultSet instanceof ResultSetWrapper);
+    assertInstanceOf(ResultSetWrapper.class, resultSet);
 
     resultSet.next();
     int result = resultSet.getInt(1);

--- a/wrapper/src/test/java/integration/container/tests/EFM2Test.java
+++ b/wrapper/src/test/java/integration/container/tests/EFM2Test.java
@@ -37,7 +37,6 @@ import java.util.Properties;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Logger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.MethodOrderer;
@@ -65,7 +64,6 @@ import software.amazon.jdbc.plugin.efm.base.HostMonitoringConnectionBasePlugin;
     TestEnvironmentFeatures.RUN_DB_METRICS_ONLY})
 @Order(15)
 public class EFM2Test {
-  private static final Logger LOGGER = Logger.getLogger(ReadWriteSplittingTests.class.getName());
   protected static final AuroraTestUtility auroraUtil = AuroraTestUtility.getUtility();
   protected ExecutorService executor = Executors.newFixedThreadPool(1, r -> {
     final Thread thread = new Thread(r);

--- a/wrapper/src/test/java/integration/container/tests/FailoverTest.java
+++ b/wrapper/src/test/java/integration/container/tests/FailoverTest.java
@@ -261,7 +261,7 @@ public class FailoverTest {
   @TestTemplate
   @EnableOnNumOfInstances(min = 2)
   public void test_writerFailWithinTransaction_startTransaction()
-      throws SQLException, InterruptedException {
+      throws SQLException {
 
     final String initialWriterId = this.currentWriter;
     TestInstanceInfo initialWriterInstanceInfo =

--- a/wrapper/src/test/java/integration/container/tests/KmsEncryptionIntegrationTest.java
+++ b/wrapper/src/test/java/integration/container/tests/KmsEncryptionIntegrationTest.java
@@ -157,7 +157,7 @@ public class KmsEncryptionIntegrationTest {
   }
 
   @AfterEach
-  void cleanupTestData() throws Exception {
+  void cleanupTestData() {
     // Clean up test data between tests without dropping schema
     /*
     if (connection != null && !connection.isClosed()) {

--- a/wrapper/src/test/java/integration/container/tests/LogQueryPluginTests.java
+++ b/wrapper/src/test/java/integration/container/tests/LogQueryPluginTests.java
@@ -55,8 +55,6 @@ import software.amazon.jdbc.plugin.LogQueryConnectionPlugin;
 @Order(9)
 public class LogQueryPluginTests {
 
-  private static final Logger LOGGER = Logger.getLogger(LogQueryPluginTests.class.getName());
-
   @TestTemplate
   public void testStatementExecuteQueryWithArg() throws SQLException, UnsupportedEncodingException {
 
@@ -81,7 +79,7 @@ public class LogQueryPluginTests {
     conn.close();
 
     handler.flush();
-    String logMessages = new String(os.toByteArray(), "UTF-8");
+    String logMessages = os.toString("UTF-8");
     assertTrue(logMessages.contains("[Statement.executeQuery] Executing query: SELECT 100"));
   }
 
@@ -110,7 +108,7 @@ public class LogQueryPluginTests {
     conn.close();
 
     handler.flush();
-    String logMessages = new String(os.toByteArray(), "UTF-8");
+    String logMessages = os.toString("UTF-8");
     assertTrue(
         logMessages.contains("[PreparedStatement.executeQuery] Executing query: SELECT 12345 * ?"));
   }

--- a/wrapper/src/test/java/integration/container/tests/RemoteQueryCachePluginTests.java
+++ b/wrapper/src/test/java/integration/container/tests/RemoteQueryCachePluginTests.java
@@ -61,7 +61,7 @@ import software.amazon.jdbc.plugin.cache.CachedResultSet;
 public class RemoteQueryCachePluginTests {
 
   @AfterEach
-  public void afterEach() throws Exception {
+  public void afterEach() {
     // Clear the static connection pool registry to prevent test pollution
     CacheConnection.clearEndpointPoolRegistry();
   }

--- a/wrapper/src/test/java/integration/container/tests/SimpleReadWriteSplittingTests.java
+++ b/wrapper/src/test/java/integration/container/tests/SimpleReadWriteSplittingTests.java
@@ -180,7 +180,7 @@ public class SimpleReadWriteSplittingTests extends ReadWriteSplittingTests {
   @TestTemplate
   @Disabled("Skipping because it's not applicable to SimpleReadWriteSplitting.")
   @Override
-  public void test_connectToReader_setReadOnlyTrueFalse() throws SQLException {
+  public void test_connectToReader_setReadOnlyTrueFalse() {
     // This test checks that the connection does not change when setReadOnly(true)
     // is called on a connection initially made with a reader instance endpoint.
     // Not applicable, srw will change the connection to the srwReadEndpoint.
@@ -221,7 +221,7 @@ public class SimpleReadWriteSplittingTests extends ReadWriteSplittingTests {
       + "rather than a topology instance, so disabling a single reader instance does not make the "
       + "read endpoint unreachable and there is nothing to fall back from to the writer.")
   @Override
-  public void test_setReadOnlyTrue_oneReaderDown_fallsBackToWriter() throws SQLException {
+  public void test_setReadOnlyTrue_oneReaderDown_fallsBackToWriter() {
     // Not applicable: srw routes to the configured read/write endpoints, not per-instance topology.
   }
 
@@ -230,7 +230,7 @@ public class SimpleReadWriteSplittingTests extends ReadWriteSplittingTests {
       + "rather than a topology instance, so disabling a single reader instance does not make the "
       + "read endpoint unreachable — the read does not fail, so there is no exception to expect.")
   @Override
-  public void test_setReadOnlyTrue_oneReaderDown_readThrows() throws SQLException {
+  public void test_setReadOnlyTrue_oneReaderDown_readThrows() {
     // Not applicable: srw routes to the configured read/write endpoints, not per-instance topology.
   }
 
@@ -239,7 +239,7 @@ public class SimpleReadWriteSplittingTests extends ReadWriteSplittingTests {
       + "rather than a topology instance, so disabling a single reader instance does not make the "
       + "read endpoint unreachable — failover is not triggered, so there is nothing to recover from.")
   @Override
-  public void test_setReadOnlyTrue_oneReaderDown_failoverRecovers() throws SQLException {
+  public void test_setReadOnlyTrue_oneReaderDown_failoverRecovers() {
     // Not applicable: srw routes to the configured read/write endpoints, not per-instance topology.
   }
 
@@ -249,8 +249,7 @@ public class SimpleReadWriteSplittingTests extends ReadWriteSplittingTests {
       + "no role verification the read endpoint may transiently resolve (stale DNS) to the promoted "
       + "writer. This is a topology-failover expectation that does not map to the endpoint model.")
   @Override
-  public void test_cachedReaderPromotedToWriter_switchesToDifferentReader()
-      throws SQLException, InterruptedException {
+  public void test_cachedReaderPromotedToWriter_switchesToDifferentReader() {
     // Not applicable: srw has a single fixed read endpoint and no per-instance reader selection.
   }
 }

--- a/wrapper/src/test/java/integration/container/tests/SpringCachingTests.java
+++ b/wrapper/src/test/java/integration/container/tests/SpringCachingTests.java
@@ -59,7 +59,7 @@ import software.amazon.jdbc.plugin.cache.CacheConnection;
 public class SpringCachingTests {
 
   @AfterEach
-  public void afterEach() throws Exception {
+  public void afterEach() {
     // Clear the static connection pool registry to prevent test pollution
     CacheConnection.clearEndpointPoolRegistry();
   }
@@ -81,7 +81,7 @@ public class SpringCachingTests {
   }
 
   @TestTemplate
-  public void testWrongAuthFallsBackToDatabase() throws Exception {
+  public void testWrongAuthFallsBackToDatabase() {
     // Use WRONG cache credentials
     JdbcTemplate jdbcTemplate = new JdbcTemplate(getDataSource("wrong-password", 0, true, false));
 

--- a/wrapper/src/test/java/integration/container/tests/XaTransactionTest.java
+++ b/wrapper/src/test/java/integration/container/tests/XaTransactionTest.java
@@ -17,7 +17,7 @@
 package integration.container.tests;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -127,7 +127,7 @@ public class XaTransactionTest {
     final XAConnection xaConn = ds.getXAConnection();
     try {
       final Connection conn = xaConn.getConnection();
-      assertTrue(conn instanceof ConnectionWrapper);
+      assertInstanceOf(ConnectionWrapper.class, conn);
       assertNotNull(xaConn.getXAResource());
     } finally {
       xaConn.close();
@@ -290,8 +290,7 @@ public class XaTransactionTest {
    * while a transaction is active (PostgreSQL). The rejection happens client-side, before any
    * statement is sent, so the XA branch remains usable.
    */
-  private static void setReadOnlyIgnoringDriverRejection(final Connection conn, final boolean readOnly)
-      throws SQLException {
+  private static void setReadOnlyIgnoringDriverRejection(final Connection conn, final boolean readOnly) {
     try {
       conn.setReadOnly(readOnly);
     } catch (final SQLException e) {

--- a/wrapper/src/test/java/integration/container/tests/metrics/DatabasePerformanceMetricTest.java
+++ b/wrapper/src/test/java/integration/container/tests/metrics/DatabasePerformanceMetricTest.java
@@ -794,7 +794,7 @@ public class DatabasePerformanceMetricTest {
     this.topologyEvents.stream().collect(groupingBy(x -> x.nodeId, toList()))
         .forEach((key, value) -> {
           final ArrayList<TopologyEventHolder> sortedEvents = value.stream()
-              .sorted(Comparator.comparingLong(y -> y.getOffsetTimeMs()))
+              .sorted(Comparator.comparingLong(TopologyEventHolder::getOffsetTimeMs))
               .collect(Collectors.toCollection(ArrayList::new));
           sortedEventsByOffsetTime.put(key, sortedEvents);
         });
@@ -809,7 +809,7 @@ public class DatabasePerformanceMetricTest {
             .findFirst().orElse(null))
         .collect(toSet());
 
-    if (startWriterIds.size() == 0) {
+    if (startWriterIds.isEmpty()) {
       runData.topologyError = "Can't identify start writer node.";
       return;
     }
@@ -831,7 +831,7 @@ public class DatabasePerformanceMetricTest {
             .findFirst().orElse(null))
         .collect(toSet());
 
-    if (endWriterIds.size() == 0) {
+    if (endWriterIds.isEmpty()) {
       runData.topologyError = "Can't identify end writer node.";
       return;
     }

--- a/wrapper/src/test/java/integration/host/TestEnvironment.java
+++ b/wrapper/src/test/java/integration/host/TestEnvironment.java
@@ -35,7 +35,6 @@ import integration.host.TestEnvironmentProvider.EnvPreCreateInfo;
 import integration.util.AuroraTestUtility;
 import integration.util.ContainerHelper;
 import java.io.IOException;
-import java.net.URISyntaxException;
 import java.net.UnknownHostException;
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -119,7 +118,7 @@ public class TestEnvironment implements AutoCloseable {
     this.info.setRequest(request);
   }
 
-  public static TestEnvironment build(TestEnvironmentRequest request) throws IOException, URISyntaxException {
+  public static TestEnvironment build(TestEnvironmentRequest request) throws IOException {
     LOGGER.finest("Building test env: " + request.getEnvPreCreateIndex());
     preCreateEnvironment(request.getEnvPreCreateIndex());
 

--- a/wrapper/src/test/java/integration/host/TestEnvironmentConfiguration.java
+++ b/wrapper/src/test/java/integration/host/TestEnvironmentConfiguration.java
@@ -18,81 +18,81 @@ package integration.host;
 
 public class TestEnvironmentConfiguration {
 
-  public boolean noDocker =
+  public final boolean noDocker =
       Boolean.parseBoolean(System.getProperty("test-no-docker", "false"));
-  public boolean noAurora =
+  public final boolean noAurora =
       Boolean.parseBoolean(System.getProperty("test-no-aurora", "false"));
-  public boolean noMultiAzCluster =
+  public final boolean noMultiAzCluster =
       Boolean.parseBoolean(System.getProperty("test-no-multi-az-cluster", "false"));
-  public boolean noMultiAzInstance =
+  public final boolean noMultiAzInstance =
       Boolean.parseBoolean(System.getProperty("test-no-multi-az-instance", "false"));
-  public boolean noPerformance =
+  public final boolean noPerformance =
       Boolean.parseBoolean(System.getProperty("test-no-performance", "false"));
-  public boolean noMysqlEngine =
+  public final boolean noMysqlEngine =
       Boolean.parseBoolean(System.getProperty("test-no-mysql-engine", "false"));
-  public boolean noMysqlDriver =
+  public final boolean noMysqlDriver =
       Boolean.parseBoolean(System.getProperty("test-no-mysql-driver", "false"));
-  public boolean noPgEngine =
+  public final boolean noPgEngine =
       Boolean.parseBoolean(System.getProperty("test-no-pg-engine", "false"));
-  public boolean noPgDriver =
+  public final boolean noPgDriver =
       Boolean.parseBoolean(System.getProperty("test-no-pg-driver", "false"));
-  public boolean noMariadbEngine =
+  public final boolean noMariadbEngine =
       Boolean.parseBoolean(System.getProperty("test-no-mariadb-engine", "false"));
-  public boolean noMariadbDriver =
+  public final boolean noMariadbDriver =
       Boolean.parseBoolean(System.getProperty("test-no-mariadb-driver", "false"));
-  public boolean noFailover =
+  public final boolean noFailover =
       Boolean.parseBoolean(System.getProperty("test-no-failover", "false"));
-  public boolean noIam =
+  public final boolean noIam =
       Boolean.parseBoolean(System.getProperty("test-no-iam", "false"));
-  public boolean noSecretsManager =
+  public final boolean noSecretsManager =
       Boolean.parseBoolean(System.getProperty("test-no-secrets-manager", "false"));
-  public boolean noHikari =
+  public final boolean noHikari =
       Boolean.parseBoolean(System.getProperty("test-no-hikari", "false"));
-  public boolean noGraalVm =
+  public final boolean noGraalVm =
       Boolean.parseBoolean(System.getProperty("test-no-graalvm", "false"));
-  public boolean noOpenJdk =
+  public final boolean noOpenJdk =
       Boolean.parseBoolean(System.getProperty("test-no-openjdk", "false"));
-  public boolean noOpenJdk8 =
+  public final boolean noOpenJdk8 =
       Boolean.parseBoolean(System.getProperty("test-no-openjdk8", "false"));
-  public boolean noOpenJdk11 =
+  public final boolean noOpenJdk11 =
       Boolean.parseBoolean(System.getProperty("test-no-openjdk11", "false"));
-  public boolean noOpenJdk17 =
+  public final boolean noOpenJdk17 =
       Boolean.parseBoolean(System.getProperty("test-no-openjdk17", "false"));
-  public boolean noOpenJdk21 =
+  public final boolean noOpenJdk21 =
       Boolean.parseBoolean(System.getProperty("test-no-openjdk21", "false"));
-  public boolean noOpenJdk24 =
+  public final boolean noOpenJdk24 =
       Boolean.parseBoolean(System.getProperty("test-no-openjdk24", "false"));
-  public boolean testHibernateOnly =
+  public final boolean testHibernateOnly =
       Boolean.parseBoolean(System.getProperty("test-hibernate-only", "false"));
-  public boolean testAutoscalingOnly =
+  public final boolean testAutoscalingOnly =
       Boolean.parseBoolean(System.getProperty("test-autoscaling-only", "false"));
-  public boolean testEncryptionOnly =
+  public final boolean testEncryptionOnly =
       Boolean.parseBoolean(System.getProperty("test-encryption-only", "false"));
-  public boolean testMetricsOnly =
+  public final boolean testMetricsOnly =
       Boolean.parseBoolean(System.getProperty("test-metrics-only", "false"));
 
-  public boolean noInstances1 =
+  public final boolean noInstances1 =
       Boolean.parseBoolean(System.getProperty("test-no-instances-1", "false"));
-  public boolean noInstances2 =
+  public final boolean noInstances2 =
       Boolean.parseBoolean(System.getProperty("test-no-instances-2", "false"));
-  public boolean noInstances3 =
+  public final boolean noInstances3 =
       Boolean.parseBoolean(System.getProperty("test-no-instances-3", "false"));
-  public boolean noInstances5 =
+  public final boolean noInstances5 =
       Boolean.parseBoolean(System.getProperty("test-no-instances-5", "false"));
 
-  public boolean noTracesTelemetry =
+  public final boolean noTracesTelemetry =
       Boolean.parseBoolean(System.getProperty("test-no-traces-telemetry", "false"));
-  public boolean noMetricsTelemetry =
+  public final boolean noMetricsTelemetry =
       Boolean.parseBoolean(System.getProperty("test-no-metrics-telemetry", "false"));
-  public boolean noBlueGreen =
+  public final boolean noBlueGreen =
       Boolean.parseBoolean(System.getProperty("test-no-bg", "true"));
-  public boolean testBlueGreenOnly =
+  public final boolean testBlueGreenOnly =
       Boolean.parseBoolean(System.getProperty("test-bg-only", "false"));
-  public boolean testValkeyCache =
+  public final boolean testValkeyCache =
       Boolean.parseBoolean(System.getProperty("test-valkey-cache", "false"));
 
-  public String includeTags = System.getProperty("test-include-tags");
-  public String excludeTags = System.getProperty("test-exclude-tags");
+  public final String includeTags = System.getProperty("test-include-tags");
+  public final String excludeTags = System.getProperty("test-exclude-tags");
 
   /**
    * Splits the in-container integration test classes across several CI jobs so they can run in
@@ -103,34 +103,34 @@ public class TestEnvironmentConfiguration {
    * <p>Only test class selection is affected. Which environments (deployment, engine, instance
    * count) are exercised is still controlled by the {@code test-no-*} properties.
    */
-  public int shardIndex = Integer.parseInt(System.getProperty("test-shard-index", "1"));
-  public int shardCount = Integer.parseInt(System.getProperty("test-shard-count", "1"));
+  public final int shardIndex = Integer.parseInt(System.getProperty("test-shard-index", "1"));
+  public final int shardCount = Integer.parseInt(System.getProperty("test-shard-count", "1"));
 
-  public String rdsDbRegion = System.getenv("RDS_DB_REGION");
+  public final String rdsDbRegion = System.getenv("RDS_DB_REGION");
 
-  public boolean reuseRdsDb = Boolean.parseBoolean(System.getenv("REUSE_RDS_DB"));
-  public String rdsDbName = System.getenv("RDS_DB_NAME"); // "cluster-mysql", "instance-name", "cluster-multi-az-name"
-  public String rdsDbDomain =
+  public final boolean reuseRdsDb = Boolean.parseBoolean(System.getenv("REUSE_RDS_DB"));
+  public final String rdsDbName = System.getenv("RDS_DB_NAME"); // "cluster-mysql", "instance-name", "cluster-multi-az-name"
+  public final String rdsDbDomain =
       System.getenv("RDS_DB_DOMAIN"); // "XYZ.us-west-2.rds.amazonaws.com"
 
-  public String rdsEndpoint =
+  public final String rdsEndpoint =
       System.getenv("RDS_ENDPOINT"); // "https://rds-int.amazon.com"
 
   // Expected values: "latest", "default", or engine version, for example, "15.4"
   // If left as empty, will use default version
-  public String mysqlVersion =
+  public final String mysqlVersion =
       System.getenv("MYSQL_VERSION");
-  public String pgVersion =
+  public final String pgVersion =
       System.getenv("PG_VERSION");
 
-  public String dbName = System.getenv("DB_DATABASE_NAME");
-  public String dbUsername = System.getenv("DB_USERNAME");
-  public String dbPassword = System.getenv("DB_PASSWORD");
+  public final String dbName = System.getenv("DB_DATABASE_NAME");
+  public final String dbUsername = System.getenv("DB_USERNAME");
+  public final String dbPassword = System.getenv("DB_PASSWORD");
 
-  public String awsAccessKeyId = System.getenv("AWS_ACCESS_KEY_ID");
-  public String awsSecretAccessKey = System.getenv("AWS_SECRET_ACCESS_KEY");
-  public String awsSessionToken = System.getenv("AWS_SESSION_TOKEN");
-  public String kmsKeyId = System.getenv("KMS_KEY_ID");
-  public String iamUser = System.getenv("IAM_USER");
+  public final String awsAccessKeyId = System.getenv("AWS_ACCESS_KEY_ID");
+  public final String awsSecretAccessKey = System.getenv("AWS_SECRET_ACCESS_KEY");
+  public final String awsSessionToken = System.getenv("AWS_SESSION_TOKEN");
+  public final String kmsKeyId = System.getenv("KMS_KEY_ID");
+  public final String iamUser = System.getenv("IAM_USER");
   
 }

--- a/wrapper/src/test/java/integration/host/TestEnvironmentConfiguration.java
+++ b/wrapper/src/test/java/integration/host/TestEnvironmentConfiguration.java
@@ -109,7 +109,10 @@ public class TestEnvironmentConfiguration {
   public final String rdsDbRegion = System.getenv("RDS_DB_REGION");
 
   public final boolean reuseRdsDb = Boolean.parseBoolean(System.getenv("REUSE_RDS_DB"));
-  public final String rdsDbName = System.getenv("RDS_DB_NAME"); // "cluster-mysql", "instance-name", "cluster-multi-az-name"
+
+  // "cluster-mysql", "instance-name", "cluster-multi-az-name"
+  public final String rdsDbName = System.getenv("RDS_DB_NAME");
+
   public final String rdsDbDomain =
       System.getenv("RDS_DB_DOMAIN"); // "XYZ.us-west-2.rds.amazonaws.com"
 
@@ -132,5 +135,5 @@ public class TestEnvironmentConfiguration {
   public final String awsSessionToken = System.getenv("AWS_SESSION_TOKEN");
   public final String kmsKeyId = System.getenv("KMS_KEY_ID");
   public final String iamUser = System.getenv("IAM_USER");
-  
+
 }

--- a/wrapper/src/test/java/integration/host/TestEnvironmentProvider.java
+++ b/wrapper/src/test/java/integration/host/TestEnvironmentProvider.java
@@ -241,7 +241,7 @@ public class TestEnvironmentProvider implements TestTemplateInvocationContextPro
 
       @Override
       public List<Extension> getAdditionalExtensions() {
-        return Collections.singletonList(new GenericTypedParameterResolver(info));
+        return Collections.singletonList(new GenericTypedParameterResolver<>(info));
       }
     };
   }
@@ -264,6 +264,6 @@ public class TestEnvironmentProvider implements TestTemplateInvocationContextPro
 
   public static class EnvPreCreateInfo {
     public TestEnvironmentRequest request;
-    public Future envPreCreateFuture;
+    public Future<?> envPreCreateFuture;
   }
 }

--- a/wrapper/src/test/java/integration/util/AuroraTestUtility.java
+++ b/wrapper/src/test/java/integration/util/AuroraTestUtility.java
@@ -103,7 +103,6 @@ import software.amazon.awssdk.services.rds.model.CreateDbClusterParameterGroupRe
 import software.amazon.awssdk.services.rds.model.CreateDbClusterParameterGroupResponse;
 import software.amazon.awssdk.services.rds.model.CreateDbClusterRequest;
 import software.amazon.awssdk.services.rds.model.CreateDbInstanceRequest;
-import software.amazon.awssdk.services.rds.model.CreateDbInstanceResponse;
 import software.amazon.awssdk.services.rds.model.CreateDbParameterGroupRequest;
 import software.amazon.awssdk.services.rds.model.CreateDbParameterGroupResponse;
 import software.amazon.awssdk.services.rds.model.DBCluster;
@@ -321,7 +320,7 @@ public class AuroraTestUtility {
       throw new UnsupportedOperationException(deployment.toString());
     }
 
-    CreateDbInstanceResponse response = rdsClient.createDBInstance(CreateDbInstanceRequest.builder()
+    rdsClient.createDBInstance(CreateDbInstanceRequest.builder()
         .dbInstanceIdentifier(identifier)
         .publiclyAccessible(true)
         .dbName(dbName)

--- a/wrapper/src/test/java/integration/util/ConsoleConsumer.java
+++ b/wrapper/src/test/java/integration/util/ConsoleConsumer.java
@@ -23,7 +23,7 @@ import software.amazon.jdbc.util.Messages;
 public class ConsoleConsumer
     extends BaseConsumer<org.testcontainers.containers.output.Slf4jLogConsumer> {
 
-  private boolean separateOutputStreams;
+  private final boolean separateOutputStreams;
 
   public ConsoleConsumer() {
     this(false);

--- a/wrapper/src/test/java/integration/util/ContainerHelper.java
+++ b/wrapper/src/test/java/integration/util/ContainerHelper.java
@@ -70,14 +70,6 @@ public class ContainerHelper {
   private static final String XRAY_TELEMETRY_IMAGE_NAME = "amazon/aws-xray-daemon";
   private static final String OTLP_TELEMETRY_IMAGE_NAME = "amazon/aws-otel-collector";
 
-  private static final String RETRIEVE_TOPOLOGY_SQL_POSTGRES =
-      "SELECT SERVER_ID, SESSION_ID FROM pg_catalog.aurora_replica_status() "
-          + "ORDER BY CASE WHEN SESSION_ID OPERATOR(pg_catalog.=) 'MASTER_SESSION_ID' THEN 0 ELSE 1 END";
-  private static final String RETRIEVE_TOPOLOGY_SQL_MYSQL =
-      "SELECT SERVER_ID, SESSION_ID FROM information_schema.replica_host_status "
-          + "ORDER BY IF(SESSION_ID = 'MASTER_SESSION_ID', 0, 1)";
-  private static final String SERVER_ID = "SERVER_ID";
-
   public Long runCmd(GenericContainer<?> container, String... cmd)
       throws IOException, InterruptedException {
     System.out.println("==== Container console feed ==== >>>>");
@@ -405,10 +397,10 @@ public class ContainerHelper {
         .withCommand("postgres", "-c", "max_prepared_transactions=10");
   }
 
-  public GenericContainer createPostgisContainer(
+  public GenericContainer<?> createPostgisContainer(
       Network network, String networkAlias, String testDbName, String username, String password) {
 
-    GenericContainer genericContainer = new GenericContainer(
+    GenericContainer<?> genericContainer = new GenericContainer<>(
         new ImageFromDockerfile()
             .withDockerfileFromBuilder(builder ->
                 builder

--- a/wrapper/src/test/java/integration/util/SimpleJndiContext.java
+++ b/wrapper/src/test/java/integration/util/SimpleJndiContext.java
@@ -35,7 +35,7 @@ import javax.naming.spi.ObjectFactory;
  * testing purposes. Objects are stored as references.
  */
 public class SimpleJndiContext implements Context {
-  private Map<String, Object> map = new HashMap<String, Object>();
+  private final Map<String, Object> map = new HashMap<>();
 
   public SimpleJndiContext() {
   }
@@ -76,92 +76,92 @@ public class SimpleJndiContext implements Context {
     map.put(name, ((Referenceable) obj).getReference());
   }
 
-  public void unbind(Name name) throws NamingException {
+  public void unbind(Name name) {
     unbind(name.get(0));
   }
 
-  public void unbind(String name) throws NamingException {
+  public void unbind(String name) {
     map.remove(name);
   }
 
-  public void rename(Name oldName, Name newName) throws NamingException {
+  public void rename(Name oldName, Name newName) {
     rename(oldName.get(0), newName.get(0));
   }
 
-  public void rename(String oldName, String newName) throws NamingException {
+  public void rename(String oldName, String newName) {
     map.put(newName, map.remove(oldName));
   }
 
-  public NamingEnumeration<NameClassPair> list(Name name) throws NamingException {
+  public NamingEnumeration<NameClassPair> list(Name name) {
     return null;
   }
 
-  public NamingEnumeration<NameClassPair> list(String name) throws NamingException {
+  public NamingEnumeration<NameClassPair> list(String name) {
     return null;
   }
 
-  public NamingEnumeration<Binding> listBindings(Name name) throws NamingException {
+  public NamingEnumeration<Binding> listBindings(Name name) {
     return null;
   }
 
-  public NamingEnumeration<Binding> listBindings(String name) throws NamingException {
+  public NamingEnumeration<Binding> listBindings(String name) {
     return null;
   }
 
-  public void destroySubcontext(Name name) throws NamingException {
+  public void destroySubcontext(Name name) {
   }
 
-  public void destroySubcontext(String name) throws NamingException {
+  public void destroySubcontext(String name) {
   }
 
-  public Context createSubcontext(Name name) throws NamingException {
+  public Context createSubcontext(Name name) {
     return null;
   }
 
-  public Context createSubcontext(String name) throws NamingException {
+  public Context createSubcontext(String name) {
     return null;
   }
 
-  public Object lookupLink(Name name) throws NamingException {
+  public Object lookupLink(Name name) {
     return null;
   }
 
-  public Object lookupLink(String name) throws NamingException {
+  public Object lookupLink(String name) {
     return null;
   }
 
-  public NameParser getNameParser(Name name) throws NamingException {
+  public NameParser getNameParser(Name name) {
     return null;
   }
 
-  public NameParser getNameParser(String name) throws NamingException {
+  public NameParser getNameParser(String name) {
     return null;
   }
 
-  public Name composeName(Name name, Name prefix) throws NamingException {
+  public Name composeName(Name name, Name prefix) {
     return null;
   }
 
-  public String composeName(String name, String prefix) throws NamingException {
+  public String composeName(String name, String prefix) {
     return null;
   }
 
-  public Object addToEnvironment(String propName, Object propVal) throws NamingException {
+  public Object addToEnvironment(String propName, Object propVal) {
     return null;
   }
 
-  public Object removeFromEnvironment(String propName) throws NamingException {
+  public Object removeFromEnvironment(String propName) {
     return null;
   }
 
-  public Hashtable<?, ?> getEnvironment() throws NamingException {
+  public Hashtable<?, ?> getEnvironment() {
     return null;
   }
 
-  public void close() throws NamingException {
+  public void close() {
   }
 
-  public String getNameInNamespace() throws NamingException {
+  public String getNameInNamespace() {
     return null;
   }
 }

--- a/wrapper/src/test/java/integration/util/SimpleJndiContextFactory.java
+++ b/wrapper/src/test/java/integration/util/SimpleJndiContextFactory.java
@@ -18,11 +18,10 @@ package integration.util;
 
 import java.util.Hashtable;
 import javax.naming.Context;
-import javax.naming.NamingException;
 import javax.naming.spi.InitialContextFactory;
 
 public class SimpleJndiContextFactory implements InitialContextFactory {
-  public Context getInitialContext(Hashtable<?, ?> environment) throws NamingException {
+  public Context getInitialContext(Hashtable<?, ?> environment) {
     return new SimpleJndiContext();
   }
 }


### PR DESCRIPTION
## Summary

Cleans up IntelliJ inspection warnings across the integration test sources
(`wrapper/src/test/java/integration/**`). All changes are mechanical and
behavior-preserving - structure changes only, never observable behavior.

33 files touched, driven by an IntelliJ headless code inspection scoped to the
integration test tree.

## What changed

- **Redundant `throws` removed** from methods that never throw the declared
  exception (mostly empty `@Disabled` override tests and `@AfterEach` hooks, plus
  the `SimpleJndiContext`/`SimpleJndiContextFactory` JNDI implementations). Kept
  `throws` wherever the body can actually throw (e.g. the `lookup`/`bind` chain,
  and `FailoverTest` which still throws `SQLException`).
- **`final`** added to effectively-final fields/locals (notably the 54
  system-property-backed fields in `TestEnvironmentConfiguration`, verified to have
  no reassignment anywhere in the project).
- **Assertion simplifications:** `assertTrue(x instanceof T)` -> `assertInstanceOf(T.class, x)`;
  `size() == 0` / `> 0` / `>= 1` -> `isEmpty()` / `assertFalse(...isEmpty())`.
- **Modernizations:** lambdas -> method references; raw types -> generics
  (`GenericContainer<?>`, `Future<?>`, diamond operator).
- **Dead code:** removed unused private fields, dead local variables, redundant
  `null` initializers, and unused imports - always preserving side-effecting calls
  (`executeQuery`, DNS lookups, etc.).

## Deliberately not changed

To keep the diff safe and focused, these were left alone:

- Noise categories: spellcheck, grammar, and SQL source-to-sink flow findings.
- Behavior-risky items: unused constructors (needed for Jackson deserialization),
  unused public helper methods (possible reflective use), unused method parameters
  (signature changes), JSON-serialized metrics fields, and
  `try (ResultSet rs = ...)` resources (removing them would skip auto-close).
- Findings needing judgment: `IgnoreResultOfCall`, `AutoCloseableResource`,
  `ConstantValue`, `DataFlowIssue`, `SameParameterValue`, and similar.
- `CharsetObjectCanBeUsed` on `ByteArrayOutputStream`: the `toString(Charset)` form
  is Java 10+, and the test sources target Java 8, so the Java 8-safe
  `toString("UTF-8")` was used instead.

## Testing

- `:aws-advanced-jdbc-wrapper:compileTestJava` - BUILD SUCCESSFUL
- `:aws-advanced-jdbc-wrapper:compileHibernateTestJava` (Java 17 source set) - BUILD SUCCESSFUL

The integration tests themselves require live RDS/Aurora clusters and containers,
so they were not executed locally; compilation of both test source sets is the
practical local check.
