### PR TITLE
fix: avoid NoSuchMethodError in IAM LightRdsUtility with older auth SDK

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/iam/LightRdsUtility.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/iam/LightRdsUtility.java
@@ -24,12 +24,10 @@ import java.util.logging.Logger;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
-import software.amazon.awssdk.auth.credentials.CredentialUtils;
 import software.amazon.awssdk.auth.signer.params.Aws4PresignerParams;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.http.SdkHttpMethod;
 import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.utils.CompletableFutureUtils;
 import software.amazon.awssdk.utils.StringUtils;
 
 @SuppressWarnings("deprecation")
@@ -78,12 +76,12 @@ public class LightRdsUtility implements IamTokenUtility {
 
     final Instant expirationTime = Instant.now(this.clock).plus(EXPIRATION_DURATION);
 
-    // CompletableFutureUtils.joinLikeSync's type parameter is @NonNull-bounded; the wildcard
-    // captured from resolveIdentity() cannot be proven @NonNull by the checker (an SDK generics
-    // inference limitation), so the type-argument warning is suppressed here.
-    @SuppressWarnings("type.argument")
-    final AwsCredentials credentials = CredentialUtils.toCredentials(
-        CompletableFutureUtils.joinLikeSync(credentialsProvider.resolveIdentity()));
+    // Use the long-stable synchronous resolveCredentials() rather than the newer
+    // resolveIdentity() (introduced with the identity-spi refactor in AWS SDK ~2.20). When only a
+    // transitive AWS SDK dependency such as secretsmanager is on the classpath, it may resolve
+    // 'auth' to an older version that lacks resolveIdentity(), producing a NoSuchMethodError.
+    // resolveCredentials() has existed since AWS SDK v2.0 and avoids that version sensitivity.
+    final AwsCredentials credentials = credentialsProvider.resolveCredentials();
 
     final Aws4PresignerParams presignRequest = Aws4PresignerParams.builder()
         .signingClockOverride(this.clock)

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/iam/LightRdsUtilityTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/iam/LightRdsUtilityTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.jdbc.plugin.iam;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+
+class LightRdsUtilityTest {
+
+  private static final Instant FIXED_INSTANT = Instant.parse("2024-10-20T00:00:00Z");
+  private static final Region REGION = Region.US_WEST_2;
+  private static final String HOSTNAME = "test-cluster.cluster-xyz.us-west-2.rds.amazonaws.com";
+  private static final int PORT = 5432;
+  private static final String USERNAME = "jane_doe";
+  private static final AwsCredentials CREDENTIALS =
+      AwsBasicCredentials.create("accessKeyId", "secretAccessKey");
+
+  /**
+   * Regression test for the {@code NoSuchMethodError} on
+   * {@code AwsCredentialsProvider.resolveIdentity()} (see the IAM + Secrets Manager dependency
+   * issue). {@link LightRdsUtility} must resolve credentials via the long-stable synchronous
+   * {@code resolveCredentials()} and must never call the newer {@code resolveIdentity()} method,
+   * which is absent from older transitive {@code auth} versions and triggers the runtime failure.
+   */
+  @Test
+  void generateAuthenticationToken_usesResolveCredentialsAndNeverResolveIdentity() {
+    final AwsCredentialsProvider credentialsProvider = mock(AwsCredentialsProvider.class);
+    when(credentialsProvider.resolveCredentials()).thenReturn(CREDENTIALS);
+
+    final String token = new LightRdsUtility(FIXED_INSTANT).generateAuthenticationToken(
+        credentialsProvider,
+        REGION,
+        HOSTNAME,
+        PORT,
+        USERNAME);
+
+    // The credentials must be obtained through resolveCredentials(), never resolveIdentity().
+    verify(credentialsProvider).resolveCredentials();
+    verify(credentialsProvider, never()).resolveIdentity();
+
+    // Behavior preserved: a valid presigned RDS auth token is produced.
+    assertTrue(token.startsWith(HOSTNAME + ":" + PORT),
+        () -> "Unexpected token prefix: " + token);
+    assertFalse(token.startsWith("https://"), "https:// prefix should be stripped");
+    assertTrue(token.contains("Action=connect"), () -> "Missing Action query param: " + token);
+    assertTrue(token.contains("DBUser=" + USERNAME), () -> "Missing DBUser query param: " + token);
+    assertTrue(token.contains("X-Amz-Algorithm=AWS4-HMAC-SHA256"),
+        () -> "Missing SigV4 algorithm: " + token);
+    assertTrue(token.contains("X-Amz-Signature="), () -> "Missing SigV4 signature: " + token);
+  }
+
+  /**
+   * A deterministic clock must yield a deterministic token, confirming the signing path does not
+   * depend on wall-clock time and that repeated resolutions are stable.
+   */
+  @Test
+  void generateAuthenticationToken_isDeterministicForFixedClock() {
+    final AwsCredentialsProvider credentialsProvider = mock(AwsCredentialsProvider.class);
+    when(credentialsProvider.resolveCredentials()).thenReturn(CREDENTIALS);
+
+    final LightRdsUtility utility = new LightRdsUtility(FIXED_INSTANT);
+    final String first = utility.generateAuthenticationToken(
+        credentialsProvider, REGION, HOSTNAME, PORT, USERNAME);
+    final String second = utility.generateAuthenticationToken(
+        credentialsProvider, REGION, HOSTNAME, PORT, USERNAME);
+
+    org.junit.jupiter.api.Assertions.assertEquals(first, second);
+  }
+}


### PR DESCRIPTION
## Summary

Fixes a `NoSuchMethodError` thrown by the IAM auth plugin when the AWS SDK `auth` module on the
classpath is older than the one the wrapper compiles against - a situation that arises when the
Secrets Manager dependency (or another transitive AWS SDK dependency) is present but the dedicated
IAM/RDS dependencies are not.

```
java.lang.NoSuchMethodError: software.amazon.awssdk.auth.credentials.AwsCredentialsProvider.resolveIdentity()Ljava/util/concurrent/CompletableFuture;
	at software.amazon.jdbc.plugin.iam.LightRdsUtility.generateAuthenticationToken(LightRdsUtility.java:82)
```

## Root cause

`IamAuthUtils.getTokenUtility()` selects `LightRdsUtility` whenever the `auth` +
`http-client-spi` classes are present, which they are when Secrets Manager is on the classpath.
`LightRdsUtility` then called `credentialsProvider.resolveIdentity()`, a method added to
`AwsCredentialsProvider` with the identity-spi refactor (AWS SDK ~2.20). Because all AWS SDK
modules are declared as optional/compile-only, the runtime `auth` version can be resolved
transitively to an older release that lacks `resolveIdentity()`, producing the `NoSuchMethodError`.

## Change

- `LightRdsUtility` now resolves credentials via the long-stable synchronous
  `AwsCredentialsProvider.resolveCredentials()`, which has existed since AWS SDK v2.0 and does not
  depend on identity-spi. This removes the `resolveIdentity()` / `CompletableFutureUtils.joinLikeSync`
  / `CredentialUtils.toCredentials` chain and the version-sensitive call.
- The credentials passed to the SigV4 presigner are unchanged, so token output is identical.

## Testing

- Added `LightRdsUtilityTest` with two unit regression tests:
  - asserts credentials are obtained via `resolveCredentials()` and `resolveIdentity()` is never
    called, while still producing a valid presigned SigV4 token (`Action=connect`, `DBUser`,
    `X-Amz-Algorithm`, `X-Amz-Signature`);
  - asserts deterministic token output for a fixed clock.
- Both new tests pass; the module compiles cleanly with the two now-unused imports removed.
- The existing `AwsIamIntegrationTest` asserts the light and regular utilities produce identical
  tokens; it compiles but requires live AWS credentials to run.
