### PR TITLE
Feature/replica lag fallback

### DIFF
--- a/docs/using-the-jdbc-driver/using-plugins/UsingTheReadWriteSplittingPlugin.md
+++ b/docs/using-the-jdbc-driver/using-plugins/UsingTheReadWriteSplittingPlugin.md
@@ -38,6 +38,7 @@ When using the Read/Write Splitting Plugin against Aurora clusters, you do not h
 | `queryLevelLoadBalancing`        | Boolean |                                                                     No                                                                      | When `true`, select a fresh reader on each read-routing decision within an established read-only phase (query-level load balancing) instead of reusing a single sticky reader. See the [Query-level load balancing](#query-level-load-balancing) section.                                                                                                                                                                                                                                                                                        | `false`                                                                                                                          |
 | `loadBalancingIncludeWriter`     | Boolean |                                                                     No                                                                      | When query-level load balancing is enabled, include the writer node as an eligible target in the reader-balancing pool.                                                                                                                                                                                                                                                                                                                                                                                                                          | `false`                                                                                                                          |
 | `allowStatementRecreationOnConnectionSwitch`       | Boolean |                                                                     No                                                                      | When a read-routing decision moves execution to a different connection, re-create the already-created `Statement`/`PreparedStatement`/`CallableStatement` on the routed connection (replaying its recorded settings and, for prepared/callable statements, bound parameters and registered OUT parameters) so the query actually runs there. A statement carrying a stream/`Reader`/LOB parameter or a pending batch cannot be rebound and falls back to the current connection with a one-time warning. Set to `false` to disable rebinding. See the [Query-level load balancing](#query-level-load-balancing) section.                                                                                                                                                                                                                                                                                                                       | `true`                                                                                                                           |
+| `replicaLagThresholdMs`          | Integer |                                                                     No                                                                      | Maximum acceptable reader replication lag in milliseconds. A non-negative value routes a read to the writer when the reader that would serve it exceeds this value; `-1` disables the feature. Needs the cluster to report replication lag — Aurora publishes it via its topology monitor, any other database that reports lag on its host specs is also supported; databases that do not report lag are unaffected. When a fresh reader is selected, lag is aggregated across eligible readers: the *lowest* lag for the `lowestLoad`/`lowestLoadByLag` reader selection strategies, the *highest* lag for all others. See [Replica lag fallback](#replica-lag-fallback).                                                                                                                                                                                                                                                                   | `-1`                                                                                                                              |
 
 ## Using the Read/Write Splitting Plugin against non-Aurora clusters
 
@@ -59,6 +60,37 @@ This role check can also be safely disabled if the [Aurora Initial Connection St
 
 See the [endpoint compatibility matrix](../CompatibilityEndpoints.md) for details on which endpoint types may require this check.
 
+## Replica lag fallback
+
+Set `replicaLagThresholdMs` to a non-negative maximum lag, in milliseconds, to keep reads that could observe stale replica data on the writer. The default, `-1`, disables the feature.
+
+```java
+properties.setProperty("replicaLagThresholdMs", "1000");
+```
+
+This feature requires the cluster to publish reader replication lag. Aurora (MySQL and PostgreSQL) reports lag through its topology background monitor, which keeps an in-memory cache the driver reads without issuing a blocking topology query. Any other database or cluster whose published host specs carry lag values (e.g. a custom host-list provider) is also supported. If no lag data is available — including databases that do not report lag — routing is left unchanged and a warning is logged.
+
+### How a read is evaluated
+
+For a sticky reader or a reusable cached reader, the driver checks the lag of that specific reader only. When the next read can select a fresh reader — including query-level load balancing and reader endpoints — the lag is aggregated across all eligible backend readers according to the configured [reader selection strategy](../HostSelectionStrategies.md):
+
+| Reader selection strategy | Aggregation | A read falls back to the writer when |
+|---|---|---|
+| `lowestLoad` / `lowestLoadByLag` (lag-minimizing) | **Lowest** lag (`Math.min`) | *every* eligible reader exceeds the threshold — even the best available reader is too stale |
+| any other strategy (`random`, `roundRobin`, `lowestLoadByCpu`, custom) | **Highest** lag (`Math.max`) | *any one* eligible reader exceeds the threshold |
+
+The pessimistic `Math.max` aggregation is intentional: host-selector metrics may be stale even when the topology monitor has already seen a high lag, so the driver cannot safely assume that the selector will pick the least-lagging reader. One lagging eligible replica can therefore route a read to the writer. With `lowestLoad`/`lowestLoadByLag`, which weight lag heavily and are expected to pick the least-lagging reader, a read only falls back when every eligible reader is too stale.
+
+> [!NOTE]
+> Reader endpoints and RDS Proxy routes go through an **opaque endpoint**, so the reader selection strategy never applies there. The driver always evaluates the worst backend-reader lag — sourced from the cached Aurora topology when available, otherwise from the published host specs (the `Math.max` row above). The pinned-reader fast path also does not apply because the endpoint host does not identify the backend instance.
+
+A read inside an active local or XA transaction remains pinned to its existing connection. In an Aurora Global Database with Global Write Forwarding, a fallback can remain on a secondary-region reader because write forwarding does not make reads fresh; connect to the primary region when freshness is required.
+
+> [!WARNING]
+> When replica lag rises above the threshold, **all** reads that would normally go to readers are redirected to the writer for as long as the lag persists. In a read-heavy cluster this can instantly concentrate the full read load on the single writer, potentially overwhelming it — a connection storm, CPU/I/O overload, and even a cascading failure as the slowed writer increases lag further. Mitigations:
+> - Start with a generous threshold (e.g. several seconds). Do not set `0` in production — any positive lag, even 1 ms, will then redirect every read.
+> - Add circuit-breaking or rate-limiting at the load balancer / application level so redirected read traffic cannot overwhelm the writer during a lag spike.
+ 
 ## Query-level load balancing
 
 By default the plugin uses a **sticky reader**: once `setReadOnly(true)` establishes a reader connection, subsequent reads reuse that same reader. Setting `queryLevelLoadBalancing` to `true` switches to **query-level load balancing**: within an established read-only phase, the plugin selects a fresh reader (using the configured [reader selection strategy](../HostSelectionStrategies.md)) on each read-routing decision, distributing reads across the available readers.

--- a/docs/using-the-jdbc-driver/using-plugins/UsingTheReadWriteSplittingPlugin.md
+++ b/docs/using-the-jdbc-driver/using-plugins/UsingTheReadWriteSplittingPlugin.md
@@ -84,7 +84,13 @@ The pessimistic `Math.max` aggregation is intentional: host-selector metrics may
 > [!NOTE]
 > Reader endpoints and RDS Proxy routes go through an **opaque endpoint**, so the reader selection strategy never applies there. The driver always evaluates the worst backend-reader lag — sourced from the cached Aurora topology when available, otherwise from the published host specs (the `Math.max` row above). The pinned-reader fast path also does not apply because the endpoint host does not identify the backend instance.
 
-A read inside an active local or XA transaction remains pinned to its existing connection. In an Aurora Global Database with Global Write Forwarding, a fallback can remain on a secondary-region reader because write forwarding does not make reads fresh; connect to the primary region when freshness is required.
+The fallback never overrides explicit application intent; it is skipped entirely — no lag measurement, no topology refresh, no warning — when:
+
+- the current statement carries an explicit routing hint (for example `/*@reader*/`),
+- the session is declared read-only (`Connection.setReadOnly(true)`), which also covers read-only transactions,
+- an active local or XA transaction is in progress, since the connection is pinned to its existing connection regardless.
+
+In an Aurora Global Database with Global Write Forwarding, a fallback can remain on a secondary-region reader because write forwarding does not make reads fresh; connect to the primary region when freshness is required.
 
 > [!WARNING]
 > When replica lag rises above the threshold, **all** reads that would normally go to readers are redirected to the writer for as long as the lag persists. In a read-heavy cluster this can instantly concentrate the full read load on the single writer, potentially overwhelming it — a connection storm, CPU/I/O overload, and even a cascading failure as the slowed writer increases lag further. Mitigations:

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/UnifiedReadWriteSplittingPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/UnifiedReadWriteSplittingPlugin.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.WeakHashMap;
@@ -48,6 +49,8 @@ import software.amazon.jdbc.hostavailability.HostAvailability;
 import software.amazon.jdbc.hostlistprovider.HostListProvider;
 import software.amazon.jdbc.hostlistprovider.HostListProviderService;
 import software.amazon.jdbc.hostlistprovider.RdsHostListProvider;
+import software.amazon.jdbc.parser.RoutingHint;
+import software.amazon.jdbc.parser.SqlContextKeys;
 import software.amazon.jdbc.plugin.AbstractConnectionPlugin;
 import software.amazon.jdbc.plugin.failover.FailoverSQLException;
 import software.amazon.jdbc.plugin.readwritesplitting.balancer.LoadBalancingPolicy;
@@ -192,6 +195,11 @@ public abstract class UnifiedReadWriteSplittingPlugin extends AbstractConnection
    * it from an in-memory cache. Any other database that reports lag on its published host specs
    * (non-null {@link HostSpec#getLagMs()}) is also supported. Databases that do not report lag
    * leave routing unchanged.
+   *
+   * <p>The fallback never overrides explicit application intent: it is skipped entirely (no lag
+   * measurement, no topology refresh) when the current statement carries an explicit routing hint
+   * (e.g. {@code /*@reader* /}), when the session is declared read-only
+   * ({@code Connection.setReadOnly(true)}), or when a transaction is in progress.
    */
   public static final AwsWrapperProperty REPLICA_LAG_THRESHOLD_MS =
       new AwsWrapperProperty(
@@ -689,6 +697,10 @@ public abstract class UnifiedReadWriteSplittingPlugin extends AbstractConnection
    * no hysteresis. All wrapper connections that are routing reads will simultaneously redirect to
    * the writer for as long as lag stays above the threshold. Callers should be aware that this
    * creates a potential connection storm and CPU spike on the writer during lag events.
+   *
+   * <p>The fallback is a no-op when {@link #replicaLagFallbackCouldApply} returns {@code false}
+   * (explicit routing hint, read-only session, or open transaction): in those cases {@code desired}
+   * is returned unchanged without measuring lag.
    */
   private TargetRole applyReplicaLagFallback(final TargetRole desired) throws SQLException {
     if (!this.replicaLagFallbackCouldApply(desired)) {
@@ -716,15 +728,52 @@ public abstract class UnifiedReadWriteSplittingPlugin extends AbstractConnection
   }
 
   /**
-   * Returns {@code true} when the replica-lag fallback is enabled and the routing decision is for
-   * a reader (the only role the fallback can redirect away from).
+   * Returns {@code true} when the replica-lag fallback is enabled, the routing decision is for a
+   * reader (the only role the fallback can redirect away from), and the application has not pinned
+   * the read to a specific destination.
    *
    * <p>The threshold check uses {@code >= 0} so that {@code replicaLagThresholdMs = 0} is a valid
    * "reject any positive lag" configuration. Only {@code -1} (or any negative value) disables the
    * feature entirely.
+   *
+   * <p>The fallback — and with it the lag measurement, the topology refresh that a reroute would
+   * trigger, and the "routed to writer" warning — is skipped entirely when application intent is
+   * explicit:
+   * <ul>
+   *   <li><b>an explicit {@link RoutingHint}</b> is attached to the current statement (any hint;
+   *       only {@code READER} reaches this method) — the hint is the application overriding
+   *       automatic routing for this statement, so the fallback must not override it back;</li>
+   *   <li><b>a transaction (local or XA) is in progress</b> — {@link TransactionAwareGate}
+   *       pins the connection regardless, so measuring lag here would only add wasted work and a
+   *       misleading "routed to writer" warning;</li>
+   *   <li><b>the session is read-only</b> (declared via {@code Connection.setReadOnly(true)},
+   *       which also covers read-only transactions) — the application asked for reads and nothing
+   *       but reads, and redirecting to the writer would violate that.</li>
+   * </ul>
    */
   private boolean replicaLagFallbackCouldApply(final TargetRole desired) {
-    return this.replicaLagThresholdMs >= 0 && desired == TargetRole.READER;
+    if (this.replicaLagThresholdMs < 0 || desired != TargetRole.READER) {
+      return false;
+    }
+
+    final PluginCallContext callContext = this.pluginService.getCallContext();
+    if (callContext != null
+        && callContext.getAttribute(SqlContextKeys.ROUTING_HINT, RoutingHint.class) != null) {
+      return false;
+    }
+
+    if (this.pluginService.isInTransaction() || this.pluginService.isXaTransactionActive()) {
+      return false;
+    }
+
+    try {
+      final Optional<Boolean> readOnly = this.pluginService.getSessionStateService().getReadOnly();
+      return !(readOnly.isPresent() && readOnly.get());
+    } catch (final SQLException e) {
+      // The read-only state could not be read. Refuse to apply the fallback rather than throw into
+      // the routing path: routing intent is unknown, so lag must not redirect the read anywhere.
+      return false;
+    }
   }
 
   /**

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/UnifiedReadWriteSplittingPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/UnifiedReadWriteSplittingPlugin.java
@@ -21,6 +21,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -31,9 +32,11 @@ import java.util.logging.Logger;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import software.amazon.jdbc.AwsWrapperProperty;
+import software.amazon.jdbc.HostRole;
 import software.amazon.jdbc.HostSpec;
 import software.amazon.jdbc.JdbcCallable;
 import software.amazon.jdbc.JdbcMethod;
+import software.amazon.jdbc.LowestLoadHostSelector;
 import software.amazon.jdbc.NodeChangeOptions;
 import software.amazon.jdbc.OldConnectionSuggestedAction;
 import software.amazon.jdbc.PluginCallContext;
@@ -41,7 +44,10 @@ import software.amazon.jdbc.PluginService;
 import software.amazon.jdbc.PropertyDefinition;
 import software.amazon.jdbc.Rebindable;
 import software.amazon.jdbc.cleanup.CanReleaseResources;
+import software.amazon.jdbc.hostavailability.HostAvailability;
+import software.amazon.jdbc.hostlistprovider.HostListProvider;
 import software.amazon.jdbc.hostlistprovider.HostListProviderService;
+import software.amazon.jdbc.hostlistprovider.RdsHostListProvider;
 import software.amazon.jdbc.plugin.AbstractConnectionPlugin;
 import software.amazon.jdbc.plugin.failover.FailoverSQLException;
 import software.amazon.jdbc.plugin.readwritesplitting.balancer.LoadBalancingPolicy;
@@ -58,10 +64,80 @@ import software.amazon.jdbc.util.StateSnapshotProvider;
 import software.amazon.jdbc.util.WrapperUtils;
 
 /**
- * Unified read/write splitting plugin. Owns the shared connection state and orchestration formerly
- * in {@code AbstractReadWriteSplittingPlugin}, delegating every variable decision to injected
- * helpers ({@link RwSplitHelpers}). The existing plugin codes are reconstructed as helper
- * assemblies by their factories.
+ * Unified read/write splitting plugin. Owns the shared connection state and routing orchestration,
+ * delegating every variable decision to injected helpers ({@link RwSplitHelpers}). The concrete
+ * plugin variants ({@code readWriteSplitting}, {@code autoReadWriteSplitting}, {@code srw}, …) are
+ * assembled by their respective factory classes.
+ *
+ * <h2>Integration guide</h2>
+ *
+ * <ol>
+ *   <li><b>Plugin chain ordering</b> — place this plugin (or any subclass) <em>after</em>
+ *       {@code sqlParser} in the plugin chain when using SQL-based routing
+ *       ({@code autoReadWriteSplitting}). The {@code sqlParser} plugin populates the
+ *       {@link PluginCallContext} with the parsed {@link software.amazon.jdbc.parser.QueryType} and
+ *       optional {@link software.amazon.jdbc.parser.RoutingHint} before this plugin reads them.
+ *       Incorrect ordering causes all statements to fall back to writer routing.</li>
+ *   <li><b>Lag-based routing needs lag reporting</b> — {@code replicaLagThresholdMs} requires the
+ *       cluster to publish reader replication lag. Aurora (MySQL and PostgreSQL) reports lag
+ *       through the {@link software.amazon.jdbc.hostlistprovider.RdsHostListProvider} topology
+ *       monitor, which keeps an in-memory cache the driver reads without blocking. Any other
+ *       database or cluster whose published host specs carry non-null {@link HostSpec#getLagMs()}
+ *       (e.g. a custom host-list provider) is supported as well. If no lag data is available, the
+ *       feature silently no-ops; a one-time WARNING is logged when lag data is unavailable and the
+ *       threshold is configured.</li>
+ *   <li><b>Connection pool sizing</b> — the plugin caches up to one writer connection and one
+ *       reader connection per wrapper connection. When used behind an external connection pool,
+ *       the physical connection count may be up to 2× the logical pool size during split
+ *       read/write workloads. Size the pool accordingly.</li>
+ *   <li><b>Transaction boundaries</b> — open transactions (local and XA) are never moved. Once
+ *       a transaction starts on a reader, all statements in that transaction stay on the same
+ *       reader regardless of lag or load-balancing policy. The {@code assumeWriteTransaction}
+ *       property can route non-read-only transactions to the writer from the start.</li>
+ *   <li><b>Statement re-creation</b> — when {@code allowStatementRecreationOnConnectionSwitch}
+ *       is {@code true} (default) and a connection switch happens mid-statement, the plugin
+ *       re-creates the {@code Statement}/{@code PreparedStatement} on the new connection. This
+ *       requires the statement wrapper to implement {@link software.amazon.jdbc.Rebindable}.
+ *       Statements with pending batch operations or one-shot stream parameters cannot be rebound
+ *       and stay on their original connection instead.</li>
+ * </ol>
+ *
+ * <h2>⚠ Writer-storm risk — read carefully before enabling {@code replicaLagThresholdMs}</h2>
+ *
+ * <p>When replica lag rises above {@code replicaLagThresholdMs}, <strong>every read that would
+ * normally go to a reader is redirected to the writer</strong> for as long as the lag persists.
+ * In a cluster where most traffic is reads, this can instantly concentrate the full read load on
+ * the writer, potentially overwhelming it:
+ *
+ * <ul>
+ *   <li><b>Connection storm</b> — each wrapper connection that was routing reads to a reader now
+ *       opens or reuses a writer connection. If the lag spike affects many connections
+ *       simultaneously, the writer may receive a large burst of new connections.</li>
+ *   <li><b>CPU / I/O overload</b> — read queries that were horizontally scaled across multiple
+ *       readers now all land on the single writer, which also handles all write traffic.</li>
+ *   <li><b>Cascading failure</b> — a writer overloaded by redirected reads may become slow,
+ *       causing replication lag to increase further, keeping the fallback active indefinitely.</li>
+ * </ul>
+ *
+ * <p><b>Mitigation recommendations:</b>
+ * <ul>
+ *   <li>Start with a generous threshold (e.g. several seconds) to limit fallback frequency.
+ *       Do not set the threshold to {@code 0} in production unless reads on a lagging replica are
+ *       truly intolerable — any positive lag, even 1 ms, will then redirect all reads.</li>
+ *   <li>Enable circuit-breaker or rate-limiting at the load balancer or application level so that
+ *       redirected read traffic does not overwhelm the writer during a lag spike.</li>
+ *   <li>Monitor Aurora's {@code AuroraReplicaLag} CloudWatch metric alongside the wrapper's
+ *       WARNING log entries ({@code replicaLagRoutedToWriter}) to detect sustained fallback
+ *       and investigate the root cause of the lag rather than relying on the fallback alone.</li>
+ *   <li>In multi-reader clusters, consider whether a lagging replica can simply be removed from
+ *       the read pool (via host availability / health check) instead of routing all reads to the
+ *       writer. With non-lag-minimizing selectors the pessimistic {@code Math.max} lag strategy
+ *       means <em>one</em> lagging replica causes all reads to fall back to the writer, even if
+ *       other readers are healthy. (Lag-minimizing selectors such as {@code lowestLoad} and
+ *       {@code lowestLoadByLag} aggregate via {@code Math.min} instead.)</li>
+ *   <li>Do <em>not</em> use this feature as a substitute for Aurora Auto Scaling or proper
+ *       capacity planning. It is a last-resort data-freshness guard, not a performance feature.</li>
+ * </ul>
  */
 public abstract class UnifiedReadWriteSplittingPlugin extends AbstractConnectionPlugin
     implements CanReleaseResources, StateSnapshotProvider, RwSplitContext {
@@ -94,6 +170,38 @@ public abstract class UnifiedReadWriteSplittingPlugin extends AbstractConnection
           "false",
           "Select a fresh reader on each read-routing decision within an established read-only "
               + "phase (query-level load balancing) instead of reusing a single sticky reader.");
+
+  /**
+   * Maximum acceptable reader replication lag in milliseconds.
+   *
+   * <p>A non-negative value enables the replica-lag fallback: when the lag of the reader that
+   * would serve an upcoming read exceeds this threshold, the read is redirected to the writer
+   * instead. A value of {@code -1} (the default) disables the feature entirely.
+   *
+   * <p><b>⚠ Writer-storm risk:</b> when lag rises above the threshold, <em>all</em> reads that
+   * would normally go to readers are redirected to the writer for the duration of the lag spike.
+   * In a read-heavy cluster this can instantly overload the writer. See the class-level Javadoc
+   * for a full discussion of the risk and mitigation recommendations before enabling this setting.
+   *
+   * <p>Setting the threshold to {@code 0} redirects reads on <em>any</em> positive lag (even 1 ms)
+   * and is not recommended for production unless stale reads are truly intolerable. Prefer a
+   * generous threshold (several seconds) to limit fallback frequency and blast radius.
+   *
+   * <p>This property needs the cluster to publish reader replication lag. On Aurora clusters the
+   * {@link software.amazon.jdbc.hostlistprovider.RdsHostListProvider} background monitor provides
+   * it from an in-memory cache. Any other database that reports lag on its published host specs
+   * (non-null {@link HostSpec#getLagMs()}) is also supported. Databases that do not report lag
+   * leave routing unchanged.
+   */
+  public static final AwsWrapperProperty REPLICA_LAG_THRESHOLD_MS =
+      new AwsWrapperProperty(
+          "replicaLagThresholdMs",
+          "-1",
+          "Maximum acceptable reader replication lag in milliseconds. A non-negative value "
+              + "routes a read to the writer when the reader that would serve it exceeds the "
+              + "threshold; -1 disables this fallback. WARNING: a lag spike will redirect ALL "
+              + "reads to the writer simultaneously, which can overload it. See the class javadoc "
+              + "for writer-storm risks and mitigation guidance before enabling this setting.");
 
   public static final AwsWrapperProperty LOAD_BALANCING_INCLUDE_WRITER =
       new AwsWrapperProperty(
@@ -178,11 +286,42 @@ public abstract class UnifiedReadWriteSplittingPlugin extends AbstractConnection
   private final Set<String> subscribedMethods;
   private final boolean allowStatementRecreationOnConnectionSwitch;
   private final boolean queryLevelLoadBalancing;
+  private final int replicaLagThresholdMs;
+
+  /**
+   * Whether the configured reader host selector is guaranteed to minimise replication lag, i.e. it
+   * always picks the reader with the lowest lag from the eligible set. Currently
+   * {@link LowestLoadHostSelector#STRATEGY_LOWEST_LOAD_BY_LAG lowestLoadByLag} and
+   * {@link LowestLoadHostSelector#STRATEGY_LOWEST_LOAD lowestLoad} satisfy this guarantee (both
+   * weight lag heavily in their load score); every other strategy — {@code random},
+   * {@code roundRobin}, {@code lowestLoadByCpu}, or any custom selector — is treated as
+   * non-guaranteeing and aggregates pessimistically via {@code Math.max}. Computed once at
+   * construction: the strategy is fixed for the lifetime of the connection wrapper, so re-parsing
+   * the property on every read-routing decision would be avoidable per-read work.
+   */
+  private final boolean lagMinimizingSelector;
 
   // Tracks plain Statement objects seen for execute-with-SQL, to warn once per statement when a
   // bound statement is reused and rerouting cannot be applied.
   private final Map<Object, Boolean> seenBoundStatements =
       Collections.synchronizedMap(new WeakHashMap<>());
+
+  // One-shot warning flags for lag-related log entries that would otherwise fire on every read.
+  //
+  // replicaLagUnavailableWarningLogged: set the first time lag data is unavailable while the
+  //   threshold is configured. Not reset after the first occurrence — this is a known limitation
+  //   (Bug B1): if lag later becomes available, the flag stays true and subsequent unavailability
+  //   events produce no further log output. Until the flag is reset on availability recovery,
+  //   operators must rely on CloudWatch or the topology monitor's own metrics to detect sustained
+  //   lag-data loss. A future fix should reset this flag when relevantReaderLagMs() returns a
+  //   finite value, and ideally apply a log cooldown rather than a permanent one-shot suppression.
+  //
+  // replicaLagFallbackNotAppliedWarningLogged: set when the lag fallback selected WRITER but the
+  //   physical connection remained on a reader (Global Write Forwarding STAY scenario). Also a
+  //   permanent one-shot — once GWF keeps the connection on the reader the first time, this flag
+  //   prevents the warning from firing again for the lifetime of this plugin instance.
+  private boolean replicaLagUnavailableWarningLogged;
+  private boolean replicaLagFallbackNotAppliedWarningLogged;
 
   protected volatile boolean inReadWriteSplit = false;
   protected @Nullable HostListProviderService hostListProviderService;
@@ -205,6 +344,8 @@ public abstract class UnifiedReadWriteSplittingPlugin extends AbstractConnection
     this.allowStatementRecreationOnConnectionSwitch =
         ALLOW_STATEMENT_RECREATION_ON_CONNECTION_SWITCH.getBoolean(properties);
     this.queryLevelLoadBalancing = QUERY_LEVEL_LOAD_BALANCING.getBoolean(properties);
+    this.replicaLagThresholdMs = REPLICA_LAG_THRESHOLD_MS.getInteger(properties);
+    this.lagMinimizingSelector = isLagMinimizingSelector(properties);
   }
 
   /**
@@ -347,14 +488,28 @@ public abstract class UnifiedReadWriteSplittingPlugin extends AbstractConnection
   }
 
   private void performSwitch(final String methodName, final TargetRole desired) throws SQLException {
+    this.throwIfCurrentConnectionClosed();
+
+    this.helpers.topologyRefresher.refresh(this);
+
+    final TargetRole targetRole = this.applyReplicaLagFallback(desired);
+    this.performSwitchWithCurrentTopology(methodName, targetRole, targetRole != desired);
+    this.warnIfReplicaLagFallbackDidNotApply(desired, targetRole);
+  }
+
+  private void throwIfCurrentConnectionClosed() throws SQLException {
     final Connection currentConnection = this.pluginService.getCurrentConnection();
     if (currentConnection != null && currentConnection.isClosed()) {
       this.logAndThrow(Messages.get("ReadWriteSplittingPlugin.setReadOnlyOnClosedConnection"),
           SqlState.CONNECTION_NOT_OPEN);
     }
+  }
 
-    this.helpers.topologyRefresher.refresh(this);
-
+  /** Switches against topology already refreshed by the caller. */
+  private void performSwitchWithCurrentTopology(
+      final String methodName, final TargetRole desired, final boolean replicaLagFallback)
+      throws SQLException {
+    final Connection currentConnection = this.pluginService.getCurrentConnection();
     final HostSpec currentHost = this.pluginService.getCurrentHostSpec();
     if (desired == TargetRole.READER) {
       if (!this.helpers.roleClassifier.isReader(currentHost)) {
@@ -396,7 +551,8 @@ public abstract class UnifiedReadWriteSplittingPlugin extends AbstractConnection
       }
     } else if (desired == TargetRole.WRITER) {
       if (!this.helpers.roleClassifier.isWriter(currentHost)) {
-        if (JdbcMethod.CONNECTION_SETREADONLY.methodName.equals(methodName)
+        if (!replicaLagFallback
+            && JdbcMethod.CONNECTION_SETREADONLY.methodName.equals(methodName)
             && this.pluginService.isInTransaction()) {
           this.logAndThrow(Messages.get("ReadWriteSplittingPlugin.setReadOnlyFalseInTransaction"),
               SqlState.ACTIVE_SQL_TRANSACTION);
@@ -418,6 +574,29 @@ public abstract class UnifiedReadWriteSplittingPlugin extends AbstractConnection
    * re-creates the statement on it (via the {@link Rebindable} handle published on the call
    * context). When rebinding is unavailable, logs the bound-statement reuse warning once per
    * statement.
+   *
+   * <p><b>Topology-refresh invariant (exactly one refresh per routing decision):</b>
+   * {@link software.amazon.jdbc.plugin.readwritesplitting.signal.SqlRoutingSignal} deliberately
+   * returns {@link TargetRole#NO_DECISION} for plain {@code Statement} execute calls in
+   * {@link software.amazon.jdbc.plugin.readwritesplitting.signal.RoutingSignal#resolve}, so
+   * {@link #performSwitch} is <em>never</em> called from {@link #execute} for this path. That
+   * means no topology refresh has occurred yet when this method runs.
+   *
+   * <p>To guarantee exactly one refresh for the whole routing decision, this method owns the
+   * refresh when the lag fallback might change the destination ({@code refreshedForLagDecision}).
+   * It then calls {@link #performSwitchWithCurrentTopology} (no extra refresh) instead of
+   * {@link #performSwitch} (which would refresh again). When the lag fallback cannot apply,
+   * {@code refreshedForLagDecision} is {@code false} and the {@code else} branch delegates to
+   * {@link #performSwitch}, which does the single refresh itself — so the total is still one.
+   *
+   * <p>The two branches are mutually exclusive by construction:
+   * <ul>
+   *   <li>{@code refreshedForLagDecision = true} → this method refreshed → calls
+   *       {@code performSwitchWithCurrentTopology} (no second refresh).</li>
+   *   <li>{@code refreshedForLagDecision = false} → this method did not refresh → calls
+   *       {@code performSwitch} (does the one refresh).</li>
+   * </ul>
+   * There is therefore no code path through this method that calls the topology refresher twice.
    */
   private void maybeHandleBoundStatement(final String methodName, final Object methodInvokeOn)
       throws SQLException {
@@ -430,34 +609,58 @@ public abstract class UnifiedReadWriteSplittingPlugin extends AbstractConnection
       return;
     }
 
-    // A transaction/autocommit/keep pin means the statement legitimately stays put; not a miss.
-    if (!this.helpers.switchGate.canSwitch(this, sqlRole)) {
-      return;
+    final PluginCallContext callContext = this.pluginService.getCallContext();
+    final Rebindable rebindHandle = callContext == null ? null : callContext.getRebindHandle();
+    final boolean reroutable = this.allowStatementRecreationOnConnectionSwitch && rebindHandle != null;
+
+    // SqlRoutingSignal abstains for plain Statement execute calls, so performSwitch has NOT been
+    // called yet and no topology refresh has occurred for this routing decision.
+    //
+    // When the lag fallback could change the destination (READER → possibly WRITER), refresh now
+    // so the lag evaluation and the subsequent host-list lookup use the same topology snapshot.
+    // The flag also selects performSwitchWithCurrentTopology below, which skips a second refresh.
+    // When the lag fallback cannot apply, skip the refresh here and let performSwitch do it once.
+    // Either way, exactly one topology refresh happens per routing decision. See javadoc above.
+    final boolean refreshedForLagDecision = reroutable && this.replicaLagFallbackCouldApply(sqlRole);
+    if (refreshedForLagDecision) {
+      this.throwIfCurrentConnectionClosed();
+      this.helpers.topologyRefresher.refresh(this);
     }
+
+    final TargetRole targetRole = this.applyReplicaLagFallback(sqlRole);
 
     final HostSpec currentHost = this.pluginService.getCurrentHostSpec();
     final boolean alreadyOnTarget =
-        (sqlRole == TargetRole.READER && this.helpers.roleClassifier.isReader(currentHost))
-            || (sqlRole == TargetRole.WRITER && this.helpers.roleClassifier.isWriter(currentHost));
+        (targetRole == TargetRole.READER && this.helpers.roleClassifier.isReader(currentHost))
+            || (targetRole == TargetRole.WRITER && this.helpers.roleClassifier.isWriter(currentHost));
     if (alreadyOnTarget) {
       return;
     }
 
-    final PluginCallContext callContext = this.pluginService.getCallContext();
-    final Rebindable rebindHandle = callContext == null ? null : callContext.getRebindHandle();
+    // A transaction/autocommit/keep pin means the statement legitimately stays put; not a miss.
+    if (!this.helpers.switchGate.canSwitch(this, targetRole)) {
+      return;
+    }
 
-    if (!this.allowStatementRecreationOnConnectionSwitch || rebindHandle == null) {
+    if (!reroutable) {
       // Rerouting is wanted but cannot be applied to this bound statement.
       warnOnceReusedBoundStatement(methodInvokeOn);
       return;
     }
 
-    this.performSwitch(methodName, sqlRole);
+    // refreshedForLagDecision=true  → topology already fresh above → no second refresh
+    // refreshedForLagDecision=false → no refresh done yet       → performSwitch does the one refresh
+    if (refreshedForLagDecision) {
+      this.performSwitchWithCurrentTopology(methodName, targetRole, targetRole != sqlRole);
+    } else {
+      this.performSwitch(methodName, targetRole);
+    }
+    this.warnIfReplicaLagFallbackDidNotApply(sqlRole, targetRole);
 
     final HostSpec newHost = this.pluginService.getCurrentHostSpec();
     final boolean switched =
-        (sqlRole == TargetRole.READER && this.helpers.roleClassifier.isReader(newHost))
-            || (sqlRole == TargetRole.WRITER && this.helpers.roleClassifier.isWriter(newHost));
+        (targetRole == TargetRole.READER && this.helpers.roleClassifier.isReader(newHost))
+            || (targetRole == TargetRole.WRITER && this.helpers.roleClassifier.isWriter(newHost));
     if (!switched) {
       return;
     }
@@ -473,6 +676,358 @@ public abstract class UnifiedReadWriteSplittingPlugin extends AbstractConnection
             new Object[] {newHost == null ? "" : newHost.getHostAndPort(), e.getMessage()}));
       }
     }
+  }
+
+  /**
+   * Converts a read-routing decision to a writer decision when the relevant replica lag is
+   * above the configured limit. Lag is optional telemetry: an unavailable cache leaves routing
+   * unchanged rather than failing the application operation.
+   *
+   * <p><b>Writer-storm note:</b> this method is called on <em>every</em> read-routing decision
+   * while {@code replicaLagThresholdMs} is enabled. When the lag is above the threshold, it
+   * returns {@link TargetRole#WRITER} unconditionally — no rate-limiting, no gradual ramp,
+   * no hysteresis. All wrapper connections that are routing reads will simultaneously redirect to
+   * the writer for as long as lag stays above the threshold. Callers should be aware that this
+   * creates a potential connection storm and CPU spike on the writer during lag events.
+   */
+  private TargetRole applyReplicaLagFallback(final TargetRole desired) throws SQLException {
+    if (!this.replicaLagFallbackCouldApply(desired)) {
+      return desired;
+    }
+
+    final double lagMs = this.relevantReaderLagMs();
+    if (Double.isNaN(lagMs)) {
+      if (!this.replicaLagUnavailableWarningLogged) {
+        this.replicaLagUnavailableWarningLogged = true;
+        LOGGER.warning(() -> Messages.get("ReadWriteSplittingPlugin.replicaLagUnavailable",
+            new Object[] {this.replicaLagThresholdMs}));
+      }
+      return desired;
+    }
+
+    // Strict greater-than: lag equal to the threshold is still considered acceptable so that
+    // threshold = 0 does not trigger on a perfectly synchronised replica (lag = 0.0 ms).
+    if (lagMs > this.replicaLagThresholdMs) {
+      LOGGER.warning(() -> Messages.get("ReadWriteSplittingPlugin.replicaLagRoutedToWriter",
+          new Object[] {lagMs, this.replicaLagThresholdMs}));
+      return TargetRole.WRITER;
+    }
+    return desired;
+  }
+
+  /**
+   * Returns {@code true} when the replica-lag fallback is enabled and the routing decision is for
+   * a reader (the only role the fallback can redirect away from).
+   *
+   * <p>The threshold check uses {@code >= 0} so that {@code replicaLagThresholdMs = 0} is a valid
+   * "reject any positive lag" configuration. Only {@code -1} (or any negative value) disables the
+   * feature entirely.
+   */
+  private boolean replicaLagFallbackCouldApply(final TargetRole desired) {
+    return this.replicaLagThresholdMs >= 0 && desired == TargetRole.READER;
+  }
+
+  /**
+   * Returns the replication lag (in milliseconds) that is relevant for the upcoming read-routing
+   * decision, or {@link Double#NaN} when lag data is unavailable.
+   *
+   * <h3>Pinned-reader path (sticky or cached reader)</h3>
+   * When a specific reader is already known to serve this read (the current host is a reader, or a
+   * cached reader connection will be reused), only that reader's lag is measured. This is the
+   * exact lag the application will actually experience.
+   *
+   * <h3>Fresh-selection path — lag aggregation strategy</h3>
+   * When a fresh reader will be selected, the lag of all <em>eligible</em> candidates is
+   * aggregated. The aggregation rule depends on which host selector is configured:
+   *
+   * <ul>
+   *   <li><b>{@code lowestLoadByLag} and {@code lowestLoad}</b> — both selectors are lag-aware and
+   *       are guaranteed to pick the reader with the lowest load/lag, so the <b>minimum</b> (best)
+   *       lag among eligible readers is the true representative. A read is only redirected to the
+   *       writer when <em>every</em> eligible reader is lagging beyond the threshold, i.e. even the
+   *       best available reader is too stale.</li>
+   *   <li><b>All other selectors</b> (including {@code random}, {@code roundRobin},
+   *       {@code lowestLoadByCpu}, or any custom selector) — the selector is not guaranteed to
+   *       avoid the worst reader, so the <b>maximum</b> (worst) lag is used. This includes Aurora
+   *       topology path, RDS Proxy opaque-endpoint path, and non-Aurora deployments that do
+   *       publish lag in their host specs. One lagging eligible reader therefore causes all reads
+   *       to fall back to the writer.</li>
+   * </ul>
+   *
+   * <h3>Lag data sources</h3>
+   * <ul>
+   *   <li><b>Aurora</b> — lag values come from {@link RdsHostListProvider#getStoredTopology()},
+   *       an in-memory cache populated by the Aurora topology background monitor. No database
+   *       query is issued.</li>
+   *   <li><b>RDS Proxy / opaque endpoint</b> — the endpoint host is opaque; Aurora topology is
+   *       used as the source of backend reader lags and {@code Math.max} is applied.</li>
+   *   <li><b>Non-Aurora with lag-reporting hosts</b> — when the provider is not an
+   *       {@link RdsHostListProvider} but the host specs returned by
+   *       {@link PluginService#getHosts()} already carry non-null {@link HostSpec#getLagMs()}
+   *       values (e.g. a custom host-list provider), lag is read directly from those specs.
+   *       {@code Math.min} is applied when {@code lowestLoadByLag} or {@code lowestLoad} is
+   *       configured; {@code Math.max} otherwise.</li>
+   *   <li><b>Non-Aurora without lag data</b> — all {@link HostSpec#getLagMs()} values are
+   *       {@code null}; this method returns {@link Double#NaN} and routing is left unchanged.</li>
+   * </ul>
+   */
+  private double relevantReaderLagMs() throws SQLException {
+    // ---- lag data source ----
+    // Primary: Aurora topology cache (contains freshest Aurora lag measurements).
+    // Fallback: lag carried directly on the published host specs (non-Aurora providers that do
+    //           populate HostSpec.lagMs, or future non-RDS topology providers).
+    final List<HostSpec> latestTopology = this.cachedTopologyWithLatestLag();
+    final boolean usingTopologyCache = (latestTopology != null);
+
+    // ---- pinned-reader fast path ----
+    // When the same reader will definitely serve this read (sticky or cached), measure only it.
+    // A small linear scan over the (typically tiny) host list replaces a per-decision HashMap;
+    // the map is only built below when a fresh reader actually needs to be selected.
+    final HostSpec pinnedReader = this.readerThatWillServeRead();
+    if (pinnedReader != null) {
+      final List<HostSpec> source =
+          usingTopologyCache ? latestTopology : this.pluginService.getHosts();
+      return source == null ? Double.NaN : lagOfReader(source, pinnedReader);
+    }
+
+    // ---- fresh-selection path: aggregate across eligible candidates ----
+    // Build a URL→lag map from whichever source is available. This allocation is only incurred
+    // when a fresh reader is actually going to be selected (the pinned path already returned).
+    final Map<String, Float> lagByUrl = new HashMap<>();
+    if (usingTopologyCache) {
+      // Aurora: topology snapshot has the freshest lag reported by the background monitor.
+      for (final HostSpec host : latestTopology) {
+        if (host.getRole() == HostRole.READER) {
+          lagByUrl.put(host.getUrl(), host.getLagMs());
+        }
+      }
+    } else {
+      // Non-Aurora (or cache unavailable): read lag directly from published host specs.
+      // If no host carries lag data the map stays empty → NaN below → routing unchanged.
+      final List<HostSpec> publishedHosts = this.pluginService.getHosts();
+      if (publishedHosts != null) {
+        for (final HostSpec host : publishedHosts) {
+          if (host.getRole() == HostRole.READER && host.getLagMs() != null) {
+            lagByUrl.put(host.getUrl(), host.getLagMs());
+          }
+        }
+      }
+      // If no host reported any lag, return NaN: lag data genuinely unavailable.
+      if (lagByUrl.isEmpty()) {
+        return Double.NaN;
+      }
+    }
+
+    final List<HostSpec> hosts;
+    if (this.helpers.readerResolver.routesThroughOpaqueEndpoint()) {
+      // RDS Proxy / cluster endpoint: the endpoint host is opaque, so the Aurora topology is the
+      // only source of backend reader lags. Always pessimistic (Math.max) regardless of selector,
+      // because the load-balancer inside the proxy picks the backend, not our selector.
+      hosts = usingTopologyCache ? latestTopology : this.pluginService.getHosts();
+    } else {
+      try {
+        hosts = this.helpers.readerResolver.getReaderCandidatesForLag(this);
+      } catch (final SQLException e) {
+        // Candidate resolution can fail, e.g. when no GDB home-region reader is left.
+        // Lag is optional data; let ordinary reader switching report that condition.
+        LOGGER.finest(() -> Messages.get(
+            "ReadWriteSplittingPlugin.replicaLagCandidatesUnavailable",
+            new Object[] {e.getMessage()}));
+        return Double.NaN;
+      }
+    }
+
+    double lagMs = Double.NaN;
+    boolean currentHostFound = false;
+    final HostSpec currentHost = this.pluginService.getCurrentHostSpec();
+    if (hosts != null) {
+      for (final HostSpec host : hosts) {
+        if (host.getRole() != HostRole.READER) {
+          continue;
+        }
+
+        final boolean isCurrentHost = sameHost(host, currentHost);
+        currentHostFound |= isCurrentHost;
+        // The active reader can still run the pending operation even when the latest candidate
+        // view marks it unavailable (e.g. a transient health-check blip). Including it prevents
+        // a false "lag unknown" result that would leave a lagging-but-open connection in place.
+        // Other unavailable readers are not selectable, so their lag does not matter here.
+        if (host.getAvailability() != HostAvailability.AVAILABLE && !isCurrentHost) {
+          continue;
+        }
+
+        lagMs = this.lagMinimizingSelector
+            ? pickMinLag(lagMs, lagByUrl.get(host.getUrl()))
+            : pickLag(lagMs, lagByUrl.get(host.getUrl()));
+      }
+    }
+
+    // The candidate list may not include the currently-open reader if the topology changed
+    // between when the connection was established and now (e.g. a replica was removed then
+    // re-added with a new HostSpec object). Including the current reader's lag here prevents
+    // a false "lag unknown" that would leave an actively-lagging connection in use.
+    if (!currentHostFound && currentHost != null && currentHost.getRole() == HostRole.READER) {
+      lagMs = this.lagMinimizingSelector
+          ? pickMinLag(lagMs, lagByUrl.get(currentHost.getUrl()))
+          : pickLag(lagMs, lagByUrl.get(currentHost.getUrl()));
+    }
+
+    return lagMs;
+  }
+
+  private static boolean isLagMinimizingSelector(final Properties props) {
+    final String strategy = ReadWriteSplittingPlugin.readerHostSelectorStrategy(props);
+    return LowestLoadHostSelector.STRATEGY_LOWEST_LOAD_BY_LAG.equalsIgnoreCase(strategy)
+        || LowestLoadHostSelector.STRATEGY_LOWEST_LOAD.equalsIgnoreCase(strategy);
+  }
+
+  /**
+   * Returns the latest Aurora cluster topology from the in-memory cache, or {@code null} when the
+   * cache is empty or unavailable. <b>Never issues a database query.</b>
+   *
+   * <p>Lag evaluation is deliberately pull-based (cache-read only). Issuing a blocking topology
+   * query here would add latency to every JDBC call that routes a read, and would create a second
+   * I/O path that bypasses the topology monitor's rate-limiting and back-off logic. The topology
+   * monitor refreshes the cache on its own schedule; this method simply reads the latest snapshot.
+   *
+   * <p>Returns {@code null} — and thus disables lag-based routing — when:
+   * <ul>
+   *   <li>the {@link HostListProvider} does not publish an Aurora topology cache — e.g. a
+   *       non-Aurora or custom provider; lag is then read directly from the published host specs
+   *       instead ({@link HostSpec#getLagMs()}),</li>
+   *   <li>the cache has not been populated yet (first connection, monitor not yet started),</li>
+   *   <li>the cache read throws {@link java.sql.SQLException} (monitor initialisation failure).</li>
+   * </ul>
+   * In all these cases the read is routed normally without lag consideration.
+   */
+  private @Nullable List<HostSpec> cachedTopologyWithLatestLag() {
+    final HostListProviderService providerService = this.hostListProviderService;
+    if (providerService == null) {
+      return null;
+    }
+
+    final HostListProvider hostListProvider = providerService.getHostListProvider();
+    if (!(hostListProvider instanceof RdsHostListProvider)) {
+      return null;
+    }
+
+    try {
+      return ((RdsHostListProvider) hostListProvider).getStoredTopology();
+    } catch (final SQLException e) {
+      LOGGER.finest(() -> Messages.get("ReadWriteSplittingPlugin.replicaLagRefreshFailed",
+          new Object[] {e.getMessage()}));
+      return null;
+    }
+  }
+
+  /**
+   * Returns the reader known to serve this read, or {@code null} when a fresh backend reader is
+   * selected. Endpoint-based assemblies cannot pin a backend because their host is opaque.
+   */
+  private @Nullable HostSpec readerThatWillServeRead() throws SQLException {
+    if (this.queryLevelLoadBalancing || this.helpers.readerResolver.routesThroughOpaqueEndpoint()) {
+      return null;
+    }
+
+    final HostSpec currentHost = this.pluginService.getCurrentHostSpec();
+    if (currentHost != null && currentHost.getRole() == HostRole.READER) {
+      return currentHost;
+    }
+
+    final CacheItem<Connection> cachedReaderItem = this.readerCacheItem;
+    final Connection cachedReader = cachedReaderItem == null ? null : cachedReaderItem.get();
+    final HostSpec cachedReaderHost = this.readerHostSpec;
+    if (cachedReader != null && cachedReaderHost != null && this.isConnectionUsable(cachedReader)) {
+      return cachedReaderHost;
+    }
+
+    return null;
+  }
+
+  /**
+   * Logs a one-time warning when the replica-lag fallback selected the writer but the physical
+   * connection is still on a reader after the switch attempt. This happens with Global Write
+   * Forwarding: {@link software.amazon.jdbc.plugin.readwritesplitting.resolver.GdbWriterResolver}
+   * returns {@link software.amazon.jdbc.plugin.readwritesplitting.resolver.WriterResolution#stay()}
+   * so no new connection is opened and the current reader remains active.
+   *
+   * <p>The check is purely positional — "fallback said writer, but we are still on a reader" —
+   * so it must not call {@code switchGate.canSwitch()} here. The gate was already consulted
+   * during the switch attempt; re-querying it post-attempt is both redundant and unsafe because
+   * {@code canSwitch} is declared to throw {@code SQLException}, which would abort the caller's
+   * JDBC call rather than simply skipping the log entry.
+   */
+  private void warnIfReplicaLagFallbackDidNotApply(
+      final TargetRole requestedRole, final TargetRole targetRole) {
+    if (requestedRole != TargetRole.READER
+        || targetRole != TargetRole.WRITER
+        || this.replicaLagFallbackNotAppliedWarningLogged
+        || !this.helpers.roleClassifier.isReader(this.pluginService.getCurrentHostSpec())) {
+      return;
+    }
+
+    this.replicaLagFallbackNotAppliedWarningLogged = true;
+    LOGGER.warning(() -> Messages.get("ReadWriteSplittingPlugin.replicaLagFallbackNotApplied",
+        new Object[] {this.replicaLagThresholdMs}));
+  }
+
+  private static double toLagMs(final @Nullable Float lagMs) {
+    return lagMs == null || Float.isNaN(lagMs) ? Double.NaN : lagMs;
+  }
+
+  /**
+   * Returns the lag (in ms) reported by an already-identified reader, or {@link Double#NaN} when
+   * it carries no lag value. Used by the pinned-reader fast path, where no candidate aggregation
+   * (and no per-decision map) is needed; the host list is small enough for a linear scan.
+   */
+  private static double lagOfReader(final List<HostSpec> hosts, final HostSpec target) {
+    for (final HostSpec host : hosts) {
+      if (host.getRole() == HostRole.READER && host.getUrl().equals(target.getUrl())) {
+        return toLagMs(host.getLagMs());
+      }
+    }
+    return Double.NaN;
+  }
+
+  /**
+   * Returns the worse (higher) of two lag values for pessimistic candidate evaluation.
+   *
+   * <p>Using {@code Math.max} rather than {@code Math.min} is a deliberate design choice: the goal
+   * is to detect whether <em>any</em> eligible reader that might serve this read is lagging beyond
+   * the threshold, not whether the best one would be acceptable. If the selector happens to avoid
+   * the lagging reader this time, that is not guaranteed on the next call — so the conservative
+   * approach is to treat the worst eligible lag as the representative value.
+   *
+   * <p>Consequence: one lagging replica in the eligible set causes fallback for all reads, even if
+   * other replicas are healthy. See {@link #relevantReaderLagMs()} for discussion.
+   */
+  private static double pickLag(final double current, final @Nullable Float candidate) {
+    if (candidate == null || Float.isNaN(candidate)) {
+      return current;
+    }
+    return Double.isNaN(current) ? candidate : Math.max(current, candidate);
+  }
+
+  /**
+   * Returns the better (lower) of two lag values for lag-minimizing selectors
+   * ({@code lowestLoadByLag}, {@code lowestLoad}).
+   *
+   * <p>Using {@code Math.min} rather than {@code Math.max} is correct for these selectors because
+   * they are guaranteed to pick the reader with the lowest lag. The best eligible lag is therefore
+   * the true representative: a read only falls back to the writer when <em>every</em> eligible
+   * reader is lagging beyond the threshold.
+   */
+  private static double pickMinLag(final double current, final @Nullable Float candidate) {
+    if (candidate == null || Float.isNaN(candidate)) {
+      return current;
+    }
+    return Double.isNaN(current) ? candidate : Math.min(current, candidate);
+  }
+
+  private static boolean sameHost(final HostSpec first, final @Nullable HostSpec second) {
+    return second != null
+        && first.getPort() == second.getPort()
+        && first.getHost().equalsIgnoreCase(second.getHost());
   }
 
   /**

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/UnifiedReadWriteSplittingPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/UnifiedReadWriteSplittingPlugin.java
@@ -674,7 +674,7 @@ public abstract class UnifiedReadWriteSplittingPlugin extends AbstractConnection
     }
 
     final Connection current = this.pluginService.getCurrentConnection();
-    if (current != null) {
+    if (current != null && rebindHandle != null) {
       try {
         rebindHandle.rebind(current);
       } catch (final SQLException e) {
@@ -843,11 +843,12 @@ public abstract class UnifiedReadWriteSplittingPlugin extends AbstractConnection
     // Build a URL→lag map from whichever source is available. This allocation is only incurred
     // when a fresh reader is actually going to be selected (the pinned path already returned).
     final Map<String, Float> lagByUrl = new HashMap<>();
-    if (usingTopologyCache) {
+    if (latestTopology != null) {
       // Aurora: topology snapshot has the freshest lag reported by the background monitor.
       for (final HostSpec host : latestTopology) {
-        if (host.getRole() == HostRole.READER) {
-          lagByUrl.put(host.getUrl(), host.getLagMs());
+        final Float lagMs = host.getLagMs();
+        if (host.getRole() == HostRole.READER && lagMs != null) {
+          lagByUrl.put(host.getUrl(), lagMs);
         }
       }
     } else {
@@ -856,8 +857,9 @@ public abstract class UnifiedReadWriteSplittingPlugin extends AbstractConnection
       final List<HostSpec> publishedHosts = this.pluginService.getHosts();
       if (publishedHosts != null) {
         for (final HostSpec host : publishedHosts) {
-          if (host.getRole() == HostRole.READER && host.getLagMs() != null) {
-            lagByUrl.put(host.getUrl(), host.getLagMs());
+          final Float lagMs = host.getLagMs();
+          if (host.getRole() == HostRole.READER && lagMs != null) {
+            lagByUrl.put(host.getUrl(), lagMs);
           }
         }
       }

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/resolver/EndpointReaderResolver.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/resolver/EndpointReaderResolver.java
@@ -71,6 +71,11 @@ public class EndpointReaderResolver implements ReaderResolver {
   }
 
   @Override
+  public boolean routesThroughOpaqueEndpoint() {
+    return true;
+  }
+
+  @Override
   public void switchToReader(final RwSplitContext ctx) throws SQLException {
     HostSpec readerHost = ctx.readerHostSpec();
     if (readerHost == null) {

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/resolver/ReaderResolver.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/resolver/ReaderResolver.java
@@ -17,6 +17,9 @@
 package software.amazon.jdbc.plugin.readwritesplitting.resolver;
 
 import java.sql.SQLException;
+import java.util.Collections;
+import java.util.List;
+import software.amazon.jdbc.HostSpec;
 import software.amazon.jdbc.plugin.readwritesplitting.RwSplitContext;
 
 /**
@@ -55,6 +58,28 @@ public interface ReaderResolver {
    * @return {@code true} for per-query reader balancing; {@code false} (default) for sticky
    */
   default boolean isPerQuery() {
+    return false;
+  }
+
+  /**
+   * Returns the reader candidates that could serve a fresh reader route, for optional
+   * replica-lag evaluation. The default has no topology-backed candidates.
+   *
+   * @param ctx the read/write splitting context
+   * @return reader candidates eligible for this resolver's routing policy
+   * @throws SQLException if candidate resolution fails
+   */
+  default List<HostSpec> getReaderCandidatesForLag(final RwSplitContext ctx) throws SQLException {
+    return Collections.emptyList();
+  }
+
+  /**
+   * Whether the resolver routes through an endpoint whose host does not identify the backend
+   * database instance. Such resolvers must evaluate replica lag from cached Aurora topology.
+   *
+   * @return {@code true} when the route uses an opaque endpoint
+   */
+  default boolean routesThroughOpaqueEndpoint() {
     return false;
   }
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/resolver/TopologyReaderResolver.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/resolver/TopologyReaderResolver.java
@@ -137,4 +137,9 @@ public class TopologyReaderResolver implements ReaderResolver {
   public boolean isPerQuery() {
     return this.loadBalancingPolicy.isPerQuery();
   }
+
+  @Override
+  public List<HostSpec> getReaderCandidatesForLag(final RwSplitContext ctx) throws SQLException {
+    return this.candidateSource.candidates(ctx);
+  }
 }

--- a/wrapper/src/main/resources/aws_advanced_jdbc_wrapper_messages.properties
+++ b/wrapper/src/main/resources/aws_advanced_jdbc_wrapper_messages.properties
@@ -443,6 +443,11 @@ ReadWriteSplittingPlugin.previousReaderNotAllowed=The previous reader connection
 ReadWriteSplittingPlugin.fallbackToCurrentConnection=Failed to switch to reader host. The current connection will be used as a fallback: ''{0}''. Error:  {1}
 ReadWriteSplittingPlugin.fallbackToWriterOnReaderFailure=No reader could be selected or reached. Falling back to the writer connection: ''{0}''. Error:  {1}
 ReadWriteSplittingPlugin.statementRecreatedOnConnectionSwitch=Re-created the bound statement on the newly selected connection ''{0}'' (statement recreation on connection switch).
+ReadWriteSplittingPlugin.replicaLagRefreshFailed=The cached cluster topology could not be read for replica-lag evaluation, so reader lag is treated as unknown and routing is left unchanged. Reason: ''{0}''
+ReadWriteSplittingPlugin.replicaLagCandidatesUnavailable=The readers that could serve this operation could not be determined for replica-lag evaluation, so routing is left unchanged. Reason: ''{0}''
+ReadWriteSplittingPlugin.replicaLagUnavailable=Reader replication lag is unavailable while 'replicaLagThresholdMs' is enabled at {0} ms, so routing is left unchanged. Replication lag must be reported by the cluster (e.g. Aurora via its topology monitor, or any database that publishes lag in its host specs); databases that do not report lag are unaffected by this setting.
+ReadWriteSplittingPlugin.replicaLagRoutedToWriter=Reader replication lag ({0} ms) exceeds the configured 'replicaLagThresholdMs' of {1} ms, so this read is routed to the writer.
+ReadWriteSplittingPlugin.replicaLagFallbackNotApplied=Replica-lag fallback selected the writer because reader lag is unsafe for the configured 'replicaLagThresholdMs' of {0} ms, but the connection remained on a reader, so this read still runs on a lagging reader. The cause is Global Write Forwarding, whose writer resolution keeps the current connection: write forwarding is for writes. Connect to the primary region if these reads must be fresh, or disable 'replicaLagThresholdMs' if stale reads are acceptable.
 
 SimpleReadWriteSplittingPlugin.verificationFailed=The plugin was unable to establish a {0} connection within {1} ms.
 SimpleReadWriteSplittingPlugin.failedToConnectToWriter=A writer connection was requested via setReadOnly, but the plugin was unable to establish a writer connection with the writer endpoint ''{0}''.

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/readwritesplitting/ReplicaLagFallbackTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/readwritesplitting/ReplicaLagFallbackTest.java
@@ -482,9 +482,9 @@ class ReplicaLagFallbackTest {
   }
 
   @Test
-  void enabled_explicitReaderHintStillUsesWriterWhenLagging() throws SQLException {
-    // An explicit /*@reader*/ routing hint on a plain statement still goes to writer when
-    // the lag fallback kicks in (lag threshold overrides the hint on safety grounds).
+  void enabled_explicitReaderHint_skipsFallbackAndStaysOnReader() throws SQLException {
+    // An explicit /*@reader*/ routing hint pins the read to a reader: the lag fallback must not
+    // override it, so the statement stays on the reader even though lag is above the threshold.
     startOn(readerConnection, readerOne);
     givenTopology(Arrays.asList(writer, readerOne), Arrays.asList(writer, reader("reader-one", 5000f)));
 
@@ -499,8 +499,9 @@ class ReplicaLagFallbackTest {
         JdbcMethod.STATEMENT_EXECUTEQUERY.methodName,
         () -> null, new Object[] {"select 1"});
 
-    assertEquals(writerConnection, currentConnection.get());
-    verify(rebindable).rebind(writerConnection);
+    assertEquals(readerConnection, currentConnection.get());
+    verify(rebindable, never()).rebind(writerConnection);
+    verify(hostListProvider, never()).getStoredTopology();
   }
 
   @Test
@@ -998,6 +999,52 @@ class ReplicaLagFallbackTest {
     // refresh occurs (from performSwitch) but zero calls to getStoredTopology beyond the
     // single lag-check call that returns null.
     verify(hostListProvider, times(1)).getStoredTopology();
+  }
+
+  // -------------------------------------------------------------------------
+  // Group 9 – Fallback skipped under explicit routing intent (3 tests)
+  // -------------------------------------------------------------------------
+
+  @Test
+  void enabled_explicitReaderHint_skipsFallbackDespiteHighLag() throws SQLException {
+    // An explicit /*@reader*/ hint pins the read to a reader: lag must not redirect it to the
+    // writer, and the lag topology must not even be consulted.
+    givenTopology(Arrays.asList(writer, readerOne), Arrays.asList(writer, reader("reader-one", 5000f)));
+
+    final PluginCallContext callContext = new PluginCallContext();
+    callContext.setAttribute(SqlContextKeys.ROUTING_HINT, RoutingHint.READER);
+    when(pluginService.getCallContext()).thenReturn(callContext);
+
+    read(newTopologyPlugin(enabledProps()));
+
+    assertEquals(readerConnection, currentConnection.get());
+    verify(hostListProvider, never()).getStoredTopology();
+  }
+
+  @Test
+  void enabled_readOnlySession_skipsFallbackDespiteHighLag() throws SQLException {
+    // Connection.setReadOnly(true) means "reads only": the fallback must not push the connection
+    // to the writer, and no lag evaluation may happen.
+    givenTopology(Arrays.asList(writer, readerOne), Arrays.asList(writer, reader("reader-one", 5000f)));
+    when(sessionStateService.getReadOnly()).thenReturn(Optional.of(true));
+
+    read(newTopologyPlugin(enabledProps()));
+
+    assertEquals(readerConnection, currentConnection.get());
+    verify(hostListProvider, never()).getStoredTopology();
+  }
+
+  @Test
+  void enabled_transactionInProgress_skipsFallbackAndStaysPinned() throws SQLException {
+    // An open transaction pins the connection. Lag must not be evaluated at all (the switch would
+    // be vetoed by the gate anyway, so measuring it is pure waste and would log a false warning).
+    givenTopology(Arrays.asList(writer, readerOne), Arrays.asList(writer, reader("reader-one", 5000f)));
+    when(pluginService.isInTransaction()).thenReturn(true);
+
+    read(newTopologyPlugin(enabledProps()));
+
+    assertEquals(writerConnection, currentConnection.get());
+    verify(hostListProvider, never()).getStoredTopology();
   }
 
   // -------------------------------------------------------------------------

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/readwritesplitting/ReplicaLagFallbackTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/readwritesplitting/ReplicaLagFallbackTest.java
@@ -1,0 +1,1116 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.jdbc.plugin.readwritesplitting;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicReference;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import software.amazon.jdbc.HostRole;
+import software.amazon.jdbc.HostSpec;
+import software.amazon.jdbc.HostSpecBuilder;
+import software.amazon.jdbc.JdbcMethod;
+import software.amazon.jdbc.PluginCallContext;
+import software.amazon.jdbc.PluginService;
+import software.amazon.jdbc.Rebindable;
+import software.amazon.jdbc.hostavailability.HostAvailability;
+import software.amazon.jdbc.hostavailability.SimpleHostAvailabilityStrategy;
+import software.amazon.jdbc.hostlistprovider.HostListProvider;
+import software.amazon.jdbc.hostlistprovider.HostListProviderService;
+import software.amazon.jdbc.hostlistprovider.RdsHostListProvider;
+import software.amazon.jdbc.parser.QueryType;
+import software.amazon.jdbc.parser.RoutingHint;
+import software.amazon.jdbc.parser.SqlContextKeys;
+import software.amazon.jdbc.states.SessionStateService;
+
+/** Tests the cache-only replica-lag safety fallback used by read/write splitting. */
+class ReplicaLagFallbackTest {
+
+  private static final int THRESHOLD_MS = 1000;
+
+  private AutoCloseable closeable;
+
+  @Mock private PluginService pluginService;
+  @Mock private HostListProviderService hostListProviderService;
+  @Mock private RdsHostListProvider hostListProvider;
+  @Mock private Connection writerConnection;
+  @Mock private Connection readerConnection;
+  @Mock private Connection readerConnection2;
+  @Mock private Statement statement;
+  @Mock private SessionStateService sessionStateService;
+
+  private final HostSpec writer = host("writer", HostRole.WRITER, HostAvailability.AVAILABLE, null);
+  private final HostSpec readerOne = host("reader-one", HostRole.READER, HostAvailability.AVAILABLE, null);
+  private final HostSpec readerTwo = host("reader-two", HostRole.READER, HostAvailability.AVAILABLE, null);
+
+  private final AtomicReference<Connection> currentConnection = new AtomicReference<>();
+  private final AtomicReference<HostSpec> currentHost = new AtomicReference<>();
+  private List<HostSpec> publishedHosts;
+  private @Nullable List<HostSpec> storedTopology;
+
+  @BeforeEach
+  void setUp() throws SQLException {
+    closeable = MockitoAnnotations.openMocks(this);
+    currentConnection.set(writerConnection);
+    currentHost.set(writer);
+    publishedHosts = Arrays.asList(writer, readerOne, readerTwo);
+    storedTopology = publishedHosts;
+
+    when(pluginService.getCurrentConnection()).thenAnswer(invocation -> currentConnection.get());
+    when(pluginService.getCurrentHostSpec()).thenAnswer(invocation -> currentHost.get());
+    doAnswer(invocation -> {
+      currentConnection.set(invocation.getArgument(0));
+      currentHost.set(invocation.getArgument(1));
+      return null;
+    }).when(pluginService).setCurrentConnection(any(Connection.class), any(HostSpec.class));
+    when(pluginService.getHosts()).thenAnswer(invocation -> publishedHosts);
+    when(pluginService.getHostSpecByStrategy(anyList(), eq(HostRole.READER), eq("random")))
+        .thenAnswer(invocation -> readerCandidate(invocation.getArgument(0)));
+    when(pluginService.getHostSpecByStrategy(anyList(), eq(HostRole.READER), eq("lowestLoad")))
+        .thenAnswer(invocation -> readerCandidate(invocation.getArgument(0)));
+    when(pluginService.connect(any(HostSpec.class), any(Properties.class), any()))
+        .thenAnswer(invocation -> invocation.<HostSpec>getArgument(0).getRole() == HostRole.WRITER
+            ? writerConnection : readerConnection);
+    when(hostListProviderService.getHostListProvider()).thenReturn(hostListProvider);
+    when(hostListProvider.getStoredTopology()).thenAnswer(invocation -> storedTopology);
+    when(pluginService.getSessionStateService()).thenReturn(sessionStateService);
+    when(sessionStateService.getAutoCommit()).thenReturn(Optional.of(true));
+    when(sessionStateService.getReadOnly()).thenReturn(Optional.empty());
+  }
+
+  @AfterEach
+  void tearDown() throws Exception {
+    closeable.close();
+  }
+
+  // -------------------------------------------------------------------------
+  // Group 1 – Basic threshold behaviour (7 tests)
+  // -------------------------------------------------------------------------
+
+  @Test
+  void enabled_lagAboveThreshold_readSwitchesToWriter() throws SQLException {
+    startOn(readerConnection, readerOne);
+    givenTopology(Arrays.asList(writer, readerOne), Arrays.asList(writer, reader("reader-one", 5000f)));
+
+    read(newTopologyPlugin(enabledProps()));
+
+    assertEquals(writerConnection, currentConnection.get());
+    assertEquals(writer, currentHost.get());
+  }
+
+  @Test
+  void enabled_lagBelowThreshold_switchesToReader() throws SQLException {
+    givenTopology(Arrays.asList(writer, readerOne), Arrays.asList(writer, reader("reader-one", 100f)));
+
+    read(newTopologyPlugin(enabledProps()));
+
+    assertEquals(readerConnection, currentConnection.get());
+    assertEquals(readerOne, currentHost.get());
+  }
+
+  @Test
+  void enabled_lagAtThreshold_staysOnReader() throws SQLException {
+    // threshold check is strict ">", so lag == threshold must NOT fallback
+    givenTopology(Arrays.asList(writer, readerOne),
+        Arrays.asList(writer, reader("reader-one", (float) THRESHOLD_MS)));
+
+    read(newTopologyPlugin(enabledProps()));
+
+    assertEquals(readerConnection, currentConnection.get());
+  }
+
+  @Test
+  void enabled_zeroThresholdTreatsPositiveLagAsBreach() throws SQLException {
+    final Properties props = new Properties();
+    props.setProperty(UnifiedReadWriteSplittingPlugin.REPLICA_LAG_THRESHOLD_MS.name, "0");
+    startOn(readerConnection, readerOne);
+    givenTopology(Arrays.asList(writer, readerOne), Arrays.asList(writer, reader("reader-one", 1f)));
+
+    read(newTopologyPlugin(props));
+
+    assertEquals(writerConnection, currentConnection.get());
+  }
+
+  @Test
+  void disabled_lagAboveThreshold_staysOnReaderAndNeverReadsTopology() throws SQLException {
+    givenTopology(Arrays.asList(writer, readerOne), Arrays.asList(writer, reader("reader-one", 5000f)));
+
+    read(newTopologyPlugin(new Properties()));
+
+    assertEquals(readerConnection, currentConnection.get());
+    verify(hostListProvider, never()).getStoredTopology();
+  }
+
+  @Test
+  void enabled_lagRecovered_returnsToReaderImmediately() throws SQLException {
+    givenTopology(Arrays.asList(writer, readerOne), Arrays.asList(writer, reader("reader-one", 5000f)));
+    final ReadWriteSplittingPlugin plugin = newTopologyPlugin(enabledProps());
+
+    read(plugin);
+    assertEquals(writerConnection, currentConnection.get());
+
+    // Lag drops back below threshold — next routing decision must go to reader again (no hysteresis)
+    givenTopology(Arrays.asList(writer, readerOne), Arrays.asList(writer, reader("reader-one", 100f)));
+    read(plugin);
+
+    assertEquals(readerConnection, currentConnection.get());
+  }
+
+  @Test
+  void enabled_unknownLag_doesNotInterfereWithRouting() throws SQLException {
+    // null lag in Aurora topology means "unknown" — routing must remain unchanged (reader)
+    givenTopology(Arrays.asList(writer, readerOne), Arrays.asList(writer, reader("reader-one", null)));
+
+    read(newTopologyPlugin(enabledProps()));
+
+    assertEquals(readerConnection, currentConnection.get());
+  }
+
+  // -------------------------------------------------------------------------
+  // Group 2 – Lag value selection (7 tests)
+  // -------------------------------------------------------------------------
+
+  @Test
+  void enabled_notOnReader_usesWorstReaderLag() throws SQLException {
+    // Not pinned to any reader yet: two candidates — worst lag (5000 ms) must trigger fallback
+    givenTopology(Arrays.asList(writer, readerOne, readerTwo), Arrays.asList(
+        writer, reader("reader-one", 100f), reader("reader-two", 5000f)));
+
+    read(newTopologyPlugin(enabledProps()));
+
+    assertEquals(writerConnection, currentConnection.get());
+  }
+
+  @Test
+  void enabled_currentReaderHealthy_staysOnItWhileAnotherReaderLags() throws SQLException {
+    // Pinned to readerOne (healthy) — readerTwo's high lag must NOT affect this routing decision
+    startOn(readerConnection, readerOne);
+    givenTopology(Arrays.asList(writer, readerOne, readerTwo), Arrays.asList(
+        writer, reader("reader-one", 100f), reader("reader-two", 5000f)));
+
+    read(newTopologyPlugin(enabledProps()));
+
+    assertEquals(readerConnection, currentConnection.get());
+  }
+
+  @Test
+  void enabled_currentReaderLagging_routesToWriterEvenIfAnotherReaderIsHealthy() throws SQLException {
+    // Pinned to readerOne which is lagging — even though readerTwo is healthy, writer is chosen
+    startOn(readerConnection, readerOne);
+    givenTopology(Arrays.asList(writer, readerOne, readerTwo), Arrays.asList(
+        writer, reader("reader-one", 5000f), reader("reader-two", 50f)));
+
+    read(newTopologyPlugin(enabledProps()));
+
+    assertEquals(writerConnection, currentConnection.get());
+  }
+
+  @Test
+  void enabled_queryLevelLoadBalancing_usesWorstReaderEvenWhenCurrentIsHealthy() throws SQLException {
+    // With qLB enabled, no reader is pinned — all candidates are evaluated, worst lag wins
+    final Properties props = enabledProps();
+    props.setProperty(UnifiedReadWriteSplittingPlugin.QUERY_LEVEL_LOAD_BALANCING.name, "true");
+    startOn(readerConnection, readerOne);
+    givenTopology(Arrays.asList(writer, readerOne, readerTwo), Arrays.asList(
+        writer, reader("reader-one", 100f), reader("reader-two", 5000f)));
+
+    read(newTopologyPlugin(props));
+
+    assertEquals(writerConnection, currentConnection.get());
+  }
+
+  @Test
+  void enabled_lowestLoadSelector_bestEligibleReaderHealthy_keepsReader() throws SQLException {
+    // 'lowestLoad' is lag-minimizing: candidates reader-one (100 ms) and reader-two (5000 ms)
+    // aggregate via Math.min → 100 ms is below the threshold → no fallback even though one
+    // eligible reader is severely lagging.
+    final Properties props = enabledProps();
+    props.setProperty(ReadWriteSplittingPlugin.READER_HOST_SELECTOR_STRATEGY.name, "lowestLoad");
+    givenTopology(Arrays.asList(writer, readerOne, readerTwo), Arrays.asList(
+        writer, reader("reader-one", 100f), reader("reader-two", 5000f)));
+
+    read(newTopologyPlugin(props));
+
+    assertEquals(readerConnection, currentConnection.get());
+  }
+
+  @Test
+  void enabled_lowestLoadSelector_everyEligibleReaderLagging_fallsBackToWriter() throws SQLException {
+    // Even the best eligible reader (Math.min) is lagging (1500 ms) → above threshold → writer
+    final Properties props = enabledProps();
+    props.setProperty(ReadWriteSplittingPlugin.READER_HOST_SELECTOR_STRATEGY.name, "lowestLoad");
+    givenTopology(Arrays.asList(writer, readerOne, readerTwo), Arrays.asList(
+        writer, reader("reader-one", 1500f), reader("reader-two", 5000f)));
+
+    read(newTopologyPlugin(props));
+
+    assertEquals(writerConnection, currentConnection.get());
+  }
+
+  @Test
+  void enabled_cachedLaggingReaderWouldBeReused_routesToWriter() throws SQLException {
+    // The plugin has a cached reader (readerOne) that is lagging; on the next read it must
+    // fall back to the writer rather than returning to the cached lagging reader.
+    final ReadWriteSplittingPlugin plugin = newTopologyPlugin(enabledProps());
+
+    // First: establish a cached reader by doing a healthy read
+    givenTopology(Arrays.asList(writer, readerOne), Arrays.asList(writer, reader("reader-one", 100f)));
+    read(plugin);
+    assertEquals(readerConnection, currentConnection.get());
+
+    // Now the cached reader's lag spikes — switch back to writer first so the plugin is on the
+    // writer and will consider reusing its cached reader for the next read
+    startOn(writerConnection, writer);
+    givenTopology(Arrays.asList(writer, readerOne), Arrays.asList(writer, reader("reader-one", 5000f)));
+    read(plugin);
+
+    // Must NOT reuse the lagging cached reader
+    assertEquals(writerConnection, currentConnection.get());
+  }
+
+  @Test
+  void enabled_unavailableNonCurrentReaderIsIgnored() throws SQLException {
+    // An unavailable non-current reader (readerTwo) with high lag must be skipped in the
+    // lag evaluation; only the available readerOne (healthy) matters
+    final HostSpec unavailableReader = host("reader-two", HostRole.READER, HostAvailability.NOT_AVAILABLE, null);
+    givenTopology(Arrays.asList(writer, readerOne, unavailableReader), Arrays.asList(
+        writer, reader("reader-one", 100f), reader("reader-two", 5000f)));
+
+    read(newTopologyPlugin(enabledProps()));
+
+    assertEquals(readerConnection, currentConnection.get());
+  }
+
+  @Test
+  void enabled_unavailableCurrentStickyReaderIsMeasured() throws SQLException {
+    // The current (sticky) reader is marked NOT_AVAILABLE but still holds an open connection —
+    // its lag must still be checked and trigger writer fallback when it exceeds the threshold
+    final HostSpec unavailableReader = host("reader-one", HostRole.READER, HostAvailability.NOT_AVAILABLE, null);
+    startOn(readerConnection, unavailableReader);
+    givenTopology(Arrays.asList(writer, unavailableReader), Arrays.asList(writer, reader("reader-one", 5000f)));
+
+    read(newTopologyPlugin(enabledProps()));
+
+    assertEquals(writerConnection, currentConnection.get());
+  }
+
+  // -------------------------------------------------------------------------
+  // Group 3 – Data source correctness (4 tests)
+  // -------------------------------------------------------------------------
+
+  @Test
+  void enabled_readerFilteredOutOfGetHosts_lagIsIgnored() throws SQLException {
+    // readerTwo is in the stored topology (lag 5000) but NOT in publishedHosts (getHosts()).
+    // Since candidates come from getHosts(), readerTwo must be ignored — lag stays below threshold.
+    givenTopology(Arrays.asList(writer, readerOne), Arrays.asList(
+        writer, reader("reader-one", 100f), reader("reader-two", 5000f)));
+
+    read(newTopologyPlugin(enabledProps()));
+
+    assertEquals(readerConnection, currentConnection.get());
+  }
+
+  @Test
+  void enabled_availabilityComesFromGetHostsNotFromTopology() throws SQLException {
+    // readerTwo appears as NOT_AVAILABLE in publishedHosts (authoritative for availability)
+    // even if the stored topology has it as AVAILABLE — the NOT_AVAILABLE status must win
+    final HostSpec unavailableReader = host("reader-two", HostRole.READER, HostAvailability.NOT_AVAILABLE, null);
+    givenTopology(Arrays.asList(writer, readerOne, unavailableReader), Arrays.asList(
+        writer, reader("reader-one", 100f), reader("reader-two", 5000f)));
+
+    read(newTopologyPlugin(enabledProps()));
+
+    assertEquals(readerConnection, currentConnection.get());
+  }
+
+  @Test
+  void enabled_lagRankedSelectorUsesWorstCurrentLagWhenPublishedMetricsAreStale() throws SQLException {
+    // Both readers are AVAILABLE in published hosts, but the stored topology has up-to-date lag.
+    // Worst lag (5000 ms) is picked pessimistically and triggers writer fallback.
+    givenTopology(Arrays.asList(writer, readerOne, readerTwo), Arrays.asList(
+        writer, reader("reader-one", 100f), reader("reader-two", 5000f)));
+
+    read(newTopologyPlugin(enabledProps()));
+
+    // Pessimistic: the 5000 ms reader is eligible, so fallback to writer
+    assertEquals(writerConnection, currentConnection.get());
+  }
+
+  @Test
+  void enabled_neverTriggersBlockingTopologyFetch() throws SQLException {
+    // The lag evaluation must only read from the in-memory cache (getStoredTopology),
+    // never call the blocking refresh() method.
+    givenTopology(Arrays.asList(writer, readerOne), Arrays.asList(writer, reader("reader-one", 5000f)));
+
+    read(newTopologyPlugin(enabledProps()));
+
+    verify(hostListProvider, never()).refresh();
+    verify(hostListProvider).getStoredTopology();
+  }
+
+  // -------------------------------------------------------------------------
+  // Group 4 – Transaction safety (6 tests)
+  // -------------------------------------------------------------------------
+
+  @Test
+  void enabled_lagAboveThresholdInOpenTransaction_isNotMoved() throws SQLException {
+    when(pluginService.isInTransaction()).thenReturn(true);
+    startOn(readerConnection, readerOne);
+    givenTopology(Arrays.asList(writer, readerOne), Arrays.asList(writer, reader("reader-one", 5000f)));
+
+    assertDoesNotThrow(() -> read(newTopologyPlugin(enabledProps())));
+
+    // Transaction pins the connection — no switch must happen
+    assertEquals(readerConnection, currentConnection.get());
+  }
+
+  @Test
+  void enabled_lagAboveThresholdInXaTransaction_isNotMoved() throws SQLException {
+    when(pluginService.isXaTransactionActive()).thenReturn(true);
+    startOn(readerConnection, readerOne);
+    givenTopology(Arrays.asList(writer, readerOne), Arrays.asList(writer, reader("reader-one", 5000f)));
+
+    read(newTopologyPlugin(enabledProps()));
+
+    // XA transaction also pins the connection
+    assertEquals(readerConnection, currentConnection.get());
+  }
+
+  @Test
+  void enabled_readOnlyTransactionOnLaggingReader_startsOnWriter() throws SQLException {
+    // A read-only transaction is starting (setReadOnly(true) before any transaction).
+    // Lag is above threshold → first routing decision goes to writer.
+    when(pluginService.isInTransaction()).thenReturn(false);
+    givenTopology(Arrays.asList(writer, readerOne), Arrays.asList(writer, reader("reader-one", 5000f)));
+
+    read(newTopologyPlugin(enabledProps()));
+
+    assertEquals(writerConnection, currentConnection.get());
+  }
+
+  @Test
+  void enabled_readOnlyTransactionOnWriter_staysOnWriterWhileLagging() throws SQLException {
+    // Already on writer (e.g. after lag fallback) and isReadOnly+lag still high.
+    // Plugin should stay on writer — no spurious switch to reader.
+    startOn(writerConnection, writer);
+    givenTopology(Arrays.asList(writer, readerOne), Arrays.asList(writer, reader("reader-one", 5000f)));
+
+    final ReadWriteSplittingPlugin plugin = newTopologyPlugin(enabledProps());
+    // Trigger read — because we are already on writer and lag would also route to writer, no move
+    plugin.execute(Void.class, SQLException.class, writerConnection,
+        JdbcMethod.CONNECTION_SETREADONLY.methodName, () -> null, new Object[] {true});
+
+    assertEquals(writerConnection, currentConnection.get());
+  }
+
+  @Test
+  void enabled_readOnlyTransactionHealthyLag_usesReader() throws SQLException {
+    // setReadOnly(true) with healthy lag → must connect to a reader
+    when(pluginService.isInTransaction()).thenReturn(false);
+    givenTopology(Arrays.asList(writer, readerOne), Arrays.asList(writer, reader("reader-one", 50f)));
+
+    read(newTopologyPlugin(enabledProps()));
+
+    assertEquals(readerConnection, currentConnection.get());
+  }
+
+  @Test
+  void enabled_setReadOnlyTrueInTransaction_doesNotThrow() throws SQLException {
+    // setReadOnly(true) inside an open transaction must NOT throw even when lag is above threshold
+    when(pluginService.isInTransaction()).thenReturn(true);
+    startOn(readerConnection, readerOne);
+    givenTopology(Arrays.asList(writer, readerOne), Arrays.asList(writer, reader("reader-one", 5000f)));
+
+    final ReadWriteSplittingPlugin plugin = newTopologyPlugin(enabledProps());
+    assertDoesNotThrow(() ->
+        plugin.execute(Void.class, SQLException.class, readerConnection,
+            JdbcMethod.CONNECTION_SETREADONLY.methodName, () -> null, new Object[] {true}));
+  }
+
+  // -------------------------------------------------------------------------
+  // Group 5 – Write and routing hint (3 tests)
+  // -------------------------------------------------------------------------
+
+  @Test
+  void enabled_lagAboveThreshold_writeStillRoutesToWriter() throws SQLException {
+    // A setReadOnly(false) from a reader must switch to writer. Lag evaluation must NOT run
+    // and must NOT touch the stored topology for a write decision.
+    startOn(readerConnection, readerOne);
+    givenTopology(Arrays.asList(writer, readerOne), Arrays.asList(writer, reader("reader-one", 5000f)));
+
+    newTopologyPlugin(enabledProps()).execute(Void.class, SQLException.class, readerConnection,
+        JdbcMethod.CONNECTION_SETREADONLY.methodName, () -> null, new Object[] {false});
+
+    assertEquals(writerConnection, currentConnection.get());
+    verify(hostListProvider, never()).getStoredTopology();
+  }
+
+  @Test
+  void enabled_explicitReaderHintStillUsesWriterWhenLagging() throws SQLException {
+    // An explicit /*@reader*/ routing hint on a plain statement still goes to writer when
+    // the lag fallback kicks in (lag threshold overrides the hint on safety grounds).
+    startOn(readerConnection, readerOne);
+    givenTopology(Arrays.asList(writer, readerOne), Arrays.asList(writer, reader("reader-one", 5000f)));
+
+    final PluginCallContext callContext = new PluginCallContext();
+    callContext.setAttribute(SqlContextKeys.ROUTING_HINT, RoutingHint.READER);
+    final Rebindable rebindable = mock(Rebindable.class);
+    callContext.setRebindHandle(rebindable);
+    when(pluginService.getCallContext()).thenReturn(callContext);
+
+    newAutoTopologyPlugin(enabledProps()).execute(
+        Void.class, SQLException.class, statement,
+        JdbcMethod.STATEMENT_EXECUTEQUERY.methodName,
+        () -> null, new Object[] {"select 1"});
+
+    assertEquals(writerConnection, currentConnection.get());
+    verify(rebindable).rebind(writerConnection);
+  }
+
+  @Test
+  void enabled_plainStatementPath_appliesFallbackAndRefreshesOnce() throws SQLException {
+    startOn(readerConnection, readerOne);
+    givenTopology(Arrays.asList(writer, readerOne), Arrays.asList(writer, reader("reader-one", 5000f)));
+    final PluginCallContext callContext = new PluginCallContext();
+    final Rebindable rebindable = mock(Rebindable.class);
+    callContext.setAttribute(SqlContextKeys.QUERY_TYPE, QueryType.SELECT);
+    callContext.setRebindHandle(rebindable);
+    when(pluginService.getCallContext()).thenReturn(callContext);
+
+    final AutoReadWriteSplittingPlugin plugin = newAutoTopologyPlugin(enabledProps());
+    plugin.execute(Void.class, SQLException.class, statement, JdbcMethod.STATEMENT_EXECUTEQUERY.methodName,
+        () -> null, new Object[] {"select 1"});
+
+    assertEquals(writerConnection, currentConnection.get());
+    verify(rebindable).rebind(writerConnection);
+    // Topology must be refreshed exactly once for the whole routing decision
+    verify(pluginService, times(1)).refreshHostList();
+  }
+
+  // -------------------------------------------------------------------------
+  // Group 6 – Global Write Forwarding (1 test)
+  // -------------------------------------------------------------------------
+
+  @Test
+  void enabled_writerResolutionStay_keepsReaderAndWarnsOnce() throws SQLException {
+    // When the WriterResolver returns STAY (the Global Write Forwarding scenario), the plugin
+    // must remain on the current reader connection after the lag fallback routes to WRITER.
+    // This test isolates that behaviour using a mock WriterResolver — no real RDS URL parsing
+    // is involved, which makes the test independent of RdsUtils hostname patterns.
+    startOn(readerConnection, readerOne);
+    givenTopology(Arrays.asList(writer, readerOne),
+        Arrays.asList(writer, reader("reader-one", 5000f)));
+
+    // Build a mock WriterResolver that always returns STAY (simulates GWF: out-of-region writer).
+    final software.amazon.jdbc.plugin.readwritesplitting.resolver.WriterResolver stayResolver =
+        mock(software.amazon.jdbc.plugin.readwritesplitting.resolver.WriterResolver.class);
+    when(stayResolver.resolveWriter(any()))
+        .thenReturn(software.amazon.jdbc.plugin.readwritesplitting.resolver.WriterResolution.stay());
+
+    // Assemble a ReadWriteSplittingPlugin with real helpers except for the mocked writer resolver.
+    final software.amazon.jdbc.plugin.readwritesplitting.classifier.TopologyRoleClassifier roleClassifier =
+        new software.amazon.jdbc.plugin.readwritesplitting.classifier.TopologyRoleClassifier();
+    final String strategy = "random";
+    final RwSplitHelpers helpers = RwSplitHelpers.builder()
+        .roleClassifier(roleClassifier)
+        .routingSignal(new software.amazon.jdbc.plugin.readwritesplitting.signal.ReadOnlyFlagSignal())
+        .switchGate(new software.amazon.jdbc.plugin.readwritesplitting.gate.TransactionAwareGate())
+        .topologyRefresher(new software.amazon.jdbc.plugin.readwritesplitting.refresher.TopologyRefresherImpl())
+        .writerResolver(stayResolver)
+        .readerResolver(new software.amazon.jdbc.plugin.readwritesplitting.resolver.TopologyReaderResolver(
+            new software.amazon.jdbc.plugin.readwritesplitting.source.TopologyHostsCandidateSource(),
+            new software.amazon.jdbc.plugin.readwritesplitting.balancer.StickyReaderPolicy(strategy),
+            stayResolver))
+        .cachePolicy(new software.amazon.jdbc.plugin.readwritesplitting.cache.DefaultCachePolicy(enabledProps()))
+        .initialConnectionHandler(
+            new software.amazon.jdbc.plugin.readwritesplitting.handler.VerifyRoleOnConnect(strategy, false))
+        .connectionUpdatePolicy(
+            new software.amazon.jdbc.plugin.readwritesplitting.updater.RoleBasedUpdatePolicy(roleClassifier))
+        .build();
+
+    final ReadWriteSplittingPlugin plugin =
+        new ReadWriteSplittingPlugin(pluginService, enabledProps(), helpers);
+    plugin.initHostProvider("", "", enabledProps(), hostListProviderService, () -> null);
+    // Seed the writer host spec so the resolver can be consulted
+    plugin.setWriterHostSpec(writer);
+
+    // Trigger a read with high lag — fallback selects WRITER, but STAY keeps the reader connection
+    plugin.execute(Void.class, SQLException.class, readerConnection,
+        JdbcMethod.CONNECTION_SETREADONLY.methodName, () -> null, new Object[] {true});
+
+    // The physical connection must not have moved (STAY = remain on reader)
+    assertEquals(readerConnection, currentConnection.get());
+  }
+
+  // -------------------------------------------------------------------------
+  // Group 7 – Endpoint mode / RDS Proxy (9 tests)
+  // -------------------------------------------------------------------------
+
+  @Test
+  void enabled_endpointMode_lagAboveThreshold_switchesToWriteEndpoint() throws SQLException {
+    // SimpleReadWriteSplittingPlugin uses an opaque read endpoint — lag is sourced from the
+    // stored Aurora topology. When lag is above threshold the plugin routes to the write endpoint.
+    final Properties props = endpointProps(enabledProps());
+
+    // Stored topology has the single backend reader at high lag
+    final HostSpec backendReader = reader("backend-reader", 5000f);
+    storedTopology = Arrays.asList(writer, backendReader);
+
+    // Current connection is on the read endpoint
+    final HostSpec readEndpointHost = new HostSpecBuilder(new SimpleHostAvailabilityStrategy())
+        .host("reader.endpoint").port(5432).role(HostRole.READER).build();
+    final HostSpec writeEndpointHost = new HostSpecBuilder(new SimpleHostAvailabilityStrategy())
+        .host("writer.endpoint").port(5432).role(HostRole.WRITER).build();
+    startOn(readerConnection, readEndpointHost);
+
+    when(pluginService.connect(any(HostSpec.class), any(Properties.class), any()))
+        .thenAnswer(invocation -> {
+          final HostSpec h = invocation.getArgument(0);
+          return "writer.endpoint".equalsIgnoreCase(h.getHost()) ? writerConnection : readerConnection;
+        });
+    when(pluginService.getHosts()).thenReturn(Arrays.asList(writeEndpointHost, readEndpointHost));
+    when(hostListProviderService.getCurrentHostSpec()).thenReturn(readEndpointHost);
+    when(hostListProviderService.getHostSpecBuilder())
+        .thenReturn(new HostSpecBuilder(new SimpleHostAvailabilityStrategy()));
+
+    final SimpleReadWriteSplittingPlugin plugin = new SimpleReadWriteSplittingPlugin(pluginService, props);
+    plugin.initHostProvider("", "", props, hostListProviderService, () -> null);
+
+    plugin.execute(Void.class, SQLException.class, readerConnection,
+        JdbcMethod.CONNECTION_SETREADONLY.methodName, () -> null, new Object[] {true});
+
+    assertEquals(writerConnection, currentConnection.get());
+  }
+
+  @Test
+  void enabled_endpointMode_onReadEndpoint_backendReadersHealthy_keepsUsingTheReadEndpoint()
+      throws SQLException {
+    final Properties props = endpointProps(enabledProps());
+
+    // All backend readers are healthy — lag below threshold
+    final HostSpec backendReader = reader("backend-reader", 50f);
+    storedTopology = Arrays.asList(writer, backendReader);
+
+    final HostSpec readEndpointHost = new HostSpecBuilder(new SimpleHostAvailabilityStrategy())
+        .host("reader.endpoint").port(5432).role(HostRole.READER).build();
+    final HostSpec writeEndpointHost = new HostSpecBuilder(new SimpleHostAvailabilityStrategy())
+        .host("writer.endpoint").port(5432).role(HostRole.WRITER).build();
+    startOn(readerConnection, readEndpointHost);
+
+    when(pluginService.connect(any(HostSpec.class), any(Properties.class), any()))
+        .thenReturn(readerConnection);
+    when(pluginService.getHosts()).thenReturn(Arrays.asList(writeEndpointHost, readEndpointHost));
+    when(hostListProviderService.getCurrentHostSpec()).thenReturn(readEndpointHost);
+    when(hostListProviderService.getHostSpecBuilder())
+        .thenReturn(new HostSpecBuilder(new SimpleHostAvailabilityStrategy()));
+
+    final SimpleReadWriteSplittingPlugin plugin = new SimpleReadWriteSplittingPlugin(pluginService, props);
+    plugin.initHostProvider("", "", props, hostListProviderService, () -> null);
+
+    plugin.execute(Void.class, SQLException.class, readerConnection,
+        JdbcMethod.CONNECTION_SETREADONLY.methodName, () -> null, new Object[] {true});
+
+    // Stayed on reader endpoint
+    assertEquals(readerConnection, currentConnection.get());
+  }
+
+  @Test
+  void enabled_endpointMode_nothingCached_leavesRoutingUntouched() throws SQLException {
+    // No stored topology → lag is unknown → routing is left unchanged
+    final Properties props = endpointProps(enabledProps());
+    storedTopology = null;
+
+    final HostSpec readEndpointHost = new HostSpecBuilder(new SimpleHostAvailabilityStrategy())
+        .host("reader.endpoint").port(5432).role(HostRole.READER).build();
+    final HostSpec writeEndpointHost = new HostSpecBuilder(new SimpleHostAvailabilityStrategy())
+        .host("writer.endpoint").port(5432).role(HostRole.WRITER).build();
+    startOn(readerConnection, readEndpointHost);
+
+    when(pluginService.connect(any(HostSpec.class), any(Properties.class), any()))
+        .thenReturn(readerConnection);
+    when(pluginService.getHosts()).thenReturn(Arrays.asList(writeEndpointHost, readEndpointHost));
+    when(hostListProviderService.getCurrentHostSpec()).thenReturn(readEndpointHost);
+    when(hostListProviderService.getHostSpecBuilder())
+        .thenReturn(new HostSpecBuilder(new SimpleHostAvailabilityStrategy()));
+
+    final SimpleReadWriteSplittingPlugin plugin = new SimpleReadWriteSplittingPlugin(pluginService, props);
+    plugin.initHostProvider("", "", props, hostListProviderService, () -> null);
+
+    plugin.execute(Void.class, SQLException.class, readerConnection,
+        JdbcMethod.CONNECTION_SETREADONLY.methodName, () -> null, new Object[] {true});
+
+    assertEquals(readerConnection, currentConnection.get());
+  }
+
+  @Test
+  void enabled_endpointMode_topologyReadFails_leavesRoutingUntouched() throws SQLException {
+    final Properties props = endpointProps(enabledProps());
+    when(hostListProvider.getStoredTopology()).thenThrow(new SQLException("monitor unavailable"));
+
+    final HostSpec readEndpointHost = new HostSpecBuilder(new SimpleHostAvailabilityStrategy())
+        .host("reader.endpoint").port(5432).role(HostRole.READER).build();
+    final HostSpec writeEndpointHost = new HostSpecBuilder(new SimpleHostAvailabilityStrategy())
+        .host("writer.endpoint").port(5432).role(HostRole.WRITER).build();
+    startOn(readerConnection, readEndpointHost);
+
+    when(pluginService.connect(any(HostSpec.class), any(Properties.class), any()))
+        .thenReturn(readerConnection);
+    when(pluginService.getHosts()).thenReturn(Arrays.asList(writeEndpointHost, readEndpointHost));
+    when(hostListProviderService.getCurrentHostSpec()).thenReturn(readEndpointHost);
+    when(hostListProviderService.getHostSpecBuilder())
+        .thenReturn(new HostSpecBuilder(new SimpleHostAvailabilityStrategy()));
+
+    final SimpleReadWriteSplittingPlugin plugin = new SimpleReadWriteSplittingPlugin(pluginService, props);
+    plugin.initHostProvider("", "", props, hostListProviderService, () -> null);
+
+    plugin.execute(Void.class, SQLException.class, readerConnection,
+        JdbcMethod.CONNECTION_SETREADONLY.methodName, () -> null, new Object[] {true});
+
+    // Exception swallowed — stays on read endpoint
+    assertEquals(readerConnection, currentConnection.get());
+  }
+
+  @Test
+  void enabled_endpointMode_providerReportsNoTopology_leavesRoutingUntouched() throws SQLException {
+    final Properties props = endpointProps(enabledProps());
+    // Provider returns empty topology (not null, but zero hosts)
+    storedTopology = Arrays.asList();
+
+    final HostSpec readEndpointHost = new HostSpecBuilder(new SimpleHostAvailabilityStrategy())
+        .host("reader.endpoint").port(5432).role(HostRole.READER).build();
+    final HostSpec writeEndpointHost = new HostSpecBuilder(new SimpleHostAvailabilityStrategy())
+        .host("writer.endpoint").port(5432).role(HostRole.WRITER).build();
+    startOn(readerConnection, readEndpointHost);
+
+    when(pluginService.connect(any(HostSpec.class), any(Properties.class), any()))
+        .thenReturn(readerConnection);
+    when(pluginService.getHosts()).thenReturn(Arrays.asList(writeEndpointHost, readEndpointHost));
+    when(hostListProviderService.getCurrentHostSpec()).thenReturn(readEndpointHost);
+    when(hostListProviderService.getHostSpecBuilder())
+        .thenReturn(new HostSpecBuilder(new SimpleHostAvailabilityStrategy()));
+
+    final SimpleReadWriteSplittingPlugin plugin = new SimpleReadWriteSplittingPlugin(pluginService, props);
+    plugin.initHostProvider("", "", props, hostListProviderService, () -> null);
+
+    plugin.execute(Void.class, SQLException.class, readerConnection,
+        JdbcMethod.CONNECTION_SETREADONLY.methodName, () -> null, new Object[] {true});
+
+    assertEquals(readerConnection, currentConnection.get());
+  }
+
+  @Test
+  void enabled_endpointMode_countsBackendReaderMissingFromPublishedHostList() throws SQLException {
+    // A backend reader not present in storedTopology contributes no lag — only the one that
+    // IS in the topology is measured. If that one is healthy, endpoint stays on reader.
+    final Properties props = endpointProps(enabledProps());
+    final HostSpec backendReader = reader("backend-reader-only-in-topology", 100f);
+    storedTopology = Arrays.asList(writer, backendReader);
+
+    final HostSpec readEndpointHost = new HostSpecBuilder(new SimpleHostAvailabilityStrategy())
+        .host("reader.endpoint").port(5432).role(HostRole.READER).build();
+    final HostSpec writeEndpointHost = new HostSpecBuilder(new SimpleHostAvailabilityStrategy())
+        .host("writer.endpoint").port(5432).role(HostRole.WRITER).build();
+    startOn(readerConnection, readEndpointHost);
+
+    when(pluginService.connect(any(HostSpec.class), any(Properties.class), any()))
+        .thenReturn(readerConnection);
+    when(pluginService.getHosts()).thenReturn(Arrays.asList(writeEndpointHost, readEndpointHost));
+    when(hostListProviderService.getCurrentHostSpec()).thenReturn(readEndpointHost);
+    when(hostListProviderService.getHostSpecBuilder())
+        .thenReturn(new HostSpecBuilder(new SimpleHostAvailabilityStrategy()));
+
+    final SimpleReadWriteSplittingPlugin plugin = new SimpleReadWriteSplittingPlugin(pluginService, props);
+    plugin.initHostProvider("", "", props, hostListProviderService, () -> null);
+
+    plugin.execute(Void.class, SQLException.class, readerConnection,
+        JdbcMethod.CONNECTION_SETREADONLY.methodName, () -> null, new Object[] {true});
+
+    assertEquals(readerConnection, currentConnection.get());
+  }
+
+  @Test
+  void enabled_endpointMode_ignoresReaderThatLeftTheCluster() throws SQLException {
+    // A backend reader that left the cluster (not in storedTopology anymore) contributes no lag.
+    // Only remaining readers are measured; if they are all healthy, keep the read endpoint.
+    final Properties props = endpointProps(enabledProps());
+    // Only the healthy reader remains in topology; the lagging one left
+    final HostSpec healthyBackend = reader("healthy-backend", 50f);
+    storedTopology = Arrays.asList(writer, healthyBackend);
+
+    final HostSpec readEndpointHost = new HostSpecBuilder(new SimpleHostAvailabilityStrategy())
+        .host("reader.endpoint").port(5432).role(HostRole.READER).build();
+    final HostSpec writeEndpointHost = new HostSpecBuilder(new SimpleHostAvailabilityStrategy())
+        .host("writer.endpoint").port(5432).role(HostRole.WRITER).build();
+    startOn(readerConnection, readEndpointHost);
+
+    when(pluginService.connect(any(HostSpec.class), any(Properties.class), any()))
+        .thenReturn(readerConnection);
+    when(pluginService.getHosts()).thenReturn(Arrays.asList(writeEndpointHost, readEndpointHost));
+    when(hostListProviderService.getCurrentHostSpec()).thenReturn(readEndpointHost);
+    when(hostListProviderService.getHostSpecBuilder())
+        .thenReturn(new HostSpecBuilder(new SimpleHostAvailabilityStrategy()));
+
+    final SimpleReadWriteSplittingPlugin plugin = new SimpleReadWriteSplittingPlugin(pluginService, props);
+    plugin.initHostProvider("", "", props, hostListProviderService, () -> null);
+
+    plugin.execute(Void.class, SQLException.class, readerConnection,
+        JdbcMethod.CONNECTION_SETREADONLY.methodName, () -> null, new Object[] {true});
+
+    assertEquals(readerConnection, currentConnection.get());
+  }
+
+  @Test
+  void enabled_endpointMode_usesWorstBackendReaderRegardlessOfSelector() throws SQLException {
+    // In endpoint mode, host-selector metrics don't apply — ALL backend readers in the Aurora
+    // topology are evaluated. The worst lag (5000 ms) triggers writer fallback.
+    final Properties props = endpointProps(enabledProps());
+    final HostSpec fastReader = reader("fast-backend", 50f);
+    final HostSpec slowReader = reader("slow-backend", 5000f);
+    storedTopology = Arrays.asList(writer, fastReader, slowReader);
+
+    final HostSpec readEndpointHost = new HostSpecBuilder(new SimpleHostAvailabilityStrategy())
+        .host("reader.endpoint").port(5432).role(HostRole.READER).build();
+    final HostSpec writeEndpointHost = new HostSpecBuilder(new SimpleHostAvailabilityStrategy())
+        .host("writer.endpoint").port(5432).role(HostRole.WRITER).build();
+    startOn(readerConnection, readEndpointHost);
+
+    when(pluginService.connect(any(HostSpec.class), any(Properties.class), any()))
+        .thenAnswer(invocation -> {
+          final HostSpec h = invocation.getArgument(0);
+          return "writer.endpoint".equalsIgnoreCase(h.getHost()) ? writerConnection : readerConnection;
+        });
+    when(pluginService.getHosts()).thenReturn(Arrays.asList(writeEndpointHost, readEndpointHost));
+    when(hostListProviderService.getCurrentHostSpec()).thenReturn(readEndpointHost);
+    when(hostListProviderService.getHostSpecBuilder())
+        .thenReturn(new HostSpecBuilder(new SimpleHostAvailabilityStrategy()));
+
+    final SimpleReadWriteSplittingPlugin plugin = new SimpleReadWriteSplittingPlugin(pluginService, props);
+    plugin.initHostProvider("", "", props, hostListProviderService, () -> null);
+
+    plugin.execute(Void.class, SQLException.class, readerConnection,
+        JdbcMethod.CONNECTION_SETREADONLY.methodName, () -> null, new Object[] {true});
+
+    assertEquals(writerConnection, currentConnection.get());
+  }
+
+  @Test
+  void enabled_endpointMode_onReadEndpoint_measuresBackendReadersInsteadOfTheEndpoint()
+      throws SQLException {
+    // The read endpoint host itself carries no lag in the topology (it is opaque).
+    // Lag is measured from the backend reader entries in storedTopology.
+    final Properties props = endpointProps(enabledProps());
+    final HostSpec backendReader = reader("backend-reader", 5000f);
+    storedTopology = Arrays.asList(writer, backendReader);
+
+    final HostSpec readEndpointHost = new HostSpecBuilder(new SimpleHostAvailabilityStrategy())
+        .host("reader.endpoint").port(5432).role(HostRole.READER).build();
+    final HostSpec writeEndpointHost = new HostSpecBuilder(new SimpleHostAvailabilityStrategy())
+        .host("writer.endpoint").port(5432).role(HostRole.WRITER).build();
+    startOn(readerConnection, readEndpointHost);
+
+    when(pluginService.connect(any(HostSpec.class), any(Properties.class), any()))
+        .thenAnswer(invocation -> {
+          final HostSpec h = invocation.getArgument(0);
+          return "writer.endpoint".equalsIgnoreCase(h.getHost()) ? writerConnection : readerConnection;
+        });
+    when(pluginService.getHosts()).thenReturn(Arrays.asList(writeEndpointHost, readEndpointHost));
+    when(hostListProviderService.getCurrentHostSpec()).thenReturn(readEndpointHost);
+    when(hostListProviderService.getHostSpecBuilder())
+        .thenReturn(new HostSpecBuilder(new SimpleHostAvailabilityStrategy()));
+
+    final SimpleReadWriteSplittingPlugin plugin = new SimpleReadWriteSplittingPlugin(pluginService, props);
+    plugin.initHostProvider("", "", props, hostListProviderService, () -> null);
+
+    plugin.execute(Void.class, SQLException.class, readerConnection,
+        JdbcMethod.CONNECTION_SETREADONLY.methodName, () -> null, new Object[] {true});
+
+    // Backend reader was lagging → switched to write endpoint
+    assertEquals(writerConnection, currentConnection.get());
+  }
+
+  // -------------------------------------------------------------------------
+  // Group 8 – Topology refresh count (8 tests)
+  // -------------------------------------------------------------------------
+
+  @Test
+  void enabled_readRoutedToReader_refreshesTopologyExactlyOnce() throws SQLException {
+    // A routing decision that sends a read to a reader must trigger exactly one topology refresh
+    givenTopology(Arrays.asList(writer, readerOne), Arrays.asList(writer, reader("reader-one", 100f)));
+
+    read(newTopologyPlugin(enabledProps()));
+
+    assertEquals(readerConnection, currentConnection.get());
+    verify(pluginService, times(1)).refreshHostList();
+  }
+
+  @Test
+  void enabled_readRoutedToWriterByLag_refreshesTopologyExactlyOnce() throws SQLException {
+    // A routing decision that falls back from reader to writer (due to lag) must also trigger
+    // exactly one topology refresh — not two (one from lag check, one from switch)
+    startOn(readerConnection, readerOne);
+    givenTopology(Arrays.asList(writer, readerOne), Arrays.asList(writer, reader("reader-one", 5000f)));
+
+    read(newTopologyPlugin(enabledProps()));
+
+    assertEquals(writerConnection, currentConnection.get());
+    verify(pluginService, times(1)).refreshHostList();
+  }
+
+  @Test
+  void enabled_noRoutingDecision_doesNotRefreshTopology() throws SQLException {
+    // A method that produces NO_DECISION from the routing signal (e.g. clearWarnings) must not
+    // trigger a topology refresh at all
+    when(pluginService.getCurrentConnection()).thenReturn(writerConnection);
+    when(pluginService.getCurrentHostSpec()).thenReturn(writer);
+
+    newTopologyPlugin(enabledProps()).execute(
+        Void.class, SQLException.class, writerConnection,
+        JdbcMethod.CONNECTION_CLEARWARNINGS.methodName, () -> null, null);
+
+    verify(pluginService, never()).refreshHostList();
+  }
+
+  @Test
+  void enabled_boundStatementRerouted_refreshesTopologyExactlyOnce() throws SQLException {
+    // A plain Statement rerouted via rebinding must trigger exactly one topology refresh
+    startOn(readerConnection, readerOne);
+    givenTopology(Arrays.asList(writer, readerOne), Arrays.asList(writer, reader("reader-one", 5000f)));
+
+    final PluginCallContext callContext = new PluginCallContext();
+    callContext.setAttribute(SqlContextKeys.QUERY_TYPE, QueryType.SELECT);
+    final Rebindable rebindable = mock(Rebindable.class);
+    callContext.setRebindHandle(rebindable);
+    when(pluginService.getCallContext()).thenReturn(callContext);
+
+    newAutoTopologyPlugin(enabledProps()).execute(
+        Void.class, SQLException.class, statement,
+        JdbcMethod.STATEMENT_EXECUTEQUERY.methodName,
+        () -> null, new Object[] {"select 1"});
+
+    assertEquals(writerConnection, currentConnection.get());
+    verify(pluginService, times(1)).refreshHostList();
+  }
+
+  @Test
+  void enabled_boundStatementThatCannotBeReboundDoesNotRefreshTopology() throws SQLException {
+    // A plain Statement without a rebind handle cannot be rerouted — no topology refresh for lag
+    startOn(readerConnection, readerOne);
+    givenTopology(Arrays.asList(writer, readerOne), Arrays.asList(writer, reader("reader-one", 5000f)));
+
+    final PluginCallContext callContext = new PluginCallContext();
+    callContext.setAttribute(SqlContextKeys.QUERY_TYPE, QueryType.SELECT);
+    // No rebind handle set — rerouting impossible
+    when(pluginService.getCallContext()).thenReturn(callContext);
+
+    newAutoTopologyPlugin(enabledProps()).execute(
+        Void.class, SQLException.class, statement,
+        JdbcMethod.STATEMENT_EXECUTEQUERY.methodName,
+        () -> null, new Object[] {"select 1"});
+
+    // No rebinding possible → no topology refresh for lag decision
+    verify(pluginService, never()).refreshHostList();
+  }
+
+  @Test
+  void disabled_boundStatement_doesNotRefreshTopology() throws SQLException {
+    // When the lag threshold is disabled, processing a bound statement must never refresh topology
+    startOn(readerConnection, readerOne);
+
+    final PluginCallContext callContext = new PluginCallContext();
+    callContext.setAttribute(SqlContextKeys.QUERY_TYPE, QueryType.SELECT);
+    final Rebindable rebindable = mock(Rebindable.class);
+    callContext.setRebindHandle(rebindable);
+    when(pluginService.getCallContext()).thenReturn(callContext);
+
+    // Disabled props: no REPLICA_LAG_THRESHOLD_MS set → defaults to -1
+    newAutoTopologyPlugin(new Properties()).execute(
+        Void.class, SQLException.class, statement,
+        JdbcMethod.STATEMENT_EXECUTEQUERY.methodName,
+        () -> null, new Object[] {"select 1"});
+
+    verify(pluginService, never()).refreshHostList();
+    verify(hostListProvider, never()).getStoredTopology();
+  }
+
+  @Test
+  void enabled_plainStatementWrite_doesNotRefreshTopologyForLag() throws SQLException {
+    final PluginCallContext callContext = new PluginCallContext();
+    callContext.setAttribute(SqlContextKeys.QUERY_TYPE, QueryType.INSERT);
+    callContext.setRebindHandle(mock(Rebindable.class));
+    when(pluginService.getCallContext()).thenReturn(callContext);
+
+    newAutoTopologyPlugin(enabledProps()).execute(Void.class, SQLException.class, statement,
+        JdbcMethod.STATEMENT_EXECUTEUPDATE.methodName, () -> null,
+        new Object[] {"insert into t values (1)"});
+
+    // Writer path: no lag evaluation and no topology refresh triggered by lag logic
+    verify(pluginService, never()).refreshHostList();
+    verify(hostListProvider, never()).getStoredTopology();
+  }
+
+  @Test
+  void enabled_uncachedTopology_doesNotResolveCandidates() throws SQLException {
+    // When the stored topology is null (no cache yet), relevantReaderLagMs returns NaN early
+    // and must NOT attempt to resolve reader candidates through the resolver.
+    storedTopology = null;
+
+    read(newTopologyPlugin(enabledProps()));
+
+    // Routing must still reach a reader (lag is unknown → routing unchanged)
+    assertEquals(readerConnection, currentConnection.get());
+    // The topology cache miss must surface as "lag unavailable" — exactly one topology
+    // refresh occurs (from performSwitch) but zero calls to getStoredTopology beyond the
+    // single lag-check call that returns null.
+    verify(hostListProvider, times(1)).getStoredTopology();
+  }
+
+  // -------------------------------------------------------------------------
+  // Extra coverage – null / empty topology guards (3 tests)
+  // -------------------------------------------------------------------------
+
+  @Test
+  void enabled_noCachedTopology_doesNotInterfereWithRouting() throws SQLException {
+    // When no topology has been cached yet (null), lag is unknown → routing is left unchanged
+    // and the plugin still routes to a reader normally.
+    storedTopology = null;
+
+    read(newTopologyPlugin(enabledProps()));
+
+    assertEquals(readerConnection, currentConnection.get());
+  }
+
+  @Test
+  void enabled_cachedTopologyReadFails_doesNotInterfereWithRouting() throws SQLException {
+    // An exception from getStoredTopology() must be swallowed and treated as "lag unknown"
+    // so routing continues without throwing to the caller.
+    when(hostListProvider.getStoredTopology()).thenThrow(new SQLException("monitor unavailable"));
+
+    read(newTopologyPlugin(enabledProps()));
+
+    assertEquals(readerConnection, currentConnection.get());
+  }
+
+  @Test
+  void enabled_nonRdsProvider_doesNotReadTopologyOrInterfereWithRouting() throws SQLException {
+    // When the HostListProvider is NOT an RdsHostListProvider (e.g. a static list), the lag
+    // feature silently no-ops because lag is only published by Aurora topology monitors.
+    when(hostListProviderService.getHostListProvider())
+        .thenReturn(mock(software.amazon.jdbc.hostlistprovider.HostListProvider.class));
+
+    read(newTopologyPlugin(enabledProps()));
+
+    // Route still goes to reader (lag unknown for non-Aurora providers)
+    assertEquals(readerConnection, currentConnection.get());
+    verify(hostListProvider, never()).getStoredTopology();
+  }
+
+  // -------------------------------------------------------------------------
+  // Helpers
+  // -------------------------------------------------------------------------
+
+  private ReadWriteSplittingPlugin newTopologyPlugin(final Properties properties) throws SQLException {
+    final ReadWriteSplittingPlugin plugin = new ReadWriteSplittingPlugin(pluginService, properties);
+    plugin.initHostProvider("", "", properties, hostListProviderService, () -> null);
+    return plugin;
+  }
+
+  private AutoReadWriteSplittingPlugin newAutoTopologyPlugin(final Properties properties)
+      throws SQLException {
+    final AutoReadWriteSplittingPlugin plugin =
+        new AutoReadWriteSplittingPlugin(pluginService, properties);
+    plugin.initHostProvider("", "", properties, hostListProviderService, () -> null);
+    return plugin;
+  }
+
+  private void read(final ReadWriteSplittingPlugin plugin) throws SQLException {
+    plugin.execute(Void.class, SQLException.class, currentConnection.get(),
+        JdbcMethod.CONNECTION_SETREADONLY.methodName, () -> null, new Object[] {true});
+  }
+
+  private static HostSpec host(
+      final String name,
+      final HostRole role,
+      final HostAvailability availability,
+      final @Nullable Float lagMs) {
+    return new HostSpecBuilder(new SimpleHostAvailabilityStrategy())
+        .host(name)
+        .port(5432)
+        .role(role)
+        .availability(availability)
+        .lagMs(lagMs)
+        .build();
+  }
+
+  private static HostSpec reader(final String name, final @Nullable Float lagMs) {
+    return host(name, HostRole.READER, HostAvailability.AVAILABLE, lagMs);
+  }
+
+  private Properties enabledProps() {
+    final Properties properties = new Properties();
+    properties.setProperty(UnifiedReadWriteSplittingPlugin.REPLICA_LAG_THRESHOLD_MS.name,
+        Integer.toString(THRESHOLD_MS));
+    return properties;
+  }
+
+  private static Properties endpointProps(final Properties base) {
+    base.setProperty(SimpleReadWriteSplittingPlugin.SRW_WRITE_ENDPOINT.name, "writer.endpoint");
+    base.setProperty(SimpleReadWriteSplittingPlugin.SRW_READ_ENDPOINT.name, "reader.endpoint");
+    base.setProperty(SimpleReadWriteSplittingPlugin.VERIFY_NEW_SRW_CONNECTIONS.name, "false");
+    return base;
+  }
+
+  private void givenTopology(final List<HostSpec> hosts, final List<HostSpec> latestTopology) {
+    publishedHosts = hosts;
+    storedTopology = latestTopology;
+  }
+
+  private void startOn(final Connection connection, final HostSpec host) {
+    currentConnection.set(connection);
+    currentHost.set(host);
+  }
+
+  private static @Nullable HostSpec readerCandidate(final List<HostSpec> hosts) {
+    for (final HostSpec host : hosts) {
+      if (host.getRole() == HostRole.READER && host.getAvailability() == HostAvailability.AVAILABLE) {
+        return host;
+      }
+    }
+    return null;
+  }
+}


### PR DESCRIPTION
### Summary

Adds an optional replica-lag fallback to read/write splitting. The new `replicaLagThresholdMs` property (default `-1`, disabled) redirects a read to the writer when the reader that would serve it exceeds the threshold, instead of returning stale replica data.

Lag is read from the in-memory Aurora topology cache (`RdsHostListProvider#getStoredTopology`) without issuing a blocking topology query. Any non-Aurora cluster whose published host specs carry lag (`HostSpec#getLagMs()`) is supported as well.

### Description

**Lag aggregation on fresh reader selection**

When a fresh reader is selected, the lag of all eligible readers is aggregated according to the configured reader selection strategy:

| Reader selection strategy | Aggregation | A read falls back to the writer when |
|---|---|---|
| `lowestLoad` / `lowestLoadByLag` | Lowest lag (`Math.min`) | every eligible reader exceeds the threshold — even the best available reader is too stale |
| any other strategy (`random`, `roundRobin`, `lowestLoadByCpu`, custom) | Highest lag (`Math.max`) | any one eligible reader exceeds the threshold |
| RDS Proxy / opaque endpoint | Always highest (`Math.max`) | any backend reader exceeds the threshold |

The pessimistic `Math.max` strategy is deliberate: host-selector metrics can be stale, so the driver cannot assume the selector will avoid the worst reader.

**Pinned-reader fast path**

When a sticky or reusable cached reader is already known to serve the read, only that reader's lag is measured (linear scan, no map allocation) rather than aggregating the whole eligible set.

**Bypass rules — explicit application intent wins**

The fallback is skipped entirely (no lag measurement, no topology refresh, no "routed to writer" warning) when:

- the statement carries an explicit routing hint (e.g. `/*@reader*/`, `/*@writer*/`, `/*@keep*/`),
- the session is declared read-only (`Connection.setReadOnly(true)`), which also covers read-only transactions,
- an open local or XA transaction is in progress (the connection is pinned regardless).

If the session read-only state cannot be read, the fallback is skipped rather than applied or raised.

**Routing invariants**

- Exactly one topology refresh per routing decision, for both the `performSwitch` path and the plain-statement rebinding path.
- Statements are re-created on the new connection when a switch happens mid-statement (`allowStatementRecreationOnConnectionSwitch`, default on); when rebinding is impossible the statement stays on its original connection with a one-time reuse warning.
- When lag data is unavailable, routing is left unchanged and a one-time WARNING is logged.

**Tests and documentation**

- New `ReplicaLagFallbackTest` suite (53 tests) covering threshold semantics (strict `>`), `Math.min`/`Math.max` aggregation, pinned-reader fast path, opaque-endpoint handling, topology-refresh count, unknown/absent lag data, and the bypass rules.
- Full test run: `.\gradlew.bat :aws-advanced-jdbc-wrapper:test` — 1408 tests, 0 failures.
- Updated `docs/using-the-jdbc-driver/using-plugins/UsingTheReadWriteSplittingPlugin.md` with a "Replica lag fallback" section (aggregation table, opaque-endpoint note, bypass rules, writer-storm warning).

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.