### PR TITLE
fix: validate non-negative timeout and expiration properties

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/AwsWrapperProperty.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/AwsWrapperProperty.java
@@ -20,10 +20,16 @@ import java.sql.DriverPropertyInfo;
 import java.util.Properties;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import software.amazon.jdbc.util.Messages;
 
 public class AwsWrapperProperty extends DriverPropertyInfo {
 
   public final @Nullable String defaultValue;
+
+  // Optional inclusive bounds enforced by getInteger/getLong. A null bound means "unbounded" on
+  // that side. Bounds are opt-in via withBounds(...)/nonNegative().
+  private @Nullable Long minValue;
+  private @Nullable Long maxValue;
 
   public AwsWrapperProperty(
       final @NonNull String name,
@@ -56,6 +62,46 @@ public class AwsWrapperProperty extends DriverPropertyInfo {
     this.choices = choices;
   }
 
+  /**
+   * Declares inclusive bounds for this property's numeric value. The bounds are validated whenever
+   * the value is read via {@link #getInteger(Properties)} or {@link #getLong(Properties)}; a value
+   * outside the range causes an {@link IllegalArgumentException} to be thrown (fail-fast).
+   *
+   * @param min the inclusive minimum allowed value, or null for no lower bound.
+   * @param max the inclusive maximum allowed value, or null for no upper bound.
+   * @return this property, to allow fluent declaration.
+   */
+  public AwsWrapperProperty withBounds(final @Nullable Long min, final @Nullable Long max) {
+    this.minValue = min;
+    this.maxValue = max;
+    return this;
+  }
+
+  /**
+   * Marks this property as not allowing negative values. Intended for timeouts, expiration times,
+   * intervals, and other durations that are meaningless when negative.
+   *
+   * @return this property, to allow fluent declaration.
+   */
+  public AwsWrapperProperty nonNegative() {
+    return withBounds(0L, null);
+  }
+
+  private void validateBounds(final long value) {
+    if (this.minValue != null && value < this.minValue) {
+      throw new IllegalArgumentException(
+          Messages.get(
+              "AwsWrapperProperty.valueBelowMinimum",
+              new Object[] {value, name, this.minValue}));
+    }
+    if (this.maxValue != null && value > this.maxValue) {
+      throw new IllegalArgumentException(
+          Messages.get(
+              "AwsWrapperProperty.valueAboveMaximum",
+              new Object[] {value, name, this.maxValue}));
+    }
+  }
+
   public @Nullable String getString(final Properties properties) {
     return properties.getProperty(name, defaultValue);
   }
@@ -71,26 +117,32 @@ public class AwsWrapperProperty extends DriverPropertyInfo {
   public int getInteger(final Properties properties) {
     final Object value = properties.get(name);
     if (value instanceof Integer) {
-      return (Integer) value;
+      final int result = (Integer) value;
+      validateBounds(result);
+      return result;
     }
     final @Nullable String stringValue = properties.getProperty(name, defaultValue);
     // Integer.parseInt throws NumberFormatException on null, matching prior behavior when the
     // property is unset and has no default value.
     @SuppressWarnings("argument")
     final int result = Integer.parseInt(stringValue);
+    validateBounds(result);
     return result;
   }
 
   public long getLong(final Properties properties) {
     final Object value = properties.get(name);
     if (value instanceof Long) {
-      return (Long) value;
+      final long result = (Long) value;
+      validateBounds(result);
+      return result;
     }
     final @Nullable String stringValue = properties.getProperty(name, defaultValue);
     // Long.parseLong throws NumberFormatException on null, matching prior behavior when the
     // property is unset and has no default value.
     @SuppressWarnings("argument")
     final long result = Long.parseLong(stringValue);
+    validateBounds(result);
     return result;
   }
 

--- a/wrapper/src/main/java/software/amazon/jdbc/PropertyDefinition.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/PropertyDefinition.java
@@ -122,14 +122,14 @@ public class PropertyDefinition {
 
   public static final AwsWrapperProperty LOGIN_TIMEOUT =
       new AwsWrapperProperty(
-          "loginTimeout", null, "Login timeout in msec.");
+          "loginTimeout", null, "Login timeout in msec.").nonNegative();
 
   public static final AwsWrapperProperty CONNECT_TIMEOUT =
       new AwsWrapperProperty(
-          "connectTimeout", null, "Socket connect timeout in msec.");
+          "connectTimeout", null, "Socket connect timeout in msec.").nonNegative();
   public static final AwsWrapperProperty SOCKET_TIMEOUT =
       new AwsWrapperProperty(
-          "socketTimeout", null, "Socket timeout in msec.");
+          "socketTimeout", null, "Socket timeout in msec.").nonNegative();
 
   public static final AwsWrapperProperty TCP_KEEP_ALIVE =
       new AwsWrapperProperty(

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/AwsSecretsManagerConnectionPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/AwsSecretsManagerConnectionPlugin.java
@@ -101,7 +101,7 @@ public class AwsSecretsManagerConnectionPlugin extends AbstractConnectionPlugin 
   public static final AwsWrapperProperty SECRETS_MANAGER_EXPIRATION_SEC_PROPERTY = new AwsWrapperProperty(
       "secretsManagerExpirationTimeSec", String.valueOf(DEFAULT_CREDENTIALS_EXPIRATION_SEC),
       "Secrets Manager credentials' expiration time in seconds."
-  );
+  ).nonNegative();
 
   protected static final RegionUtils regionUtils = new RegionUtils();
   private static final Pattern SECRETS_ARN_PATTERN =

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/failover/FailoverConnectionPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/failover/FailoverConnectionPlugin.java
@@ -106,26 +106,26 @@ public class FailoverConnectionPlugin extends AbstractConnectionPlugin implement
           "Cluster topology refresh rate in millis during a writer failover process. "
               + "During the writer failover process, "
               + "cluster topology may be refreshed at a faster pace than normal to speed up "
-              + "discovery of the newly promoted writer.");
+              + "discovery of the newly promoted writer.").nonNegative();
 
   public static final AwsWrapperProperty FAILOVER_TIMEOUT_MS =
       new AwsWrapperProperty(
           "failoverTimeoutMs",
           "300000",
-          "Maximum allowed time for the failover process.");
+          "Maximum allowed time for the failover process.").nonNegative();
 
   public static final AwsWrapperProperty FAILOVER_WRITER_RECONNECT_INTERVAL_MS =
       new AwsWrapperProperty(
           "failoverWriterReconnectIntervalMs",
           "2000",
           "Interval of time to wait between attempts to reconnect to a failed writer during a "
-              + "writer failover process.");
+              + "writer failover process.").nonNegative();
 
   public static final AwsWrapperProperty FAILOVER_READER_CONNECT_TIMEOUT_MS =
       new AwsWrapperProperty(
           "failoverReaderConnectTimeoutMs",
           "30000",
-          "Reader connection attempt timeout during a reader failover process.");
+          "Reader connection attempt timeout during a reader failover process.").nonNegative();
 
   public static final AwsWrapperProperty ENABLE_CLUSTER_AWARE_FAILOVER =
       new AwsWrapperProperty(

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/failover2/FailoverConnectionPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/failover2/FailoverConnectionPlugin.java
@@ -85,7 +85,7 @@ public class FailoverConnectionPlugin extends AbstractConnectionPlugin implement
       new AwsWrapperProperty(
           "failoverTimeoutMs",
           "300000",
-          "Maximum allowed time for the failover process.");
+          "Maximum allowed time for the failover process.").nonNegative();
 
   public static final AwsWrapperProperty FAILOVER_MODE =
       new AwsWrapperProperty(

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/iam/IamAuthConnectionPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/iam/IamAuthConnectionPlugin.java
@@ -82,7 +82,7 @@ public class IamAuthConnectionPlugin extends AbstractConnectionPlugin implements
 
   public static final AwsWrapperProperty IAM_EXPIRATION = new AwsWrapperProperty(
       "iamExpiration", String.valueOf(DEFAULT_TOKEN_EXPIRATION_SEC),
-      "IAM token cache expiration in seconds");
+      "IAM token cache expiration in seconds").nonNegative();
 
   public static final AwsWrapperProperty IAM_TOKEN_PROPERTY_NAME = new AwsWrapperProperty(
       "iamAccessTokenPropertyName", PropertyDefinition.PASSWORD.name,

--- a/wrapper/src/main/resources/aws_advanced_jdbc_wrapper_messages.properties
+++ b/wrapper/src/main/resources/aws_advanced_jdbc_wrapper_messages.properties
@@ -39,6 +39,9 @@ AwsCredentialsManager.loginSessionRegionRequired=Unable to determine the region 
 AwsCredentialsManager.loginSessionProviderFailed=Failed to build the AWS Sign-In (login_session) credentials provider: ''{0}''
 AwsCredentialsManager.loginSessionProviderNull=Failed to build the AWS Sign-In (login_session) credentials provider: the provider builder returned no provider.
 
+AwsWrapperProperty.valueBelowMinimum=The value ''{0}'' for the configuration property ''{1}'' is below the minimum allowed value of ''{2}''.
+AwsWrapperProperty.valueAboveMaximum=The value ''{0}'' for the configuration property ''{1}'' is above the maximum allowed value of ''{2}''.
+
 RdsHostListProvider.clusterInstanceHostPatternNotSupportedForRDSProxy=An RDS Proxy url can''t be used as the 'clusterInstanceHostPattern' configuration setting.
 RdsHostListProvider.clusterInstanceHostPatternNotSupportedForRdsCustom=A custom RDS url can''t be used as the 'clusterInstanceHostPattern' configuration setting.
 RdsHostListProvider.invalidPattern=Invalid value for the 'clusterInstanceHostPattern' configuration setting - the host pattern must contain a '?' character as a placeholder for the DB instance identifiers of the instances in the cluster.

--- a/wrapper/src/test/java/software/amazon/jdbc/AwsWrapperPropertyTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/AwsWrapperPropertyTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.jdbc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Properties;
+import org.junit.jupiter.api.Test;
+
+public class AwsWrapperPropertyTest {
+
+  @Test
+  public void testNonNegativeRejectsNegativeInteger() {
+    final AwsWrapperProperty prop =
+        new AwsWrapperProperty("someTimeout", "1000", "desc").nonNegative();
+    final Properties props = new Properties();
+    props.setProperty("someTimeout", "-1");
+
+    assertThrows(IllegalArgumentException.class, () -> prop.getInteger(props));
+  }
+
+  @Test
+  public void testNonNegativeRejectsNegativeLong() {
+    final AwsWrapperProperty prop =
+        new AwsWrapperProperty("someTimeout", "1000", "desc").nonNegative();
+    final Properties props = new Properties();
+    props.setProperty("someTimeout", "-5");
+
+    assertThrows(IllegalArgumentException.class, () -> prop.getLong(props));
+  }
+
+  @Test
+  public void testNonNegativeAllowsZeroAndPositive() {
+    final AwsWrapperProperty prop =
+        new AwsWrapperProperty("someTimeout", "1000", "desc").nonNegative();
+    final Properties props = new Properties();
+
+    props.setProperty("someTimeout", "0");
+    assertEquals(0, prop.getInteger(props));
+    assertEquals(0L, prop.getLong(props));
+
+    props.setProperty("someTimeout", "42");
+    assertEquals(42, prop.getInteger(props));
+    assertEquals(42L, prop.getLong(props));
+  }
+
+  @Test
+  public void testNonNegativeUsesDefaultWhenUnset() {
+    final AwsWrapperProperty prop =
+        new AwsWrapperProperty("someTimeout", "1000", "desc").nonNegative();
+    final Properties props = new Properties();
+
+    assertEquals(1000, prop.getInteger(props));
+  }
+
+  @Test
+  public void testNonNegativeValidatesTypedIntegerValue() {
+    final AwsWrapperProperty prop =
+        new AwsWrapperProperty("someTimeout", "1000", "desc").nonNegative();
+    final Properties props = new Properties();
+    props.put("someTimeout", -3);
+
+    assertThrows(IllegalArgumentException.class, () -> prop.getInteger(props));
+  }
+
+  @Test
+  public void testNonNegativeValidatesTypedLongValue() {
+    final AwsWrapperProperty prop =
+        new AwsWrapperProperty("someTimeout", "1000", "desc").nonNegative();
+    final Properties props = new Properties();
+    props.put("someTimeout", -3L);
+
+    assertThrows(IllegalArgumentException.class, () -> prop.getLong(props));
+  }
+
+  @Test
+  public void testWithBoundsEnforcesMinAndMax() {
+    final AwsWrapperProperty prop =
+        new AwsWrapperProperty("someValue", "5", "desc").withBounds(1L, 10L);
+    final Properties props = new Properties();
+
+    props.setProperty("someValue", "0");
+    assertThrows(IllegalArgumentException.class, () -> prop.getInteger(props));
+
+    props.setProperty("someValue", "11");
+    assertThrows(IllegalArgumentException.class, () -> prop.getInteger(props));
+
+    props.setProperty("someValue", "5");
+    assertEquals(5, prop.getInteger(props));
+  }
+
+  @Test
+  public void testUnboundedPropertyAcceptsNegative() {
+    final AwsWrapperProperty prop = new AwsWrapperProperty("someValue", "-1", "desc");
+    final Properties props = new Properties();
+    props.setProperty("someValue", "-1");
+
+    assertEquals(-1, prop.getInteger(props));
+    assertEquals(-1L, prop.getLong(props));
+  }
+}


### PR DESCRIPTION
## Summary

Timeout and expiration configuration values (for example `iamExpiration` and `failoverTimeoutMs`) were accepted even when negative, which is meaningless and could lead to surprising behavior. This change validates such inputs and fails fast.

## Changes

- Added optional inclusive bounds to `AwsWrapperProperty`:
  - `withBounds(min, max)` and `nonNegative()` fluent declarations (a `null` bound means unbounded on that side).
  - `getInteger()` and `getLong()` now validate the resolved value on both the pre-typed `Integer`/`Long` path and the string-parse path, throwing `IllegalArgumentException` when out of range.
  - Existing parsing behavior is unchanged: a `NumberFormatException` is still thrown for null/non-numeric input, before the bounds check.
- Marked the following properties as `nonNegative()`:
  - Core: `loginTimeout`, `connectTimeout`, `socketTimeout`
  - `iamExpiration`, `secretsManagerExpirationTimeSec`
  - Failover v1: `failoverTimeoutMs`, `failoverWriterReconnectIntervalMs`, `failoverReaderConnectTimeoutMs`, `failoverClusterTopologyRefreshRateMs`
  - Failover v2: `failoverTimeoutMs`
- Externalized the two new error messages to the resource bundle (`AwsWrapperProperty.valueBelowMinimum`, `AwsWrapperProperty.valueAboveMaximum`).

Properties that use a negative sentinel value (such as `iamDefaultPort`, which defaults to `-1`) were intentionally left unbounded.

## Notes

`IllegalArgumentException` is the parent of `NumberFormatException`, so existing `catch (NumberFormatException)` fallbacks in the IAM/Federated auth plugins do not swallow a negative-value error; it propagates as intended.

The bounds mechanism is reusable and can be applied to additional time-based properties (efm intervals, blue/green intervals, custom-endpoint refresh rates, etc.) in follow-up work.

## Testing

Added `AwsWrapperPropertyTest` (8 cases): negative int/long rejection, zero/positive accepted, default-value path, typed-value validation, `withBounds` min+max enforcement, and that unbounded properties still accept negatives. All pass, and the module compiles cleanly.
