### PR TITLE
fix: handle SUBSTITUTE_WITH_ANY

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/PartialPluginService.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/PartialPluginService.java
@@ -183,7 +183,7 @@ public class PartialPluginService implements PluginService, CanReleaseResources,
   }
 
   @Override
-  public boolean acceptsStrategy(HostRole role, String strategy) throws SQLException {
+  public boolean acceptsStrategy(@Nullable HostRole role, String strategy) throws SQLException {
     throw new UnsupportedOperationException(
         Messages.get("PartialPluginService.unexpectedMethodCall", new Object[] {"acceptsStrategy"}));
   }

--- a/wrapper/src/main/java/software/amazon/jdbc/PluginService.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/PluginService.java
@@ -97,14 +97,14 @@ public interface PluginService extends ExceptionHandler, Wrapper, StateSnapshotP
    * {@link ConnectionPlugin} instances support the selection of a host with the requested role and
    * strategy via {@link #getHostSpecByStrategy}.
    *
-   * @param role     the desired host role
+   * @param role     the desired host role, or null if any role is acceptable
    * @param strategy the strategy that should be used to pick a host (eg "random")
    * @return true if the available {@link ConnectionProvider} or {@link ConnectionPlugin} instances
    *     support the selection of a host with the requested role and strategy via
    *     {@link #getHostSpecByStrategy}. Otherwise, return false.
    * @throws SQLException if there's an error processing this method.
    */
-  boolean acceptsStrategy(HostRole role, String strategy) throws SQLException;
+  boolean acceptsStrategy(@Nullable HostRole role, String strategy) throws SQLException;
 
   /**
    * Selects a {@link HostSpec} with the requested role from available hosts using the requested

--- a/wrapper/src/main/java/software/amazon/jdbc/PluginServiceImpl.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/PluginServiceImpl.java
@@ -243,7 +243,7 @@ public class PluginServiceImpl implements PluginService, CanReleaseResources,
   }
 
   @Override
-  public boolean acceptsStrategy(HostRole role, String strategy) throws SQLException {
+  public boolean acceptsStrategy(@Nullable HostRole role, String strategy) throws SQLException {
     return this.pluginManager.acceptsStrategy(role, strategy);
   }
 

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/AuroraInitialConnectionStrategyPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/AuroraInitialConnectionStrategyPlugin.java
@@ -596,8 +596,10 @@ public class AuroraInitialConnectionStrategyPlugin extends AbstractConnectionPlu
     }
 
     final HostRole targetRole = InstanceSubstitutionStrategy.toTargetRole(substitutionStrategy);
+    // targetRole may by null if the url is a RDS Custom Endpoint.
     final String selectionStrategy = this.selectionStrategyPropValue;
-    if (targetRole == null || selectionStrategy == null
+    if (selectionStrategy == null
+        || (targetRole == null && urlType != RdsUrlType.RDS_CUSTOM_CLUSTER)
         || !this.pluginService.acceptsStrategy(targetRole, selectionStrategy)) {
       throw new UnsupportedOperationException(
           Messages.get(
@@ -679,7 +681,7 @@ public class AuroraInitialConnectionStrategyPlugin extends AbstractConnectionPlu
         return HostRole.WRITER;
       }
 
-      if (substitutionStrategy == SUBSTITUTE_WITH_READER) {
+      if (substitutionStrategy == InstanceSubstitutionStrategy.SUBSTITUTE_WITH_READER) {
         return HostRole.READER;
       }
 

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/AuroraInitialConnectionStrategyPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/AuroraInitialConnectionStrategyPlugin.java
@@ -596,7 +596,7 @@ public class AuroraInitialConnectionStrategyPlugin extends AbstractConnectionPlu
     }
 
     final HostRole targetRole = InstanceSubstitutionStrategy.toTargetRole(substitutionStrategy);
-    // targetRole may by null if the url is a RDS Custom Endpoint.
+    // targetRole may be null if the url is a RDS Custom Endpoint.
     final String selectionStrategy = this.selectionStrategyPropValue;
     if (selectionStrategy == null
         || (targetRole == null && urlType != RdsUrlType.RDS_CUSTOM_CLUSTER)


### PR DESCRIPTION
### Summary

`getCandidateHost` incorrectly throws unsupported error for custom endpoints using the `any` substitution strategy

### Description

`InstanceSubstitutionStrategy.toTargetRole(substitutionStrategy);` returns null if the strategy is `any` and `getCandidateHost` treats `targetRole == null` as an invalid result.

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.