### PR TITLE
docs: complete Javadoc tags to clear doclint warnings

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/PluginCallContext.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/PluginCallContext.java
@@ -51,12 +51,21 @@ public class PluginCallContext {
     this.rebindHandle = null;
   }
 
-  /** Sets the rebind handle for the current call (see {@link #rebindHandle}). */
+  /**
+   * Sets the rebind handle for the current call (see {@link #rebindHandle}).
+   *
+   * @param rebindHandle the handle to the statement wrapper for the current call, or {@code null}
+   *     to clear it
+   */
   public void setRebindHandle(final @Nullable Rebindable rebindHandle) {
     this.rebindHandle = rebindHandle;
   }
 
-  /** Returns the rebind handle for the current call, or {@code null} if none. */
+  /**
+   * Returns the rebind handle for the current call, or {@code null} if none.
+   *
+   * @return the handle to the statement wrapper for the current call, or {@code null} if none
+   */
   public @Nullable Rebindable getRebindHandle() {
     return this.rebindHandle;
   }

--- a/wrapper/src/main/java/software/amazon/jdbc/Rebindable.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/Rebindable.java
@@ -31,7 +31,12 @@ import java.sql.SQLException;
  */
 public interface Rebindable extends ConnectionBoundObject {
 
-  /** The connection the current target statement is bound to. */
+  /**
+   * The connection the current target statement is bound to.
+   *
+   * @return the underlying (target) connection the current target statement is bound to
+   * @throws SQLException if the bound connection cannot be determined
+   */
   Connection getBoundConnection() throws SQLException;
 
   /**
@@ -52,6 +57,7 @@ public interface Rebindable extends ConnectionBoundObject {
    * against the new target statement.
    *
    * @param newConnection the underlying (target) connection to rebind to
+   * @throws SQLException if the target statement cannot be re-created on {@code newConnection}
    */
   void rebind(Connection newConnection) throws SQLException;
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/AbstractMonitoringConnectionHandler.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/AbstractMonitoringConnectionHandler.java
@@ -89,21 +89,30 @@ public abstract class AbstractMonitoringConnectionHandler<P> implements Monitori
    *
    * @param host     the host being considered
    * @param isWriter whether the connection is to a writer
+   * @return the matching priority index, or {@code -1} if no priority matches
    */
   protected abstract int getPriorityIndex(HostSpec host, boolean isWriter);
 
   /**
    * Returns all hosts in {@code hosts} that match the priority at {@code priorityIndex} of {@link #priorities}.
+   *
+   * @param priorityIndex the index into {@link #priorities} to match against
+   * @param hosts         the hosts to filter
+   * @return the hosts matching the given priority
    */
   protected abstract List<HostSpec> findHostsForPriority(int priorityIndex, List<HostSpec> hosts);
 
   /**
    * Returns the thread-name prefix used for the async upgrade executor (e.g., {@code "atmu"} or {@code "gatmu"}).
+   *
+   * @return the thread-name prefix for the async upgrade executor
    */
   protected abstract String getUpgradeThreadName();
 
   /**
    * Hook for subclasses to publish additional snapshot state (e.g., GDB primary region). Returns null when none.
+   *
+   * @return additional snapshot state, or {@code null} when the subclass publishes none
    */
   protected @Nullable List<Pair<String, Object>> getAdditionalSnapshotState() {
     return null;
@@ -114,6 +123,9 @@ public abstract class AbstractMonitoringConnectionHandler<P> implements Monitori
   /**
    * Formats a priority index for logging. {@link Integer#MAX_VALUE} is shown as {@code <none>}
    * to avoid confusing users with a 10-digit number.
+   *
+   * @param index the priority index to format
+   * @return the formatted priority index
    */
   protected static String formatPriorityIndex(final int index) {
     return index == Integer.MAX_VALUE ? "<none>" : Integer.toString(index);
@@ -345,6 +357,9 @@ public abstract class AbstractMonitoringConnectionHandler<P> implements Monitori
    * Returns candidates grouped by priority, with the highest priority bucket first. The caller is responsible
    * for shuffling each bucket before iterating, so that different hosts within the same priority are tried first
    * on different upgrade cycles.
+   *
+   * @param hosts the hosts to group into priority buckets
+   * @return the candidate buckets, highest priority first
    */
   protected List<List<HostSpec>> findUpgradeCandidates(List<HostSpec> hosts) {
     List<List<HostSpec>> candidatesByPriority = new ArrayList<>();

--- a/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/ClusterTopologyMonitorImpl.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/ClusterTopologyMonitorImpl.java
@@ -200,6 +200,8 @@ public class ClusterTopologyMonitorImpl extends AbstractMonitor
    * Returns the connection handler, creating it lazily on first access.
    * Lazy initialization is required so that subclass state (e.g., shadowed fields) is fully initialized
    * before {@link #createConnectionHandler()} is invoked.
+   *
+   * @return the monitoring connection handler for this monitor
    */
   protected MonitoringConnectionHandler getConnectionHandler() {
     if (this.connectionHandler == null) {
@@ -285,6 +287,8 @@ public class ClusterTopologyMonitorImpl extends AbstractMonitor
    * instead of blocking until the failover timeout. Used for non-recoverable configuration problems.
    * A new exception instance is thrown so the stack trace reflects the waiting thread while the original
    * message, SQL state, and cause are preserved.
+   *
+   * @throws SQLException if a fatal error was recorded by a node monitor
    */
   protected void throwIfFatalError() throws SQLException {
     final SQLException fatal = this.fatalError.get();
@@ -296,6 +300,8 @@ public class ClusterTopologyMonitorImpl extends AbstractMonitor
   /**
    * Records a non-recoverable configuration error detected by a node monitor and wakes any threads
    * waiting for a topology update so they can fail fast instead of blocking until the failover timeout.
+   *
+   * @param ex the non-recoverable configuration error to record
    */
   protected void recordFatalError(final SQLException ex) {
     if (this.fatalError.compareAndSet(null, ex)) {
@@ -313,6 +319,9 @@ public class ClusterTopologyMonitorImpl extends AbstractMonitor
    * connection host is not a recognized RDS endpoint and no clusterInstanceHostPattern was supplied),
    * and the underlying cause is an {@link UnknownHostException}. In that case the derived instance
    * endpoints can never resolve, so retrying until the failover timeout is pointless.
+   *
+   * @param t the connection failure to inspect
+   * @return {@code true} if the failure is a permanent, misconfiguration-caused DNS failure
    */
   protected boolean isUnresolvableDueToMisconfiguration(final Throwable t) {
     if (!"?".equals(this.instanceTemplate.getHost())) {
@@ -775,6 +784,11 @@ public class ClusterTopologyMonitorImpl extends AbstractMonitor
    * Submits a node-monitoring worker for {@code hostSpec} unless one has already been submitted for that host.
    * Any {@link SQLException} raised while creating the worker is collected into {@code exceptionList} and the host
    * is left unsubmitted so it can be retried on a later cycle.
+   *
+   * @param hostSpec                the host to monitor
+   * @param baselineWriter          the writer known at submission time, or {@code null} if unknown
+   * @param someRegionsInaccessible whether some regions were found inaccessible
+   * @param exceptionList           collects exceptions raised while creating the worker
    */
   // ConcurrentHashMap.computeIfAbsent permits the mapping function to return null (meaning "record no mapping"),
   // but the annotated JDK stub types the function as returning @NonNull; suppress that stub asymmetry here.

--- a/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/TopologyUtils.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/TopologyUtils.java
@@ -175,6 +175,8 @@ public abstract class TopologyUtils {
    * @param instanceName     the database instance name.
    * @param isWriter         true if this is a writer instance, false for reader.
    * @param weight           the instance weight for load balancing.
+   * @param cpuPercent       the instance CPU utilization, in percent, or {@code null} if unknown.
+   * @param lag              the instance replication lag, in milliseconds, or {@code null} if unknown.
    * @param lastUpdateTime   the timestamp of the last update to this instance's information.
    * @param initialHostSpec  the original host specification used for connecting.
    * @param instanceTemplate the template used to construct the new {@link HostSpec}.

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/AuroraInitialConnectionStrategyPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/AuroraInitialConnectionStrategyPlugin.java
@@ -325,6 +325,15 @@ public class AuroraInitialConnectionStrategyPlugin extends AbstractConnectionPlu
    * topology when available; if the topology isn't available yet, a connection is opened via the initial endpoint
    * (which also confirms the dialect and acts as a fallback) and, when {@code waitForInitialTopologyMs > 0}, the
    * topology fetch is awaited before re-attempting instance selection.
+   *
+   * @param originalConnectHost  the host the caller originally asked to connect to
+   * @param urlType              the RDS URL type of {@code originalConnectHost}
+   * @param substitutionStrategy the instance substitution strategy to apply
+   * @param props                the connection properties to connect with
+   * @param connectFunc          the downstream connect function for the original endpoint
+   * @param candidateConnHolder  receives the opened candidate connection
+   * @return the host the candidate connection was established to
+   * @throws SQLException if no candidate connection could be opened
    */
   protected HostSpec openCandidateConnection(
       final @NonNull HostSpec originalConnectHost,
@@ -372,6 +381,14 @@ public class AuroraInitialConnectionStrategyPlugin extends AbstractConnectionPlu
    * <p>Returns the selected instance host if the topology was fetched and the instance connection succeeded; the
    * connection is then held in {@code candidateConnHolder}. Otherwise returns {@code originalConnectHost} and the
    * already-opened initial-endpoint connection (still held in {@code candidateConnHolder}) is kept as a fallback.
+   *
+   * @param originalConnectHost  the host the caller originally asked to connect to
+   * @param urlType              the RDS URL type of {@code originalConnectHost}
+   * @param substitutionStrategy the instance substitution strategy to apply
+   * @param props                the connection properties to connect with
+   * @param candidateConnHolder  holds the fallback connection and receives the instance connection
+   * @return the selected instance host, or {@code originalConnectHost} when the fallback is kept
+   * @throws SQLException if waiting for the topology fails
    */
   protected HostSpec waitForTopologyAndConnectToInstance(
       final @NonNull HostSpec originalConnectHost,

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/AwsSecretsManagerConnectionPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/AwsSecretsManagerConnectionPlugin.java
@@ -446,8 +446,10 @@ public class AwsSecretsManagerConnectionPlugin extends AbstractConnectionPlugin 
   /**
    * Called to update credentials from the cache, or from the AWS Secrets Manager service.
    *
+   * @param hostSpec     the host the credentials are being resolved for.
    * @param forceReFetch Allows ignoring cached credentials and force fetches the latest credentials from the service.
    * @return true, if credentials were fetched from the service.
+   * @throws SQLException if the secret could not be fetched or parsed.
    */
   protected boolean updateSecret(final HostSpec hostSpec, final boolean forceReFetch) throws SQLException {
 

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/bluegreen/BlueGreenStatusMonitor.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/bluegreen/BlueGreenStatusMonitor.java
@@ -784,6 +784,10 @@ public class BlueGreenStatusMonitor {
 
   /**
    * Attempts a single IP connection. Used as a fallback when only one IP is known.
+   *
+   * @param ip the IP address to connect to
+   * @param connectionHostSpecCopy the host spec the IP host spec is derived from
+   * @return the opened connection, or {@code null} if the attempt failed
    */
   protected @Nullable Connection tryConnectToSingleIp(String ip, HostSpec connectionHostSpecCopy) {
     try {

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/AutoReadWriteSplittingPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/AutoReadWriteSplittingPlugin.java
@@ -42,7 +42,12 @@ public class AutoReadWriteSplittingPlugin extends ReadWriteSplittingPlugin {
     super(pluginService, properties, auto(properties));
   }
 
-  /** Builds the SQL-driven (prepare-time) routing assembly with a sticky reader. */
+  /**
+   * Builds the SQL-driven (prepare-time) routing assembly with a sticky reader.
+   *
+   * @param props the connection properties the assembly is configured from
+   * @return the helper assembly used by this plugin
+   */
   protected static RwSplitHelpers auto(final Properties props) {
     final TopologyRoleClassifier roleClassifier = new TopologyRoleClassifier();
     final String strategy = readerHostSelectorStrategy(props);

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/GdbReadWriteSplittingPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/GdbReadWriteSplittingPlugin.java
@@ -46,13 +46,24 @@ public class GdbReadWriteSplittingPlugin extends ReadWriteSplittingPlugin {
     super(pluginService, properties, gdb(properties));
   }
 
-  /** Constructor for subclasses that supply their own helper assembly. */
+  /**
+   * Constructor for subclasses that supply their own helper assembly.
+   *
+   * @param pluginService the plugin service this plugin operates through
+   * @param properties the connection properties
+   * @param helpers the helper assembly that drives routing decisions
+   */
   protected GdbReadWriteSplittingPlugin(
       final PluginService pluginService, final Properties properties, final RwSplitHelpers helpers) {
     super(pluginService, properties, helpers);
   }
 
-  /** Builds the Global Database assembly (region rules + GWF) with {@code setReadOnly} routing. */
+  /**
+   * Builds the Global Database assembly (region rules + GWF) with {@code setReadOnly} routing.
+   *
+   * @param props the connection properties the assembly is configured from
+   * @return the helper assembly used by this plugin
+   */
   protected static RwSplitHelpers gdb(final Properties props) {
     return gdbHelpers(props, new ReadOnlyFlagSignal(), new TransactionAwareGate());
   }
@@ -60,6 +71,11 @@ public class GdbReadWriteSplittingPlugin extends ReadWriteSplittingPlugin {
   /**
    * Shared Global Database assembly builder, parameterized by routing signal and switch gate so
    * the SQL-routed variant can reuse it.
+   *
+   * @param props the connection properties the assembly is configured from
+   * @param routingSignal the signal that decides whether a reader or a writer is required
+   * @param switchGate the gate that decides when a connection switch is allowed
+   * @return the helper assembly built from the given parts
    */
   protected static RwSplitHelpers gdbHelpers(
       final Properties props,

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/GdbSettings.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/GdbSettings.java
@@ -77,7 +77,13 @@ public class GdbSettings {
     this.enableGwf = ENABLE_GWF.getBoolean(properties);
   }
 
-  /** Resolves and validates the home region and accessible regions (idempotent). */
+  /**
+   * Resolves and validates the home region and accessible regions (idempotent).
+   *
+   * @param initHostSpec the host the region is inferred from when not configured explicitly
+   * @param props the connection properties holding the region configuration
+   * @throws SQLException if the home region cannot be determined or is not accessible
+   */
   public void init(final HostSpec initHostSpec, final Properties props) throws SQLException {
     if (this.isInit) {
       return;
@@ -157,7 +163,11 @@ public class GdbSettings {
     return region != null && this.homeRegion != null && region.equalsIgnoreCase(this.homeRegion);
   }
 
-  /** Snapshot fragment fields shared by GDB helpers. */
+  /**
+   * Snapshot fragment fields shared by GDB helpers.
+   *
+   * @param state the snapshot state list the fields are appended to
+   */
   // Checker Framework: snapshot values are intentionally nullable, but the
   // StateSnapshotProvider contract types them as Pair<String, Object> (non-null Object).
   // Fixing this properly means widening that interface to Pair<String, @Nullable Object>

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/GdbSimpleReadWriteSplittingPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/GdbSimpleReadWriteSplittingPlugin.java
@@ -53,13 +53,24 @@ public class GdbSimpleReadWriteSplittingPlugin extends SimpleReadWriteSplittingP
     super(pluginService, properties, gdbSimple(properties));
   }
 
-  /** Constructor for subclasses that supply their own helper assembly. */
+  /**
+   * Constructor for subclasses that supply their own helper assembly.
+   *
+   * @param pluginService the plugin service this plugin operates through
+   * @param properties the connection properties
+   * @param helpers the helper assembly that drives routing decisions
+   */
   protected GdbSimpleReadWriteSplittingPlugin(
       final PluginService pluginService, final Properties properties, final RwSplitHelpers helpers) {
     super(pluginService, properties, helpers);
   }
 
-  /** Builds the endpoint-based Global Database assembly with {@code setReadOnly} routing. */
+  /**
+   * Builds the endpoint-based Global Database assembly with {@code setReadOnly} routing.
+   *
+   * @param props the connection properties the assembly is configured from
+   * @return the helper assembly used by this plugin
+   */
   protected static RwSplitHelpers gdbSimple(final Properties props) {
     return gdbEndpointHelpers(props, new ReadOnlyFlagSignal(), new TransactionAwareGate());
   }
@@ -70,6 +81,11 @@ public class GdbSimpleReadWriteSplittingPlugin extends SimpleReadWriteSplittingP
    * missing. The write endpoint host is seeded before writer resolution (via
    * {@link EndpointWriterHostRefresher}) so the {@link GdbWriterResolver} can evaluate its region
    * for accessible-region / home-region rules and Global Write Forwarding.
+   *
+   * @param props the connection properties the assembly is configured from
+   * @param routingSignal the signal that decides whether a reader or a writer is required
+   * @param switchGate the gate that decides when a connection switch is allowed
+   * @return the helper assembly built from the given parts
    */
   protected static RwSplitHelpers gdbEndpointHelpers(
       final Properties props, final RoutingSignal routingSignal, final SwitchGate switchGate) {

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/ReadWriteSplittingPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/ReadWriteSplittingPlugin.java
@@ -59,7 +59,13 @@ public class ReadWriteSplittingPlugin extends UnifiedReadWriteSplittingPlugin {
     super(pluginService, properties, topology(properties));
   }
 
-  /** Constructor for subclasses that supply their own helper assembly. */
+  /**
+   * Constructor for subclasses that supply their own helper assembly.
+   *
+   * @param pluginService the plugin service this plugin operates through
+   * @param properties the connection properties
+   * @param helpers the helper assembly that drives routing decisions
+   */
   protected ReadWriteSplittingPlugin(
       final PluginService pluginService, final Properties properties, final RwSplitHelpers helpers) {
     super(pluginService, properties, helpers);
@@ -73,7 +79,12 @@ public class ReadWriteSplittingPlugin extends UnifiedReadWriteSplittingPlugin {
     return READER_HOST_SELECTOR_STRATEGY.getString(props);
   }
 
-  /** Builds the topology-aware, {@code setReadOnly}-driven, sticky-reader assembly. */
+  /**
+   * Builds the topology-aware, {@code setReadOnly}-driven, sticky-reader assembly.
+   *
+   * @param props the connection properties the assembly is configured from
+   * @return the helper assembly used by this plugin
+   */
   protected static RwSplitHelpers topology(final Properties props) {
     final TopologyRoleClassifier roleClassifier = new TopologyRoleClassifier();
     final String strategy = readerHostSelectorStrategy(props);

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/RwSplitContext.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/RwSplitContext.java
@@ -51,19 +51,48 @@ public interface RwSplitContext {
 
   @Nullable HostSpec readerHostSpec();
 
-  /** Records the writer connection and host, preserving the legacy {@code setWriterConnection} log. */
+  /**
+   * Records the writer connection and host, preserving the legacy {@code setWriterConnection} log.
+   *
+   * @param conn the writer connection to record
+   * @param host the host the writer connection is established to
+   * @throws SQLException if the writer connection cannot be recorded
+   */
   void bindWriter(Connection conn, HostSpec host) throws SQLException;
 
-  /** Records the resolved writer host (without a connection), e.g. after a topology refresh. */
+  /**
+   * Records the resolved writer host (without a connection), e.g. after a topology refresh.
+   *
+   * @param host the resolved writer host
+   */
   void setWriterHostSpec(HostSpec host);
 
-  /** Records (caches) the reader connection and host, preserving the legacy {@code setReaderConnection} log. */
+  /**
+   * Records (caches) the reader connection and host, preserving the legacy
+   * {@code setReaderConnection} log.
+   *
+   * @param conn the reader connection to cache
+   * @param host the host the reader connection is established to
+   */
   void bindReader(Connection conn, HostSpec host);
 
-  /** Switches the wrapper's current connection to the given connection/host. */
+  /**
+   * Switches the wrapper's current connection to the given connection/host.
+   *
+   * @param conn the connection to switch to
+   * @param host the host the connection is established to
+   * @throws SQLException if the current connection cannot be switched
+   */
   void switchCurrentConnectionTo(Connection conn, HostSpec host) throws SQLException;
 
-  /** Opens a connection to the given host via the plugin service (using this plugin as the caller). */
+  /**
+   * Opens a connection to the given host via the plugin service (using this plugin as the caller).
+   *
+   * @param host the host to connect to
+   * @param props the connection properties to connect with
+   * @return the newly opened connection
+   * @throws SQLException if the connection cannot be opened
+   */
   Connection connect(HostSpec host, Properties props) throws SQLException;
 
   /** Marks that the plugin is actively read/write splitting (sets {@code inReadWriteSplit}). */
@@ -85,9 +114,21 @@ public interface RwSplitContext {
 
   boolean isWriterFromPool();
 
-  /** Logs the message at SEVERE and throws a {@link ReadWriteSplittingSQLException}. */
+  /**
+   * Logs the message at SEVERE and throws a {@link ReadWriteSplittingSQLException}.
+   *
+   * @param message the message to log and to report in the exception
+   * @throws SQLException always, as a {@link ReadWriteSplittingSQLException}
+   */
   void logAndThrow(String message) throws SQLException;
 
-  /** Logs the message at SEVERE and throws a {@link ReadWriteSplittingSQLException} with the SQL state. */
+  /**
+   * Logs the message at SEVERE and throws a {@link ReadWriteSplittingSQLException} with the SQL
+   * state.
+   *
+   * @param message the message to log and to report in the exception
+   * @param sqlState the SQL state to report in the exception
+   * @throws SQLException always, as a {@link ReadWriteSplittingSQLException}
+   */
   void logAndThrow(String message, SqlState sqlState) throws SQLException;
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/RwSplitSnapshots.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/RwSplitSnapshots.java
@@ -28,7 +28,12 @@ public final class RwSplitSnapshots {
   private RwSplitSnapshots() {
   }
 
-  /** Fragment exposing the reader host selector strategy (topology-based codes). */
+  /**
+   * Fragment exposing the reader host selector strategy (topology-based codes).
+   *
+   * @param strategy the reader host selector strategy to expose
+   * @return a contributor exposing the reader host selector strategy
+   */
   public static SnapshotContributor readerStrategy(final String strategy) {
     return () -> {
       final List<Pair<String, Object>> state = new ArrayList<>();
@@ -37,7 +42,18 @@ public final class RwSplitSnapshots {
     };
   }
 
-  /** Fragment exposing the endpoint (Simple) configuration. */
+  /**
+   * Fragment exposing the endpoint (Simple) configuration.
+   *
+   * @param verifyNewConnections whether newly opened connections have their role verified
+   * @param writeEndpoint the configured write endpoint
+   * @param readEndpoint the configured read endpoint
+   * @param verifyOpenedConnectionType the role newly opened connections are verified against,
+   *     or {@code null} when no role is enforced
+   * @param retryIntervalMs the interval between connection attempts, in milliseconds
+   * @param retryTimeoutMs the overall connection attempt timeout, in milliseconds
+   * @return a contributor exposing the endpoint configuration
+   */
   // Checker Framework: snapshot values are intentionally nullable, but the
   // StateSnapshotProvider contract types them as Pair<String, Object> (non-null Object).
   // Fixing this properly means widening that interface to Pair<String, @Nullable Object>

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/SimpleReadWriteSplittingPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/SimpleReadWriteSplittingPlugin.java
@@ -91,13 +91,24 @@ public class SimpleReadWriteSplittingPlugin extends UnifiedReadWriteSplittingPlu
     super(pluginService, properties, simple(properties));
   }
 
-  /** Constructor for subclasses that supply their own helper assembly. */
+  /**
+   * Constructor for subclasses that supply their own helper assembly.
+   *
+   * @param pluginService the plugin service this plugin operates through
+   * @param properties the connection properties
+   * @param helpers the helper assembly that drives routing decisions
+   */
   protected SimpleReadWriteSplittingPlugin(
       final PluginService pluginService, final Properties properties, final RwSplitHelpers helpers) {
     super(pluginService, properties, helpers);
   }
 
-  /** Builds the endpoint-based assembly with {@code setReadOnly} routing. */
+  /**
+   * Builds the endpoint-based assembly with {@code setReadOnly} routing.
+   *
+   * @param props the connection properties the assembly is configured from
+   * @return the helper assembly used by this plugin
+   */
   protected static RwSplitHelpers simple(final Properties props) {
     return endpointHelpers(props, new ReadOnlyFlagSignal(), new TransactionAwareGate(), new NoOpTopologyRefresher());
   }
@@ -105,6 +116,12 @@ public class SimpleReadWriteSplittingPlugin extends UnifiedReadWriteSplittingPlu
   /**
    * Shared endpoint assembly builder, parameterized by routing signal and switch gate so the
    * SQL-routed variant can reuse it. Fails fast when a required endpoint is missing.
+   *
+   * @param props the connection properties the assembly is configured from
+   * @param routingSignal the signal that decides whether a reader or a writer is required
+   * @param switchGate the gate that decides when a connection switch is allowed
+   * @param topologyRefresher the topology refresher to use; endpoint mode does not refresh topology
+   * @return the helper assembly built from the given parts
    */
   protected static RwSplitHelpers endpointHelpers(
       final Properties props,

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/UnifiedReadWriteSplittingPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/UnifiedReadWriteSplittingPlugin.java
@@ -211,6 +211,10 @@ public abstract class UnifiedReadWriteSplittingPlugin extends AbstractConnection
    * Builds the reader load-balancing policy for an assembly: {@link PerQueryBalancedReaderPolicy}
    * when {@code queryLevelLoadBalancing} is enabled (honoring {@code loadBalancingIncludeWriter}),
    * otherwise a {@link StickyReaderPolicy}.
+   *
+   * @param props the connection properties the policy is configured from
+   * @param strategy the host selector strategy used to pick a reader
+   * @return the reader load-balancing policy for the assembly
    */
   protected static LoadBalancingPolicy readerLoadBalancer(final Properties props, final String strategy) {
     if (QUERY_LEVEL_LOAD_BALANCING.getBoolean(props)) {

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/balancer/LoadBalancingPolicy.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/balancer/LoadBalancingPolicy.java
@@ -36,6 +36,7 @@ public interface LoadBalancingPolicy {
    * @param ctx        the read/write splitting context
    * @param candidates the eligible reader candidates
    * @return the chosen reader host, or {@code null} if none is available
+   * @throws SQLException if the candidates cannot be evaluated
    */
   @Nullable HostSpec pickReader(RwSplitContext ctx, List<HostSpec> candidates) throws SQLException;
 

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/gate/SwitchGate.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/gate/SwitchGate.java
@@ -34,6 +34,7 @@ public interface SwitchGate {
    * @param ctx     the read/write splitting context
    * @param desired the desired target role
    * @return {@code true} if switching is allowed, {@code false} to pin the current connection
+   * @throws SQLException if the transition is illegal or the gate cannot be evaluated
    */
   boolean canSwitch(RwSplitContext ctx, TargetRole desired) throws SQLException;
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/handler/EndpointConnectionVerifier.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/handler/EndpointConnectionVerifier.java
@@ -56,6 +56,15 @@ public class EndpointConnectionVerifier {
   /**
    * Opens a verified connection to {@code hostSpec} (or via {@code connectFunc} when non-null),
    * retrying until the timeout. Returns {@code null} if verification could not be completed.
+   *
+   * @param ctx the read/write splitting context
+   * @param props the connection properties to connect with
+   * @param hostSpec the host to connect to, or {@code null} when {@code connectFunc} is used
+   * @param hostRole the role the opened connection is verified against
+   * @param connectFunc the downstream connect function, or {@code null} to connect to
+   *     {@code hostSpec} through the plugin service
+   * @return a verified connection, or {@code null} if verification could not be completed
+   * @throws SQLException if connecting fails in a non-retryable way
    */
   public @Nullable Connection getVerifiedConnection(
       final RwSplitContext ctx,

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/handler/InitialConnectionHandler.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/handler/InitialConnectionHandler.java
@@ -41,6 +41,7 @@ public interface InitialConnectionHandler {
    * @param isInitialConnection whether this is the initial connection
    * @param connectFunc         the downstream connect function
    * @return the established connection
+   * @throws SQLException if the connection cannot be established or fails verification
    */
   Connection onConnect(
       RwSplitContext ctx,

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/resolver/ReaderResolver.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/resolver/ReaderResolver.java
@@ -33,6 +33,7 @@ public interface ReaderResolver {
    * switching the current connection to it). Mirrors the legacy {@code initializeReaderConnection}.
    *
    * @param ctx the read/write splitting context
+   * @throws SQLException if no reader connection could be established
    */
   void switchToReader(RwSplitContext ctx) throws SQLException;
 

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/resolver/WriterResolver.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/resolver/WriterResolver.java
@@ -33,6 +33,7 @@ public interface WriterResolver {
    *
    * @param ctx the read/write splitting context
    * @return the writer resolution
+   * @throws SQLException if the writer cannot be resolved or connected to
    */
   WriterResolution resolveWriter(RwSplitContext ctx) throws SQLException;
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/signal/RoutingSignal.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/signal/RoutingSignal.java
@@ -46,6 +46,7 @@ public interface RoutingSignal {
    * @param methodName the JDBC method being invoked
    * @param args       the method arguments (may be {@code null})
    * @return the desired target role
+   * @throws SQLException if the desired role cannot be resolved
    */
   TargetRole resolve(RwSplitContext ctx, String methodName, @Nullable Object[] args)
       throws SQLException;
@@ -57,6 +58,7 @@ public interface RoutingSignal {
    *
    * @param ctx the read/write splitting context
    * @return the desired role, or {@link TargetRole#NO_DECISION} if this signal does not apply
+   * @throws SQLException if the desired role cannot be resolved
    */
   default TargetRole resolveForBoundStatement(RwSplitContext ctx) throws SQLException {
     return TargetRole.NO_DECISION;

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/source/ReaderCandidateSource.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/source/ReaderCandidateSource.java
@@ -33,6 +33,7 @@ public interface ReaderCandidateSource {
    *
    * @param ctx the read/write splitting context
    * @return the candidate hosts (never {@code null}; may be empty)
+   * @throws SQLException if the candidates cannot be determined
    */
   List<HostSpec> candidates(RwSplitContext ctx) throws SQLException;
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/util/WrapperUtils.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/WrapperUtils.java
@@ -231,6 +231,16 @@ public class WrapperUtils {
    * bound object, so no stale-object check can be performed; a {@link JdbcMethod} declared with
    * {@code checkBoundedConnection} must use {@link #executeWithPluginsWithBoundObject} instead, which
    * is asserted at runtime while assertions are enabled.
+   *
+   * @param resultClass       the expected result type
+   * @param connectionWrapper the wrapper connection the call belongs to
+   * @param pluginManager     the plugin manager driving the pipeline
+   * @param methodInvokeOn    the target object the method is invoked on
+   * @param jdbcMethod        the JDBC method being invoked
+   * @param jdbcMethodFunc    the call to the target JDBC method
+   * @param jdbcMethodArgs    the arguments passed to the JDBC method
+   * @param <T>               the result type
+   * @return the (possibly wrapped) result of the JDBC method
    */
   public static <T> T executeWithPlugins(
       final Class<T> resultClass,
@@ -318,6 +328,20 @@ public class WrapperUtils {
    * recorded when it was created, which lets this method reject an object left over from a connection
    * that has since been swapped out. Must be used by every {@link JdbcMethod} declared with
    * {@code checkBoundedConnection}; other methods can use {@link #executeWithPlugins}.
+   *
+   * @param resultClass       the expected result type
+   * @param exceptionClass    the checked exception type the JDBC method may throw
+   * @param connectionWrapper the wrapper connection the call belongs to
+   * @param pluginManager     the plugin manager driving the pipeline
+   * @param boundObject       the invoking wrapper, carrying its connection generation
+   * @param methodInvokeOn    the target object the method is invoked on
+   * @param jdbcMethod        the JDBC method being invoked
+   * @param jdbcMethodFunc    the call to the target JDBC method
+   * @param jdbcMethodArgs    the arguments passed to the JDBC method
+   * @param <T>               the result type
+   * @param <E>               the checked exception type
+   * @return the (possibly wrapped) result of the JDBC method
+   * @throws E if the JDBC method or a plugin throws it
    */
   public static <T, E extends Exception> T executeWithPluginsWithBoundObject(
       final Class<T> resultClass,
@@ -341,6 +365,21 @@ public class WrapperUtils {
    * execute-with-SQL methods that support rerouting. The same handle is the bound object of the call
    * (see {@link #executeWithPluginsWithBoundObject}), since a {@link Rebindable} is bound to the
    * connection its target statement was created on.
+   *
+   * @param resultClass       the expected result type
+   * @param exceptionClass    the checked exception type the JDBC method may throw
+   * @param connectionWrapper the wrapper connection the call belongs to
+   * @param pluginManager     the plugin manager driving the pipeline
+   * @param methodInvokeOn    the target object the method is invoked on
+   * @param jdbcMethod        the JDBC method being invoked
+   * @param jdbcMethodFunc    the call to the target JDBC method
+   * @param rebindHandle      the invoking statement wrapper, published for the call, or
+   *                          {@code null} when rebinding is not enabled for it
+   * @param jdbcMethodArgs    the arguments passed to the JDBC method
+   * @param <T>               the result type
+   * @param <E>               the checked exception type
+   * @return the (possibly wrapped) result of the JDBC method
+   * @throws E if the JDBC method or a plugin throws it
    */
   public static <T, E extends Exception> T executeWithPluginsWithRebindHandle(
       final Class<T> resultClass,

--- a/wrapper/src/main/java/software/amazon/jdbc/wrapper/CallableStatementWrapper.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/wrapper/CallableStatementWrapper.java
@@ -92,6 +92,8 @@ public class CallableStatementWrapper implements CallableStatement, Rebindable {
    * {@link PreparedStatementWrapper.Repreparer} used to re-create the statement on a routed
    * connection. Called by {@code ConnectionWrapper} only when query-level load balancing with
    * rebinding is configured.
+   *
+   * @param repreparer re-creates the target statement on a routed connection
    */
   public void enableRebind(final PreparedStatementWrapper.Repreparer repreparer) {
     final PreparedStatementRecorder.Installed<CallableStatement> installed =

--- a/wrapper/src/main/java/software/amazon/jdbc/wrapper/PreparedStatementWrapper.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/wrapper/PreparedStatementWrapper.java
@@ -98,6 +98,8 @@ public class PreparedStatementWrapper implements PreparedStatement, Rebindable {
    * configuration setters are captured, and stores the {@link Repreparer} used to re-create the
    * statement on a routed connection. Called by {@code ConnectionWrapper} only when query-level
    * load balancing with rebinding is configured.
+   *
+   * @param repreparer re-creates the target statement on a routed connection
    */
   public void enableRebind(final Repreparer repreparer) {
     final PreparedStatementRecorder.Installed<PreparedStatement> installed =


### PR DESCRIPTION
## Summary

The `javadoc` task emits 167 doclint "missing" warnings, which surface as
build annotations (for example on the 4.4.0 Release Draft run
[32405400491](https://github.com/aws/aws-advanced-jdbc-wrapper/actions/runs/32405400491)).
GitHub caps annotations at 10 per step and javadoc itself caps output at 100
warnings, so only a fraction of them were visible.

All 167 are of the same kind: a public or protected member that has a summary
comment but is missing one or more `@param`, `@return`, or `@throws` tags. This
PR adds the missing tags so `javadoc` runs clean, which also means the published
javadoc jar documents these parameters and return values instead of leaving them
blank.

Files touched (29 members across 28 files), grouped:

- `readwritesplitting` package (the bulk): `RwSplitContext`, `RwSplitSnapshots`,
  `UnifiedReadWriteSplittingPlugin`, `ReadWriteSplittingPlugin`,
  `AutoReadWriteSplittingPlugin`, `SimpleReadWriteSplittingPlugin`,
  `GdbReadWriteSplittingPlugin`, `GdbSimpleReadWriteSplittingPlugin`,
  `GdbSettings`, and the `balancer` / `gate` / `handler` / `resolver` /
  `signal` / `source` SPI interfaces
- `util/WrapperUtils` - the three `executeWithPlugins*` overloads
- `hostlistprovider` - `AbstractMonitoringConnectionHandler`,
  `ClusterTopologyMonitorImpl`, `TopologyUtils`
- `Rebindable`, `PluginCallContext`, `PreparedStatementWrapper`,
  `CallableStatementWrapper`
- `AuroraInitialConnectionStrategyPlugin`,
  `AwsSecretsManagerConnectionPlugin`, `BlueGreenStatusMonitor`

## Not addressed

The other warnings on that run come from the third-party
`slsa-framework/slsa-github-generator` reusable workflow (Node.js 20 deprecation
for actions pinned inside the generator, plus a "Restore cache failed:
go.sum not found" notice). They cannot be fixed from this repository, and
`v2.1.0` is already the latest release of that generator.

## Testing

- `./gradlew :aws-advanced-jdbc-wrapper:javadoc --rerun-tasks` with
  `-Xmaxwarns 10000`: 167 warnings before, 0 after.
- `./gradlew :aws-advanced-jdbc-wrapper:compileJava checkstyleMain`: passes.
- The diff is comment-only. Every added and removed line is inside a javadoc
  block; no code, signature, or control flow was changed, so there is no
  behavior to regress.
