### PR TITLE
fix: escape ampersand in maskUrlPassword javadoc

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/util/ConnectionUrlParser.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/ConnectionUrlParser.java
@@ -226,7 +226,7 @@ public class ConnectionUrlParser {
 
   /**
    * Mask the value of any "password" query parameter in a connection URL so the URL can be safely
-   * logged. For example, "...?user=foo&password=secret" becomes "...?user=foo&password=***".
+   * logged. For example, "...?user=foo&amp;password=secret" becomes "...?user=foo&amp;password=***".
    *
    * @param url the connection URL, which may be null
    * @return the URL with password values replaced by "***", or the input unchanged if it is null,


### PR DESCRIPTION
## Summary

Fixes the failing "Snapshot to Maven" build on `main` ([run 31409894274](https://github.com/aws/aws-advanced-jdbc-wrapper/actions/runs/31409894274)), which broke at the `:aws-advanced-jdbc-wrapper:javadoc` task:

```
ConnectionUrlParser.java:229: error: semicolon missing
```

## Root cause

The javadoc comment on the new `maskUrlPassword` method contained unescaped `&` characters in the example URLs (`user=foo&password=secret`). Javadoc's doclint reads `&password` as the start of an HTML entity reference and expects a closing `;`, so it reports "semicolon missing" and fails the build.

## Fix

Escaped both `&` as `&amp;` in the javadoc comment. This is a comment-only change with no behavior impact.

## Testing

- Ran `./gradlew :aws-advanced-jdbc-wrapper:javadoc` locally: now BUILD SUCCESSFUL (only pre-existing warnings remain, no errors).
