### PR TITLE
fix: mask passwords in connection URLs before logging

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/Driver.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/Driver.java
@@ -172,7 +172,8 @@ public class Driver implements java.sql.Driver {
     // the driver's own messages are logged with a level the user hasn't asked for.
     LogUtils.applyLoggerLevel(props);
 
-    LOGGER.finest(() -> Messages.get("Driver.openingConnection", new Object[] {url}));
+    LOGGER.finest(() -> Messages.get("Driver.openingConnection",
+        new Object[] {ConnectionUrlParser.maskUrlPassword(url)}));
 
     LOGGER.finest(() -> PropertyUtils.logProperties(
         PropertyUtils.maskProperties(props), "Connecting with properties: \n"));

--- a/wrapper/src/main/java/software/amazon/jdbc/DriverConnectionProvider.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/DriverConnectionProvider.java
@@ -33,6 +33,7 @@ import software.amazon.jdbc.dialect.Dialect;
 import software.amazon.jdbc.exceptions.SQLLoginException;
 import software.amazon.jdbc.targetdriverdialect.ConnectInfo;
 import software.amazon.jdbc.targetdriverdialect.TargetDriverDialect;
+import software.amazon.jdbc.util.ConnectionUrlParser;
 import software.amazon.jdbc.util.Messages;
 import software.amazon.jdbc.util.Pair;
 import software.amazon.jdbc.util.PropertyUtils;
@@ -137,7 +138,7 @@ public class DriverConnectionProvider implements ConnectionProvider {
 
     final ConnectInfo connectInfo = targetDriverDialect.prepareConnectInfo(protocol, hostSpec, copy);
 
-    LOGGER.finest(() -> "Connecting to " + connectInfo.url
+    LOGGER.finest(() -> "Connecting to " + ConnectionUrlParser.maskUrlPassword(connectInfo.url)
         + PropertyUtils.logProperties(
             PropertyUtils.maskProperties(connectInfo.props),
         "\nwith properties: \n"));
@@ -195,7 +196,7 @@ public class DriverConnectionProvider implements ConnectionProvider {
 
       final ConnectInfo fixedConnectInfo = targetDriverDialect.prepareConnectInfo(protocol, connectionHostSpec, copy);
 
-      LOGGER.finest(() -> "Connecting to " + fixedConnectInfo.url
+      LOGGER.finest(() -> "Connecting to " + ConnectionUrlParser.maskUrlPassword(fixedConnectInfo.url)
           + " after correcting the hostname from " + originalHost
           + PropertyUtils.logProperties(
               PropertyUtils.maskProperties(fixedConnectInfo.props), "\nwith properties: \n"));

--- a/wrapper/src/main/java/software/amazon/jdbc/util/ConnectionUrlParser.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/ConnectionUrlParser.java
@@ -49,6 +49,12 @@ public class ConnectionUrlParser {
           Pattern.CASE_INSENSITIVE);
 
   static final Pattern EMPTY_STRING_IN_QUOTATIONS = Pattern.compile("\"(\\s*)\"");
+
+  // Matches a "password=<value>" query parameter (case-insensitive name), capturing the
+  // "password=" prefix so it can be preserved while the value is replaced when masking.
+  private static final Pattern PASSWORD_IN_URL_PATTERN =
+      Pattern.compile("(?i)(password=)[^&]*");
+
   private static final RdsUtils rdsUtils = new RdsUtils();
 
   public List<HostSpec> getHostsFromConnectionUrl(final String initialConnection,
@@ -218,6 +224,25 @@ public class ConnectionUrlParser {
     return null;
   }
 
+  /**
+   * Mask the value of any "password" query parameter in a connection URL so the URL can be safely
+   * logged. For example, "...?user=foo&password=secret" becomes "...?user=foo&password=***".
+   *
+   * @param url the connection URL, which may be null
+   * @return the URL with password values replaced by "***", or the input unchanged if it is null,
+   *         empty, or contains no password parameter
+   */
+  public static @Nullable String maskUrlPassword(final @Nullable String url) {
+    if (StringUtils.isNullOrEmpty(url)) {
+      return url;
+    }
+    return PASSWORD_IN_URL_PATTERN.matcher(url).replaceAll("$1***");
+  }
+
+  private static boolean isSecretParameter(final @Nullable String parameterName) {
+    return parameterName != null && parameterName.toLowerCase().contains("password");
+  }
+
   // Get the properties from a given url of the generic format:
   // "protocol//[hosts][/database][?properties]"
   public static void parsePropertiesFromUrl(final String url, final Properties props) {
@@ -236,7 +261,8 @@ public class ConnectionUrlParser {
         continue;
       }
 
-      currentParameterValue = urlDecode(param.substring(pos + 1));
+      final String currentParameterName = param.substring(0, pos);
+      currentParameterValue = urlDecode(param.substring(pos + 1), currentParameterName);
       if (currentParameterValue == null) {
         continue;
       }
@@ -247,7 +273,6 @@ public class ConnectionUrlParser {
       if (matcher.matches()) {
         currentParameterValue = "";
       }
-      final String currentParameterName = param.substring(0, pos);
       props.setProperty(currentParameterName, currentParameterValue);
     }
 
@@ -298,18 +323,21 @@ public class ConnectionUrlParser {
     }
   }
 
-  private static @Nullable String urlDecode(final String url) {
+  private static @Nullable String urlDecode(final String value, final @Nullable String parameterName) {
     try {
-      return StringUtils.decode(url);
+      return StringUtils.decode(value);
     } catch (final IllegalArgumentException e) {
+      // The value being decoded is a single query-parameter value; if it belongs to a password
+      // parameter, mask it so the secret is not written to the logs.
+      final String loggedValue = isSecretParameter(parameterName) ? "***" : value;
       LOGGER.fine(
           () -> Messages.get(
               "Driver.urlParsingFailed",
-              new Object[] {url, e.getMessage()}));
+              new Object[] {loggedValue, e.getMessage()}));
     }
 
     // Attempt to use the original value for connection.
-    return url;
+    return value;
   }
 
   public String getProtocol(final String url) {

--- a/wrapper/src/test/java/software/amazon/jdbc/util/ConnectionUrlParserTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/util/ConnectionUrlParserTest.java
@@ -149,6 +149,12 @@ class ConnectionUrlParserTest {
   }
 
   @ParameterizedTest
+  @MethodSource("maskUrlPasswordUrls")
+  void testMaskUrlPassword(final String url, final String expected) {
+    assertEquals(expected, ConnectionUrlParser.maskUrlPassword(url));
+  }
+
+  @ParameterizedTest
   @MethodSource("encodedParams")
   void testEncodedParams(final String url, final String expected) {
     Properties props = new Properties();
@@ -260,6 +266,36 @@ class ConnectionUrlParserTest {
         Arguments.of("protocol//url/db?PASSWORD=foo", null),
         Arguments.of("protocol//url/db?PASSWORD=foo&user=bar", null),
         Arguments.of("protocol//url/db?pass=foo", null)
+    );
+  }
+
+  private static Stream<Arguments> maskUrlPasswordUrls() {
+    return Stream.of(
+        // null / empty / no-password inputs are returned unchanged
+        Arguments.of(null, null),
+        Arguments.of("", ""),
+        Arguments.of("protocol//url/db?user=foo", "protocol//url/db?user=foo"),
+        // basic masking
+        Arguments.of("protocol//url/db?password=secret", "protocol//url/db?password=***"),
+        // password in the middle keeps following params intact
+        Arguments.of("protocol//url/db?user=foo&password=secret&x=y",
+            "protocol//url/db?user=foo&password=***&x=y"),
+        // password followed by another param
+        Arguments.of("protocol//url/db?password=secret&user=bar",
+            "protocol//url/db?password=***&user=bar"),
+        // case-insensitive parameter name, original case preserved
+        Arguments.of("protocol//url/db?PASSWORD=secret", "protocol//url/db?PASSWORD=***"),
+        Arguments.of("protocol//url/db?Password=secret", "protocol//url/db?Password=***"),
+        // a "wrapperPassword"-style param (ends with password=) is masked too
+        Arguments.of("protocol//url/db?wrapperPassword=secret", "protocol//url/db?wrapperPassword=***"),
+        // a param that merely starts with "password" but isn't "password=" is left untouched
+        Arguments.of("protocol//url/db?passwordHint=notASecret", "protocol//url/db?passwordHint=notASecret"),
+        // empty password value stays masked/empty-safe
+        Arguments.of("protocol//url/db?password=&user=bar", "protocol//url/db?password=***&user=bar"),
+        Arguments.of("protocol//url/db?password=", "protocol//url/db?password=***"),
+        // multiple password occurrences are all masked
+        Arguments.of("protocol//url/db?password=a&x=1&password=b",
+            "protocol//url/db?password=***&x=1&password=***")
     );
   }
 


### PR DESCRIPTION
## Summary

Connection URLs can carry credentials directly in their query string
(for example `jdbc:aws-wrapper:postgresql://host/db?user=foo&password=secret`).
The `Properties` object was already masked before logging via
`PropertyUtils.maskProperties`, but the raw URL string itself was logged verbatim
in several places, leaking the password at `FINEST`/`FINE` log levels.

This change adds URL password masking and applies it to every site that logs a
user-supplied connection URL.

## Changes

- Add `ConnectionUrlParser.maskUrlPassword(url)` which replaces any
  `password=<value>` query parameter (case-insensitive name) with `password=***`,
  returning null/empty/no-password inputs unchanged.
- Apply masking to the raw-URL logging sites:
  - `Driver.openingConnection` log in `Driver.connect`.
  - Both `"Connecting to " + url` FINEST logs in `DriverConnectionProvider`.
- In `ConnectionUrlParser.parsePropertiesFromUrl` / `urlDecode`, mask the value in
  the `Driver.urlParsingFailed` log when the failing parameter is a password, so a
  secret that fails to url-decode is not written to the logs.
- Add unit tests for `maskUrlPassword`.

## Scope / notes

- URLs built by the target-driver helpers (`GenericTargetDriverDialect`,
  MariaDB/MySQL/PG helpers) are composed from protocol + host + port + database only
  and deliberately keep credentials out of the URL, so those logs are unaffected.
  `hostSpec.getUrl()` based logs are host/port only.
- Masking covers query-string passwords (`password=...`). It does not attempt to
  mask `user:pass@host` userinfo syntax, which this driver does not use in its
  connection URLs.

## Testing

- `ConnectionUrlParserTest` extended with a parameterized `testMaskUrlPassword`
  covering null/empty/no-password inputs, basic masking, params before/after the
  password, case-insensitive param names with original case preserved,
  `wrapperPassword=` masked vs `passwordHint=` left untouched, empty password
  values, and multiple password occurrences.
- Full `ConnectionUrlParserTest` suite passes (50 tests, 0 failures).
- `:aws-advanced-jdbc-wrapper:compileJava` builds cleanly.
