### PR TITLE
fix: allow writer switch when autocommit off before txn starts

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/gate/TransactionAwareGate.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/gate/TransactionAwareGate.java
@@ -40,6 +40,15 @@ import software.amazon.jdbc.util.Messages;
  *       transaction.</li>
  * </ul>
  *
+ * <p>The autocommit-off pin never blocks a switch to the {@link TargetRole#WRITER}. When control
+ * reaches that check there is no transaction in progress yet (the in-progress check above already
+ * returned), so autocommit-off only means the <em>next</em> statement would implicitly start one.
+ * That next statement is the write being routed here, and a write cannot run on a read-only reader:
+ * pinning it to the reader guarantees failure (e.g. MySQL {@code --super-read-only}, error 1290).
+ * The implicit transaction physically starts when the write executes on the writer, after which
+ * the in-progress check pins any following statements. Reads are still pinned so a read-first
+ * implicit transaction stays put.
+ *
  * <p>The legacy {@code setReadOnly(false)}-in-transaction throw is role-specific (it depends on
  * whether the current host is the writer) and is therefore enforced by the plugin orchestration,
  * which owns the role check; this gate only decides pinning.
@@ -88,7 +97,10 @@ public class TransactionAwareGate implements SwitchGate {
       return false;
     }
 
-    if (this.pinOnAutoCommitOff) {
+    // A write must reach the writer even with autocommit off: no transaction is in progress yet
+    // (checked above), so this write is what would start the implicit transaction, and a reader
+    // cannot serve it. Pinning here would guarantee a read-only failure.
+    if (this.pinOnAutoCommitOff && desired != TargetRole.WRITER) {
       try {
         final Optional<Boolean> autoCommit = ctx.pluginService().getSessionStateService().getAutoCommit();
         if (autoCommit.isPresent() && !autoCommit.get()) {

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/readwritesplitting/gate/TransactionAwareGateTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/readwritesplitting/gate/TransactionAwareGateTest.java
@@ -134,6 +134,40 @@ public class TransactionAwareGateTest {
   }
 
   @Test
+  void autoCommitOff_allowsSwitchToWriter() throws SQLException {
+    // A write with autocommit off but no transaction in progress must still reach the writer:
+    // it is the statement that would start the implicit transaction, and a read-only reader
+    // cannot serve it. Pinning would guarantee a --super-read-only failure (see issue #2083).
+    when(pluginService.isInTransaction()).thenReturn(false);
+    when(pluginService.getCallContext()).thenReturn(callContext);
+
+    final TransactionAwareGate gate = new TransactionAwareGate(true, true);
+    assertTrue(gate.canSwitch(ctx, TargetRole.WRITER));
+  }
+
+  @Test
+  void autoCommitIndeterminate_allowsSwitchToWriter() throws SQLException {
+    // Even when autocommit cannot be read, a write still cannot run on a reader, so the writer
+    // switch must not be blocked by the autocommit-off pin.
+    when(pluginService.isInTransaction()).thenReturn(false);
+    when(pluginService.getCallContext()).thenReturn(callContext);
+
+    final TransactionAwareGate gate = new TransactionAwareGate(true, true);
+    assertTrue(gate.canSwitch(ctx, TargetRole.WRITER));
+  }
+
+  @Test
+  void autoCommitOff_stillPinsWriterWhenInTransaction() throws SQLException {
+    // Once a transaction is in progress, even a write stays pinned: the connection must not
+    // change mid-transaction. This is enforced by the in-transaction check, ahead of the
+    // autocommit-off pin.
+    when(pluginService.isInTransaction()).thenReturn(true);
+
+    final TransactionAwareGate gate = new TransactionAwareGate(true, true);
+    assertFalse(gate.canSwitch(ctx, TargetRole.WRITER));
+  }
+
+  @Test
   void autoCommitOn_allowsSwitch() throws SQLException {
     when(pluginService.isInTransaction()).thenReturn(false);
     when(pluginService.getCallContext()).thenReturn(callContext);


### PR DESCRIPTION
## Summary

Fixes #2083.

`autoSimpleReadWriteSplitting` (and the other `pinOnAutoCommitOff` gate variants) blocked the first write of an implicit transaction from reaching the writer. When an application called `Connection.setAutoCommit(false)` while the connection was routed to a reader and then issued a write as the first statement (e.g. Spring Data JPA `repository.save()` without `@Transactional`), the write was pinned to the read-only reader and failed with MySQL error 1290 (`--super-read-only`).

## Root cause

`TransactionAwareGate` pins the connection whenever autocommit is off, on the assumption that the next statement would join an implicit transaction. But `setAutoCommit(false)` does not start a transaction on its own; the implicit transaction only begins when the first statement executes (`isInTransaction()` flips to `true` at that point). At the moment the first write is routed, no transaction is in progress yet, so pinning it to the reader is premature and guarantees a read-only failure.

## Change

- `TransactionAwareGate.canSwitch` now skips the autocommit-off pin when the desired target is the `WRITER`. When that check is reached, the in-transaction and XA checks have already returned, so no transaction is active: the write being routed is what would start the implicit transaction and must reach the writer. The transaction physically starts once the write lands on the writer, after which the in-transaction check pins any following statements.
- Reader routing, `KEEP`/routing-hint pins, in-transaction pins, and XA pins are unchanged.

## Testing

- Added unit tests to `TransactionAwareGateTest`: writer switch is allowed when autocommit is off with no active transaction, allowed when autocommit state is indeterminate, and still pinned when a transaction is in progress.
- `./gradlew :aws-advanced-jdbc-wrapper:test --tests "software.amazon.jdbc.plugin.readwritesplitting.*"` passes (141 tests).
