### PR TITLE
chore: Soften ACCESS_EXTERNAL_* to best-effort in CachedSQLXML

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/cache/CachedSQLXML.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/cache/CachedSQLXML.java
@@ -41,6 +41,8 @@ import javax.xml.transform.stax.StAXSource;
 import javax.xml.transform.stream.StreamSource;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.xml.sax.InputSource;
+import org.xml.sax.SAXNotRecognizedException;
+import org.xml.sax.SAXNotSupportedException;
 import org.xml.sax.XMLReader;
 import software.amazon.jdbc.util.Messages;
 
@@ -184,8 +186,11 @@ public class CachedSQLXML implements SQLXML, Serializable {
         dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
         dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
         dbf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
-        dbf.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-        dbf.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+        // ACCESS_EXTERNAL_* are best-effort defense-in-depth. Standalone parsers (e.g. Apache
+        // Xerces 2.x, which predates JAXP 1.5) reject them; disallow-doctype-decl above is the
+        // load-bearing control and stays fatal, so skipping these does not weaken XXE protection.
+        setAttributeBestEffort(dbf, XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        setAttributeBestEffort(dbf, XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
         dbf.setXIncludeAware(false);
         dbf.setExpandEntityReferences(false);
         DocumentBuilder builder = dbf.newDocumentBuilder();
@@ -200,8 +205,9 @@ public class CachedSQLXML implements SQLXML, Serializable {
         spf.setFeature("http://xml.org/sax/features/external-general-entities", false);
         spf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
         SAXParser parser = spf.newSAXParser();
-        parser.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-        parser.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+        // Best-effort; see the note in the DOM branch. disallow-doctype-decl above stays fatal.
+        setPropertyBestEffort(parser, XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        setPropertyBestEffort(parser, XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
         XMLReader reader = parser.getXMLReader();
         return sourceClass.cast(new SAXSource(reader, new InputSource(new StringReader(xmlData))));
       }
@@ -224,6 +230,42 @@ public class CachedSQLXML implements SQLXML, Serializable {
       throw new SQLException(Messages.get("CachedSQLXML.unsupportedSourceClass", new Object[]{sourceClass.getName()}));
     } catch (Exception e) {
       throw new SQLException(Messages.get("CachedSQLXML.unableToDecodeXml"), e);
+    }
+  }
+
+  /**
+   * Sets a JAXP 1.5 factory attribute best-effort. Standalone parsers on the classpath (e.g.
+   * Apache Xerces 2.x, which predates JAXP 1.5) do not recognize {@code ACCESS_EXTERNAL_DTD}/
+   * {@code ACCESS_EXTERNAL_SCHEMA} and throw when they are set. These attributes are
+   * defense-in-depth only: the load-bearing control is {@code disallow-doctype-decl} (set fatally
+   * by the caller), which rejects DTDs and therefore external-entity resolution. If the parser
+   * rejects the attribute we skip it rather than failing an otherwise-benign parse.
+   *
+   * @param dbf the factory to configure
+   * @param name the attribute name
+   * @param value the attribute value
+   */
+  private static void setAttributeBestEffort(DocumentBuilderFactory dbf, String name, Object value) {
+    try {
+      dbf.setAttribute(name, value);
+    } catch (IllegalArgumentException e) {
+      // Property not recognized by this parser; disallow-doctype-decl remains in effect.
+    }
+  }
+
+  /**
+   * Sets a JAXP 1.5 parser property best-effort. See {@link #setAttributeBestEffort} for why this
+   * is non-fatal.
+   *
+   * @param parser the parser to configure
+   * @param name the property name
+   * @param value the property value
+   */
+  private static void setPropertyBestEffort(SAXParser parser, String name, Object value) {
+    try {
+      parser.setProperty(name, value);
+    } catch (SAXNotRecognizedException | SAXNotSupportedException e) {
+      // Property not recognized by this parser; disallow-doctype-decl remains in effect.
     }
   }
 

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/cache/CachedSQLXMLTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/cache/CachedSQLXMLTest.java
@@ -46,6 +46,7 @@ import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXNotRecognizedException;
 import org.xml.sax.SAXNotSupportedException;
+import org.xml.sax.SAXParseException;
 import org.xml.sax.XMLReader;
 import org.xml.sax.helpers.DefaultHandler;
 
@@ -249,16 +250,21 @@ public class CachedSQLXMLTest {
     assertThrows(SQLException.class, () -> sqlxml.getSource(StreamSource.class));
   }
 
-  // Standalone Xerces 2.x predates JAXP 1.5 and rejects the ACCESS_EXTERNAL_DTD / ACCESS_EXTERNAL
-  // _SCHEMA properties with IllegalArgumentException (DOM) and SAXNotRecognizedException (SAX).
-  // getSource() currently sets those properties fatally, so on such a classpath EVERY document --
-  // including benign XML with no DOCTYPE -- fails to parse. These fake factories reproduce that
-  // behavior per-test (via the JAXP system property) without pulling xercesImpl onto the whole
-  // test classpath, where its META-INF/services entry would repoint every JAXP lookup.
+  // Standalone Xerces 2.x predates JAXP 1.5 and rejects ACCESS_EXTERNAL_DTD / ACCESS_EXTERNAL_SCHEMA
+  // with IllegalArgumentException (DOM) and SAXNotRecognizedException (SAX), while still honoring
+  // disallow-doctype-decl. Before the fix, getSource() set those properties fatally, so on such a
+  // classpath EVERY document -- including benign XML with no DOCTYPE -- failed to parse.
   //
-  // Against the current (unfixed) code, assertion (1) in each test fails: getSource throws
-  // SQLException for benign XML. Assertion (2) proves the load-bearing disallow-doctype-decl
-  // control still rejects DOCTYPE payloads on this classpath.
+  // The fake factories below SIMULATE that contract rather than running real Xerces: they reject
+  // only the JAXP 1.5 properties and delegate everything else (including setFeature) to the JDK
+  // parser. So the "DOCTYPE still rejected" assertions are enforced by the JDK parser standing in
+  // for Xerces, not by Xerces bytes -- a faithful test of the API contract, not of Xerces itself.
+  // This runs per-test via the JAXP system property, avoiding xercesImpl on the whole test
+  // classpath where its META-INF/services entry would repoint every JAXP lookup.
+  //
+  // In each test, assertion (1) verifies benign XML with no DOCTYPE parses on this classpath, and
+  // assertion (2) proves the load-bearing disallow-doctype-decl control still rejects DOCTYPE
+  // payloads.
 
   @Test
   void test_getSource_DOMSource_standaloneXercesClasspath() throws Exception {
@@ -276,10 +282,14 @@ public class CachedSQLXMLTest {
       assertEquals(Node.DOCUMENT_NODE, node.getNodeType());
       validateDOMElement((Document) node, "manufacturer", "TechCorp");
 
-      // disallow-doctype-decl is NOT one of the softened properties,
-      // so a DOCTYPE payload is still rejected.
+      // disallow-doctype-decl is NOT one of the softened properties, so a DOCTYPE payload is still
+      // rejected. getSource wraps everything as "unable to decode", so assert on the underlying
+      // cause -- otherwise an unrelated failure in the fake factory would satisfy the check.
       SQLXML malicious = new CachedSQLXML(XML_WITH_DOCTYPE);
-      assertThrows(SQLException.class, () -> malicious.getSource(DOMSource.class));
+      SQLException ex =
+          assertThrows(SQLException.class, () -> malicious.getSource(DOMSource.class));
+      assertTrue(ex.getCause() instanceof SAXParseException);
+      assertTrue(ex.getCause().getMessage().contains("DOCTYPE"));
     } finally {
       if (original == null) {
         System.clearProperty(prop);
@@ -305,12 +315,15 @@ public class CachedSQLXMLTest {
       xmlReader.setContentHandler(new DefaultHandler());
       xmlReader.parse(src.getInputSource()); // benign parse must not throw
 
-      // a DOCTYPE payload is rejected when the reader runs.
+      // A DOCTYPE payload is rejected when the reader runs. Assert specifically on a DOCTYPE
+      // rejection so a stray failure in the fake harness cannot masquerade as "security holds".
       SQLXML malicious = new CachedSQLXML(XML_WITH_DOCTYPE);
       SAXSource malSrc = malicious.getSource(SAXSource.class);
       XMLReader malReader = malSrc.getXMLReader();
       malReader.setContentHandler(new DefaultHandler());
-      assertThrows(Exception.class, () -> malReader.parse(malSrc.getInputSource()));
+      SAXParseException ex =
+          assertThrows(SAXParseException.class, () -> malReader.parse(malSrc.getInputSource()));
+      assertTrue(ex.getMessage().contains("DOCTYPE"));
     } finally {
       if (original == null) {
         System.clearProperty(prop);
@@ -318,6 +331,30 @@ public class CachedSQLXMLTest {
         System.setProperty(prop, original);
       }
       XercesLikeSaxParserFactory.delegate = null;
+    }
+  }
+
+  @Test
+  void test_getSource_DOMSource_failsClosedWhenDoctypeControlUnsettable() {
+    // The security guarantee the whole fix rests on: if disallow-doctype-decl cannot be set,
+    // getSource must fail closed (refuse to parse) rather than silently parse without the control.
+    // This is a tripwire -- it goes red if anyone later makes disallow-doctype-decl best-effort
+    // like the ACCESS_EXTERNAL_* properties.
+    final String prop = "javax.xml.parsers.DocumentBuilderFactory";
+    final String original = System.getProperty(prop);
+    DoctypeControlRejectingDocumentBuilderFactory.delegate = DocumentBuilderFactory.newInstance();
+    System.setProperty(prop, DoctypeControlRejectingDocumentBuilderFactory.class.getName());
+    try {
+      // Even benign XML must be refused: the parser could not be hardened, so we do not parse.
+      SQLXML benign = new CachedSQLXML("<product><manufacturer>TechCorp</manufacturer></product>");
+      assertThrows(SQLException.class, () -> benign.getSource(DOMSource.class));
+    } finally {
+      if (original == null) {
+        System.clearProperty(prop);
+      } else {
+        System.setProperty(prop, original);
+      }
+      DoctypeControlRejectingDocumentBuilderFactory.delegate = null;
     }
   }
 
@@ -354,6 +391,63 @@ public class CachedSQLXMLTest {
     @Override
     public void setFeature(String name, boolean value) throws ParserConfigurationException {
       delegate.setFeature(name, value);
+    }
+
+    @Override
+    public boolean getFeature(String name) throws ParserConfigurationException {
+      return delegate.getFeature(name);
+    }
+
+    @Override
+    public void setNamespaceAware(boolean value) {
+      delegate.setNamespaceAware(value);
+    }
+
+    @Override
+    public void setValidating(boolean value) {
+      delegate.setValidating(value);
+    }
+
+    @Override
+    public void setXIncludeAware(boolean value) {
+      delegate.setXIncludeAware(value);
+    }
+
+    @Override
+    public void setExpandEntityReferences(boolean value) {
+      delegate.setExpandEntityReferences(value);
+    }
+  }
+
+  /**
+   * A {@link DocumentBuilderFactory} that rejects the load-bearing {@code disallow-doctype-decl}
+   * feature, to verify getSource() fails closed (refuses to parse) when the control cannot be set.
+   */
+  public static final class DoctypeControlRejectingDocumentBuilderFactory
+      extends DocumentBuilderFactory {
+    static DocumentBuilderFactory delegate;
+
+    @Override
+    public void setFeature(String name, boolean value) throws ParserConfigurationException {
+      if ("http://apache.org/xml/features/disallow-doctype-decl".equals(name)) {
+        throw new ParserConfigurationException("Feature not supported: " + name);
+      }
+      delegate.setFeature(name, value);
+    }
+
+    @Override
+    public DocumentBuilder newDocumentBuilder() throws ParserConfigurationException {
+      return delegate.newDocumentBuilder();
+    }
+
+    @Override
+    public void setAttribute(String name, Object value) {
+      delegate.setAttribute(name, value);
+    }
+
+    @Override
+    public Object getAttribute(String name) {
+      return delegate.getAttribute(name);
     }
 
     @Override

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/cache/CachedSQLXMLTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/cache/CachedSQLXMLTest.java
@@ -24,8 +24,12 @@ import java.io.InputStream;
 import java.io.Reader;
 import java.sql.SQLException;
 import java.sql.SQLXML;
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
 import javax.xml.stream.XMLStreamReader;
 import javax.xml.transform.Source;
 import javax.xml.transform.dom.DOMSource;
@@ -39,6 +43,9 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.Attributes;
 import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXNotRecognizedException;
+import org.xml.sax.SAXNotSupportedException;
 import org.xml.sax.XMLReader;
 import org.xml.sax.helpers.DefaultHandler;
 
@@ -240,5 +247,211 @@ public class CachedSQLXMLTest {
     // A CachedSQLXML with no injected config falls back to STRICT, so StreamSource is rejected.
     SQLXML sqlxml = new CachedSQLXML("<root/>");
     assertThrows(SQLException.class, () -> sqlxml.getSource(StreamSource.class));
+  }
+
+  // Standalone Xerces 2.x predates JAXP 1.5 and rejects the ACCESS_EXTERNAL_DTD / ACCESS_EXTERNAL
+  // _SCHEMA properties with IllegalArgumentException (DOM) and SAXNotRecognizedException (SAX).
+  // getSource() currently sets those properties fatally, so on such a classpath EVERY document --
+  // including benign XML with no DOCTYPE -- fails to parse. These fake factories reproduce that
+  // behavior per-test (via the JAXP system property) without pulling xercesImpl onto the whole
+  // test classpath, where its META-INF/services entry would repoint every JAXP lookup.
+  //
+  // Against the current (unfixed) code, assertion (1) in each test fails: getSource throws
+  // SQLException for benign XML. Assertion (2) proves the load-bearing disallow-doctype-decl
+  // control still rejects DOCTYPE payloads on this classpath.
+
+  @Test
+  void test_getSource_DOMSource_standaloneXercesClasspath() throws Exception {
+    final String prop = "javax.xml.parsers.DocumentBuilderFactory";
+    final String original = System.getProperty(prop);
+    // Capture the JDK default BEFORE installing the override (Java 8-safe; avoids recursion).
+    XercesLikeDocumentBuilderFactory.delegate = DocumentBuilderFactory.newInstance();
+    System.setProperty(prop, XercesLikeDocumentBuilderFactory.class.getName());
+    try {
+      assertTrue(DocumentBuilderFactory.newInstance() instanceof XercesLikeDocumentBuilderFactory);
+
+      SQLXML benign = new CachedSQLXML("<product><manufacturer>TechCorp</manufacturer></product>");
+      DOMSource domSource = benign.getSource(DOMSource.class);
+      Node node = domSource.getNode();
+      assertEquals(Node.DOCUMENT_NODE, node.getNodeType());
+      validateDOMElement((Document) node, "manufacturer", "TechCorp");
+
+      // disallow-doctype-decl is NOT one of the softened properties,
+      // so a DOCTYPE payload is still rejected.
+      SQLXML malicious = new CachedSQLXML(XML_WITH_DOCTYPE);
+      assertThrows(SQLException.class, () -> malicious.getSource(DOMSource.class));
+    } finally {
+      if (original == null) {
+        System.clearProperty(prop);
+      } else {
+        System.setProperty(prop, original);
+      }
+      XercesLikeDocumentBuilderFactory.delegate = null;
+    }
+  }
+
+  @Test
+  void test_getSource_SAXSource_standaloneXercesClasspath() throws Exception {
+    final String prop = "javax.xml.parsers.SAXParserFactory";
+    final String original = System.getProperty(prop);
+    XercesLikeSaxParserFactory.delegate = SAXParserFactory.newInstance();
+    System.setProperty(prop, XercesLikeSaxParserFactory.class.getName());
+    try {
+      assertTrue(SAXParserFactory.newInstance() instanceof XercesLikeSaxParserFactory);
+
+      SQLXML benign = new CachedSQLXML("<product><manufacturer>TechCorp</manufacturer></product>");
+      SAXSource src = benign.getSource(SAXSource.class);
+      XMLReader xmlReader = src.getXMLReader();
+      xmlReader.setContentHandler(new DefaultHandler());
+      xmlReader.parse(src.getInputSource()); // benign parse must not throw
+
+      // a DOCTYPE payload is rejected when the reader runs.
+      SQLXML malicious = new CachedSQLXML(XML_WITH_DOCTYPE);
+      SAXSource malSrc = malicious.getSource(SAXSource.class);
+      XMLReader malReader = malSrc.getXMLReader();
+      malReader.setContentHandler(new DefaultHandler());
+      assertThrows(Exception.class, () -> malReader.parse(malSrc.getInputSource()));
+    } finally {
+      if (original == null) {
+        System.clearProperty(prop);
+      } else {
+        System.setProperty(prop, original);
+      }
+      XercesLikeSaxParserFactory.delegate = null;
+    }
+  }
+
+  /**
+   * A {@link DocumentBuilderFactory} that mimics standalone Apache Xerces 2.x: it rejects the JAXP
+   * 1.5 {@code ACCESS_EXTERNAL_*} attributes and delegates everything else to the JDK default.
+   */
+  public static final class XercesLikeDocumentBuilderFactory extends DocumentBuilderFactory {
+    // Captured from the JDK default BEFORE this factory is installed via the system property.
+    static DocumentBuilderFactory delegate;
+
+    // Forward all state to the delegate rather than reading it back via base-class getters:
+    // DocumentBuilderFactory.isXIncludeAware()/isExpandEntityReferences() throw
+    // UnsupportedOperationException in the abstract base unless a concrete subclass overrides them.
+    @Override
+    public DocumentBuilder newDocumentBuilder() throws ParserConfigurationException {
+      return delegate.newDocumentBuilder();
+    }
+
+    @Override
+    public void setAttribute(String name, Object value) {
+      if (XMLConstants.ACCESS_EXTERNAL_DTD.equals(name)
+          || XMLConstants.ACCESS_EXTERNAL_SCHEMA.equals(name)) {
+        throw new IllegalArgumentException("Property '" + name + "' is not recognized.");
+      }
+      delegate.setAttribute(name, value);
+    }
+
+    @Override
+    public Object getAttribute(String name) {
+      return delegate.getAttribute(name);
+    }
+
+    @Override
+    public void setFeature(String name, boolean value) throws ParserConfigurationException {
+      delegate.setFeature(name, value);
+    }
+
+    @Override
+    public boolean getFeature(String name) throws ParserConfigurationException {
+      return delegate.getFeature(name);
+    }
+
+    @Override
+    public void setNamespaceAware(boolean value) {
+      delegate.setNamespaceAware(value);
+    }
+
+    @Override
+    public void setValidating(boolean value) {
+      delegate.setValidating(value);
+    }
+
+    @Override
+    public void setXIncludeAware(boolean value) {
+      delegate.setXIncludeAware(value);
+    }
+
+    @Override
+    public void setExpandEntityReferences(boolean value) {
+      delegate.setExpandEntityReferences(value);
+    }
+  }
+
+  /**
+   * A {@link SAXParserFactory} whose parsers mimic standalone Apache Xerces 2.x: {@code
+   * SAXParser.setProperty} rejects the JAXP 1.5 {@code ACCESS_EXTERNAL_*} properties and delegates
+   * everything else to the JDK default.
+   */
+  public static final class XercesLikeSaxParserFactory extends SAXParserFactory {
+    static SAXParserFactory delegate;
+
+    @Override
+    public SAXParser newSAXParser() throws ParserConfigurationException, SAXException {
+      delegate.setNamespaceAware(isNamespaceAware());
+      delegate.setValidating(isValidating());
+      return new XercesLikeSaxParser(delegate.newSAXParser());
+    }
+
+    @Override
+    public void setFeature(String name, boolean value)
+        throws ParserConfigurationException, SAXNotRecognizedException, SAXNotSupportedException {
+      delegate.setFeature(name, value);
+    }
+
+    @Override
+    public boolean getFeature(String name)
+        throws ParserConfigurationException, SAXNotRecognizedException, SAXNotSupportedException {
+      return delegate.getFeature(name);
+    }
+  }
+
+  @SuppressWarnings("deprecation") // org.xml.sax.Parser is a deprecated abstract-method return type.
+  static final class XercesLikeSaxParser extends SAXParser {
+    private final SAXParser delegate;
+
+    XercesLikeSaxParser(SAXParser delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public void setProperty(String name, Object value)
+        throws SAXNotRecognizedException, SAXNotSupportedException {
+      if (XMLConstants.ACCESS_EXTERNAL_DTD.equals(name)
+          || XMLConstants.ACCESS_EXTERNAL_SCHEMA.equals(name)) {
+        throw new SAXNotRecognizedException("Property '" + name + "' is not recognized.");
+      }
+      delegate.setProperty(name, value);
+    }
+
+    @Override
+    public Object getProperty(String name)
+        throws SAXNotRecognizedException, SAXNotSupportedException {
+      return delegate.getProperty(name);
+    }
+
+    @Override
+    public org.xml.sax.Parser getParser() throws SAXException {
+      return delegate.getParser();
+    }
+
+    @Override
+    public XMLReader getXMLReader() throws SAXException {
+      return delegate.getXMLReader();
+    }
+
+    @Override
+    public boolean isNamespaceAware() {
+      return delegate.isNamespaceAware();
+    }
+
+    @Override
+    public boolean isValidating() {
+      return delegate.isValidating();
+    }
   }
 }


### PR DESCRIPTION
Soften ACCESS_EXTERNAL_* to best-effort in CachedSQLXML to fix parse failures on standalone-Xerces classpaths (disallow-doctype-decl stays fatal)

### Summary

  Make the JAXP 1.5 `ACCESS_EXTERNAL_DTD`/`ACCESS_EXTERNAL_SCHEMA` properties best-effort in `CachedSQLXML.getSource()` so cached XML reads no longer fail on classpaths with standalone Apache Xerces.

  ### Description
  
 Standalone Xerces 2.x predates JAXP 1.5 and rejects `ACCESS_EXTERNAL_DTD`/`ACCESS_EXTERNAL_SCHEMA` with `IllegalArgumentException` (DOM) /`SAXNotRecognizedException` (SAX). Because `getSource()` set these fatally, every `DOMSource`/`SAXSource` read — including benign XML with no DOCTYPE — threw`SQLException` on such a classpath.

  - Set `ACCESS_EXTERNAL_*` via new `setAttributeBestEffort` / `setPropertyBestEffort` helpers that catch only the "property not recognized" exceptions.
  - `disallow-doctype-decl` and the external-entity features stay **strict and fatal** so protection is unchanged.
  -`ACCESS_EXTERNAL_*` is redundant defense-in-depth once DOCTYPE is disallowed.
  - StAX branch untouched.
  - Added `CachedSQLXMLTest` cases that simulate a standalone-Xerces classpath (per-test JAXP factory override): benign XML now parses, DOCTYPE payloads are still rejected.

Behavior mirrors pgjdbc's best-effort handling of the same properties, while staying stricter on the DOCTYPE control.

  ### Additional Reviewers

  <!-- Any additional reviewers -->

  ### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.