### PR TITLE
fix: allow topology monitor context recovery

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/ClusterTopologyMonitorImpl.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/ClusterTopologyMonitorImpl.java
@@ -125,11 +125,14 @@ public class ClusterTopologyMonitorImpl extends AbstractMonitor
   protected final long refreshRateNano;
   protected final long highRefreshRateNano;
   protected final TopologyUtils topologyUtils;
-  protected final FullServicesContainer servicesContainer;
-  protected final Properties properties;
-  protected final Properties monitoringProperties;
-  protected final HostSpec initialHostSpec;
+  protected volatile FullServicesContainer servicesContainer;
+  protected volatile Properties properties;
+  protected volatile Properties monitoringProperties;
+  protected volatile HostSpec initialHostSpec;
   protected final HostSpec instanceTemplate;
+
+  // Recovery context offered by a later provider when the monitor is in panic mode.
+  protected final AtomicReference<@Nullable RecoveryContext> pendingRecoveryContext = new AtomicReference<>(null);
 
   protected @Nullable ExecutorService nodeExecutorService = null;
   protected long highRefreshRateEndTimeNano = 0;
@@ -208,6 +211,178 @@ public class ClusterTopologyMonitorImpl extends AbstractMonitor
       this.connectionHandler = this.createConnectionHandler();
     }
     return this.connectionHandler;
+  }
+
+  /**
+   * Builds a monitoring properties set from the given source properties and services container.
+   * This applies the same transformations as the constructor: copy, strip host-selection properties,
+   * apply monitoring-prefix overrides, and set timeout defaults.
+   *
+   * @param sourceProperties the source properties (e.g., from a provider)
+   * @param container        the services container for target-driver-dialect access
+   * @return a new Properties instance suitable for monitoring connections
+   */
+  protected static Properties buildMonitoringProperties(
+      final Properties sourceProperties,
+      final FullServicesContainer container) {
+    final Properties result = PropertyUtils.copyProperties(sourceProperties);
+    PropertyUtils.removeHostSelectionProperties(
+        result, container.getPluginService().getTargetDriverDialect());
+
+    sourceProperties.stringPropertyNames().stream()
+        .filter(p -> p.startsWith(MONITORING_PROPERTY_PREFIX))
+        .forEach(p -> {
+          final String value = sourceProperties.getProperty(p);
+          if (value != null) {
+            result.put(p.substring(MONITORING_PROPERTY_PREFIX.length()), value);
+          }
+          result.remove(p);
+        });
+
+    if (PropertyDefinition.SOCKET_TIMEOUT.getString(result) == null) {
+      PropertyDefinition.SOCKET_TIMEOUT.set(result, String.valueOf(defaultSocketTimeoutMs));
+    }
+    if (PropertyDefinition.CONNECT_TIMEOUT.getString(result) == null) {
+      PropertyDefinition.CONNECT_TIMEOUT.set(result, String.valueOf(defaultConnectionTimeoutMs));
+    }
+    return result;
+  }
+
+  /**
+   * Offers a recovery context to this monitor. If the monitor is currently in panic mode
+   * (no active monitoring connection), the offered context will replace the current connection
+   * context on the next monitoring cycle, allowing recovery with fresh credentials or host.
+   * If the monitor is healthy, this is a no-op.
+   *
+   * <p>This method is safe to call from any thread. The actual context replacement happens
+   * atomically on the monitoring thread.
+   *
+   * <p><strong>Concurrency note:</strong> concurrent offers are last-writer-wins. A failed
+   * candidate simply leaves the monitor in panic mode so a subsequent offer can be attempted.
+   *
+   * @param newInitialHostSpec  the host to use for recovery connection attempts
+   * @param newProperties       the connection properties (credentials, etc.)
+   * @param newServicesContainer the services container (plugin chain, connection provider, etc.)
+   * @return {@code true} if the context was accepted for recovery; {@code false} if the monitor
+   *     is healthy and does not need a new context
+   */
+  public boolean offerRecoveryContext(
+      final HostSpec newInitialHostSpec,
+      final Properties newProperties,
+      final FullServicesContainer newServicesContainer) {
+    if (!this.isInPanicMode()) {
+      return false;
+    }
+
+    this.pendingRecoveryContext.set(
+        new RecoveryContext(newInitialHostSpec, newProperties, newServicesContainer));
+
+    // Wake the monitoring loop so it picks up the context promptly.
+    synchronized (this.requestToUpdateTopology) {
+      this.requestToUpdateTopology.set(true);
+      this.requestToUpdateTopology.notifyAll();
+    }
+    return true;
+  }
+
+  /**
+   * Applies a pending recovery context, if one has been offered and the monitor is still in panic
+   * mode. Called on the monitoring thread at the start of each panic-mode iteration.
+   */
+  protected void applyPendingRecoveryContext() {
+    final RecoveryContext recovery = this.pendingRecoveryContext.getAndSet(null);
+    if (recovery == null || !this.isInPanicMode()) {
+      return;
+    }
+
+    // Build the minimal container first, before any destructive state changes. If creation
+    // fails, existing panic-mode workers and state remain untouched.
+    FullServicesContainer minimalContainer;
+    try {
+      minimalContainer = this.createRecoveryServiceContainer(
+          recovery.servicesContainer, recovery.properties);
+    } catch (SQLException ex) {
+      LOGGER.warning(() -> Messages.get(
+          "ClusterTopologyMonitorImpl.recoveryContextContainerFailed",
+          new Object[]{ex.getMessage()}));
+      return;
+    }
+
+    LOGGER.fine(() -> Messages.get(
+        "ClusterTopologyMonitorImpl.recoveryContextApplied",
+        new Object[]{recovery.initialHostSpec.getHost(), this.initialHostSpec.getHost()}));
+
+    // Stop any running node workers so they don't use stale context.
+    this.nodeThreadsStop.set(true);
+    this.closeNodeMonitors();
+    this.nodeThreadConnectionCleanUp();
+    this.submittedNodes.clear();
+    this.stableTopologiesStartNano = 0;
+    this.readerTopologiesById.clear();
+    this.completedOneCycle.clear();
+    this.nodeThreadsWriterHostSpec.set(null);
+    this.nodeThreadsLatestTopology.set(null);
+    this.nodeThreadsStop.set(false);
+
+    // Replace connection context fields. Safe: only the monitoring thread reads these.
+    this.initialHostSpec = recovery.initialHostSpec;
+    this.properties = recovery.properties;
+    this.servicesContainer = minimalContainer;
+    this.monitoringProperties = buildMonitoringProperties(recovery.properties, minimalContainer);
+    this.logUnclosedConnections = PropertyDefinition.LOG_UNCLOSED_CONNECTIONS.getBoolean(recovery.properties);
+
+    // Recreate the connection handler with the new context.
+    if (this.connectionHandler != null) {
+      this.connectionHandler.close();
+      this.connectionHandler = null;
+    }
+  }
+
+  /**
+   * Creates a minimal service container from the given source container and properties.
+   * This provides the same isolation as the initial monitor creation performed by
+   * {@link software.amazon.jdbc.util.monitoring.MonitorServiceImpl}: the provider's full plugin
+   * chain is replaced with a lightweight monitoring-only service layer.
+   *
+   * <p>Extracted into a separate method so that tests can override or spy on it without
+   * requiring deep integration infrastructure.
+   *
+   * @param sourceContainer the provider's full services container
+   * @param props           the connection properties
+   * @return a new minimal service container
+   * @throws SQLException if container creation fails
+   */
+  protected FullServicesContainer createRecoveryServiceContainer(
+      final FullServicesContainer sourceContainer,
+      final Properties props) throws SQLException {
+    return ServiceUtility.getInstance().createMinimalServiceContainer(sourceContainer, props);
+  }
+
+  /**
+   * Discards any pending recovery context that was offered while the monitor was in panic mode.
+   * Called when the monitor transitions to (or runs in) regular mode so that a stale context
+   * cannot be incorrectly applied during a future panic episode.
+   */
+  protected void discardPendingRecoveryContext() {
+    this.pendingRecoveryContext.set(null);
+  }
+
+  /**
+   * Immutable holder for recovery context offered by a later provider.
+   */
+  protected static class RecoveryContext {
+    final HostSpec initialHostSpec;
+    final Properties properties;
+    final FullServicesContainer servicesContainer;
+
+    RecoveryContext(
+        final HostSpec initialHostSpec,
+        final Properties properties,
+        final FullServicesContainer servicesContainer) {
+      this.initialHostSpec = initialHostSpec;
+      this.properties = properties;
+      this.servicesContainer = servicesContainer;
+    }
   }
 
   @Override
@@ -391,6 +566,8 @@ public class ClusterTopologyMonitorImpl extends AbstractMonitor
         this.lastActivityTimestampNanos.set(System.nanoTime());
 
         if (this.isInPanicMode()) {
+          this.applyPendingRecoveryContext();
+
           if (this.submittedNodes.isEmpty()) {
             LOGGER.finest(() -> Messages.get("ClusterTopologyMonitorImpl.startingNodeMonitoringThreads"));
 
@@ -490,6 +667,12 @@ public class ClusterTopologyMonitorImpl extends AbstractMonitor
 
         } else {
           // We are in regular mode (not panic mode).
+          // Discard any pending recovery context — it was offered while the monitor was in panic mode
+          // and is now stale. Without this, a context offered after applyPendingRecoveryContext() but
+          // before recovery completes would survive and be incorrectly applied during a future panic
+          // episode with potentially expired credentials.
+          this.discardPendingRecoveryContext();
+
           if (!this.submittedNodes.isEmpty()) {
             this.closeNodeMonitors();
             this.nodeThreadConnectionCleanUp();

--- a/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/GlobalAuroraHostListProvider.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/GlobalAuroraHostListProvider.java
@@ -66,7 +66,7 @@ public class GlobalAuroraHostListProvider extends RdsHostListProvider {
   }
 
   protected ClusterTopologyMonitor getOrCreateMonitor() throws SQLException {
-    return this.servicesContainer.getMonitorService().runIfAbsent(
+    final ClusterTopologyMonitor monitor = this.servicesContainer.getMonitorService().runIfAbsent(
         ClusterTopologyMonitorImpl.class,
         this.clusterId,
         this.servicesContainer,
@@ -82,6 +82,8 @@ public class GlobalAuroraHostListProvider extends RdsHostListProvider {
                 this.refreshRateNano,
                 this.highRefreshRateNano,
                 this.instanceTemplatesByRegion));
+    this.offerRecoveryContextIfNeeded(monitor);
+    return monitor;
   }
 
   @Override

--- a/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/RdsHostListProvider.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/RdsHostListProvider.java
@@ -175,7 +175,7 @@ public class RdsHostListProvider implements DynamicHostListProvider, CanReleaseR
   }
 
   protected ClusterTopologyMonitor getOrCreateMonitor() throws SQLException {
-    return this.servicesContainer.getMonitorService().runIfAbsent(
+    final ClusterTopologyMonitor monitor = this.servicesContainer.getMonitorService().runIfAbsent(
         ClusterTopologyMonitorImpl.class,
         this.clusterId,
         this.servicesContainer,
@@ -189,6 +189,21 @@ public class RdsHostListProvider implements DynamicHostListProvider, CanReleaseR
             this.instanceTemplate,
             this.refreshRateNano,
             this.highRefreshRateNano));
+    this.offerRecoveryContextIfNeeded(monitor);
+    return monitor;
+  }
+
+  /**
+   * Offers this provider's connection context as a recovery option to the given monitor if it is
+   * in panic mode. When the monitor already has an active monitoring connection this is a no-op.
+   *
+   * @param monitor the monitor to offer recovery context to
+   */
+  protected void offerRecoveryContextIfNeeded(final ClusterTopologyMonitor monitor) {
+    if (monitor instanceof ClusterTopologyMonitorImpl) {
+      ((ClusterTopologyMonitorImpl) monitor).offerRecoveryContext(
+          this.initialHostSpec, this.properties, this.servicesContainer);
+    }
   }
 
   @Override

--- a/wrapper/src/main/resources/aws_advanced_jdbc_wrapper_messages.properties
+++ b/wrapper/src/main/resources/aws_advanced_jdbc_wrapper_messages.properties
@@ -526,6 +526,8 @@ ClusterTopologyMonitorImpl.writerPickedUpFromNodeMonitors=The writer host detect
 ClusterTopologyMonitorImpl.writerMonitoringConnection=The monitoring connection is connected to a writer: ''{0}''.
 ClusterTopologyMonitorImpl.errorFetchingTopology=An error occurred while querying for topology: {0}
 ClusterTopologyMonitorImpl.reset=Reset: clusterId={0}, host={1}
+ClusterTopologyMonitorImpl.recoveryContextApplied=Recovery context applied: switching from host ''{1}'' to ''{0}'' for monitoring connection attempts.
+ClusterTopologyMonitorImpl.recoveryContextContainerFailed=Failed to create a minimal service container for recovery context: {0}. The recovery context will be discarded.
 ClusterTopologyMonitorImpl.resetEventReceived=MonitorResetEvent received.
 ClusterTopologyMonitorImpl.matchingReaderTopologies=The topologies detected by the reader monitors have been consistent for {0}ms, so their topology will be assumed to be correct.
 ClusterTopologyMonitorImpl.upgradedMonitoringConnection=Upgraded monitoring connection to host ''{0}'' with priority ''{1}'' (index {2}).

--- a/wrapper/src/test/java/software/amazon/jdbc/hostlistprovider/ClusterTopologyMonitorRecoveryContextTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/hostlistprovider/ClusterTopologyMonitorRecoveryContextTest.java
@@ -1,0 +1,677 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.jdbc.hostlistprovider;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import software.amazon.jdbc.HostSpec;
+import software.amazon.jdbc.HostSpecBuilder;
+import software.amazon.jdbc.PluginService;
+import software.amazon.jdbc.PropertyDefinition;
+import software.amazon.jdbc.hostavailability.SimpleHostAvailabilityStrategy;
+import software.amazon.jdbc.targetdriverdialect.TargetDriverDialect;
+import software.amazon.jdbc.util.FullServicesContainer;
+import software.amazon.jdbc.util.events.EventPublisher;
+import software.amazon.jdbc.util.monitoring.MonitorInitializer;
+import software.amazon.jdbc.util.monitoring.MonitorService;
+import software.amazon.jdbc.util.storage.StorageService;
+import software.amazon.jdbc.util.storage.TestStorageServiceImpl;
+
+/**
+ * Tests for the recovery-context rebinding mechanism in {@link ClusterTopologyMonitorImpl}.
+ * Validates that:
+ * <ul>
+ *   <li>A monitor in panic mode accepts a recovery context.</li>
+ *   <li>A healthy monitor rejects a recovery context (no-op).</li>
+ *   <li>Topology sharing by clusterId is preserved — only one monitor per clusterId.</li>
+ *   <li>Concurrent offers do not corrupt monitor state.</li>
+ *   <li>Monitoring properties are correctly rebuilt and sanitized from the new context.</li>
+ *   <li>{@link RdsHostListProvider} offers its context when obtaining a shared monitor.</li>
+ * </ul>
+ */
+class ClusterTopologyMonitorRecoveryContextTest {
+
+  private static final String CLUSTER_ID = "test-cluster";
+  private static final String MONITORING_PREFIX = "topology-monitoring-";
+
+  @Mock private PluginService mockPluginService;
+  @Mock private FullServicesContainer mockServicesContainer;
+  @Mock private FullServicesContainer mockServicesContainer2;
+  @Mock private FullServicesContainer mockMinimalContainer;
+  @Mock private TopologyUtils mockTopologyUtils;
+  @Mock private EventPublisher mockEventPublisher;
+  @Mock private MonitorService mockMonitorService;
+  @Mock private HostListProviderService mockHostListProviderService;
+  @Mock private TargetDriverDialect mockTargetDriverDialect;
+  @Mock private Connection mockConnection;
+
+  private StorageService storageService;
+  private AutoCloseable closeable;
+
+  private final HostSpec hostA = new HostSpecBuilder(new SimpleHostAvailabilityStrategy())
+      .host("host-a.cluster.us-east-1.rds.amazonaws.com").port(5432).build();
+  private final HostSpec hostB = new HostSpecBuilder(new SimpleHostAvailabilityStrategy())
+      .host("host-b.cluster.us-east-1.rds.amazonaws.com").port(5432).build();
+  private final HostSpec instanceTemplate = new HostSpecBuilder(new SimpleHostAvailabilityStrategy())
+      .host("?.us-east-1.rds.amazonaws.com").port(5432).build();
+
+  @BeforeEach
+  void setUp() {
+    closeable = MockitoAnnotations.openMocks(this);
+    storageService = new TestStorageServiceImpl(mockEventPublisher);
+
+    when(mockServicesContainer.getStorageService()).thenReturn(storageService);
+    when(mockServicesContainer.getEventPublisher()).thenReturn(mockEventPublisher);
+    when(mockServicesContainer.getPluginService()).thenReturn(mockPluginService);
+    when(mockServicesContainer.getMonitorService()).thenReturn(mockMonitorService);
+    when(mockPluginService.getTargetDriverDialect()).thenReturn(mockTargetDriverDialect);
+    when(mockTargetDriverDialect.removeHostSelectionProperties(any(Properties.class)))
+        .thenReturn(Collections.emptySet());
+
+    when(mockServicesContainer2.getStorageService()).thenReturn(storageService);
+    when(mockServicesContainer2.getEventPublisher()).thenReturn(mockEventPublisher);
+    when(mockServicesContainer2.getPluginService()).thenReturn(mockPluginService);
+    when(mockServicesContainer2.getMonitorService()).thenReturn(mockMonitorService);
+    when(mockMinimalContainer.getStorageService()).thenReturn(storageService);
+    when(mockMinimalContainer.getEventPublisher()).thenReturn(mockEventPublisher);
+    when(mockMinimalContainer.getPluginService()).thenReturn(mockPluginService);
+    when(mockMinimalContainer.getMonitorService()).thenReturn(mockMonitorService);
+    when(mockHostListProviderService.getHostSpecBuilder())
+        .thenReturn(new HostSpecBuilder(new SimpleHostAvailabilityStrategy()));
+  }
+
+  @AfterEach
+  void tearDown() throws Exception {
+    storageService.clearAll();
+    closeable.close();
+  }
+
+  /**
+   * Creates a spied monitor with {@code createRecoveryServiceContainer} stubbed to return
+   * {@link #mockMinimalContainer}, avoiding the need for deep integration infrastructure.
+   */
+  private ClusterTopologyMonitorImpl createMonitor(
+      HostSpec initialHost, Properties props, FullServicesContainer container) {
+    ClusterTopologyMonitorImpl monitor = spy(new ClusterTopologyMonitorImpl(
+        container,
+        mockTopologyUtils,
+        CLUSTER_ID,
+        initialHost,
+        props,
+        instanceTemplate,
+        TimeUnit.SECONDS.toNanos(30),
+        TimeUnit.MILLISECONDS.toNanos(100)));
+    try {
+      doReturn(mockMinimalContainer).when(monitor)
+          .createRecoveryServiceContainer(any(FullServicesContainer.class), any(Properties.class));
+    } catch (SQLException e) {
+      throw new RuntimeException(e);
+    }
+    return monitor;
+  }
+
+  // ---- offerRecoveryContext tests ----
+
+  @Test
+  void testOfferRecoveryContext_acceptedWhenInPanicMode() {
+    Properties propsA = new Properties();
+    propsA.setProperty("user", "userA");
+    ClusterTopologyMonitorImpl monitor = createMonitor(hostA, propsA, mockServicesContainer);
+
+    // Monitor starts in panic mode (no monitoring connection)
+    assertTrue(monitor.isInPanicMode(), "Monitor should start in panic mode");
+
+    Properties propsB = new Properties();
+    propsB.setProperty("user", "userB");
+    boolean accepted = monitor.offerRecoveryContext(hostB, propsB, mockServicesContainer2);
+    assertTrue(accepted, "Recovery context should be accepted when in panic mode");
+
+    // Verify the pending context is set
+    ClusterTopologyMonitorImpl.RecoveryContext pending = monitor.pendingRecoveryContext.get();
+    assertNotNull(pending, "Pending recovery context should be non-null");
+    assertSame(hostB, pending.initialHostSpec);
+    assertSame(propsB, pending.properties);
+    assertSame(mockServicesContainer2, pending.servicesContainer);
+  }
+
+  @Test
+  void testOfferRecoveryContext_rejectedWhenHealthy() {
+    Properties props = new Properties();
+    ClusterTopologyMonitorImpl monitor = createMonitor(hostA, props, mockServicesContainer);
+
+    // Simulate healthy state by setting a monitoring connection
+    monitor.monitoringConnection.set(mockConnection);
+    assertFalse(monitor.isInPanicMode(), "Monitor should not be in panic mode");
+
+    boolean accepted = monitor.offerRecoveryContext(hostB, new Properties(), mockServicesContainer2);
+    assertFalse(accepted, "Recovery context should be rejected when monitor is healthy");
+    assertNull(monitor.pendingRecoveryContext.get(), "No pending context should be stored");
+  }
+
+  // ---- applyPendingRecoveryContext tests ----
+
+  @Test
+  void testApplyPendingRecoveryContext_replacesFields() {
+    Properties propsA = new Properties();
+    propsA.setProperty("user", "userA");
+    propsA.setProperty("password", "passA");
+    ClusterTopologyMonitorImpl monitor = createMonitor(hostA, propsA, mockServicesContainer);
+
+    // Verify initial state
+    assertSame(hostA, monitor.initialHostSpec);
+    assertSame(propsA, monitor.properties);
+    assertSame(mockServicesContainer, monitor.servicesContainer);
+
+    // Offer new context
+    Properties propsB = new Properties();
+    propsB.setProperty("user", "userB");
+    propsB.setProperty("password", "passB");
+    monitor.offerRecoveryContext(hostB, propsB, mockServicesContainer2);
+
+    // Apply it (simulating the monitoring thread)
+    monitor.applyPendingRecoveryContext();
+
+    // Verify fields were replaced
+    assertSame(hostB, monitor.initialHostSpec);
+    assertSame(propsB, monitor.properties);
+    // The container should be the minimal container, not the provider's full container.
+    assertSame(mockMinimalContainer, monitor.servicesContainer,
+        "servicesContainer should be the minimal container created from the provider's context");
+
+    // Verify pending context was consumed
+    assertNull(monitor.pendingRecoveryContext.get());
+  }
+
+  @Test
+  void testApplyPendingRecoveryContext_rebuildsMonitoringProperties() {
+    // Prepare new context with monitoring prefix overrides
+    Properties propsB = new Properties();
+    propsB.setProperty("user", "userB");
+    propsB.setProperty(MONITORING_PREFIX + "socketTimeout", "9999");
+    propsB.setProperty(MONITORING_PREFIX + "connectTimeout", "8888");
+
+    Properties propsA = new Properties();
+    propsA.setProperty("user", "userA");
+    final ClusterTopologyMonitorImpl monitor = createMonitor(hostA, propsA, mockServicesContainer);
+    monitor.offerRecoveryContext(hostB, propsB, mockServicesContainer2);
+    monitor.applyPendingRecoveryContext();
+
+    Properties monProps = monitor.monitoringProperties;
+    assertEquals("9999", monProps.getProperty("socketTimeout"),
+        "Monitoring prefix override should be applied");
+    assertEquals("8888", monProps.getProperty("connectTimeout"),
+        "Monitoring prefix override should be applied");
+    // The prefixed keys themselves should be removed
+    assertNull(monProps.getProperty(MONITORING_PREFIX + "socketTimeout"),
+        "Prefixed key should be removed from monitoring properties");
+  }
+
+  @Test
+  void testApplyPendingRecoveryContext_setsDefaultTimeouts() {
+    Properties propsA = new Properties();
+    ClusterTopologyMonitorImpl monitor = createMonitor(hostA, propsA, mockServicesContainer);
+
+    // Offer context with no timeout overrides
+    Properties propsB = new Properties();
+    propsB.setProperty("user", "userB");
+    monitor.offerRecoveryContext(hostB, propsB, mockServicesContainer2);
+    monitor.applyPendingRecoveryContext();
+
+    Properties monProps = monitor.monitoringProperties;
+    assertEquals(String.valueOf(ClusterTopologyMonitorImpl.defaultSocketTimeoutMs),
+        PropertyDefinition.SOCKET_TIMEOUT.getString(monProps),
+        "Default socket timeout should be set");
+    assertEquals(String.valueOf(ClusterTopologyMonitorImpl.defaultConnectionTimeoutMs),
+        PropertyDefinition.CONNECT_TIMEOUT.getString(monProps),
+        "Default connect timeout should be set");
+  }
+
+  @Test
+  void testApplyPendingRecoveryContext_noOpWhenNoPendingContext() {
+    Properties propsA = new Properties();
+    propsA.setProperty("user", "userA");
+    ClusterTopologyMonitorImpl monitor = createMonitor(hostA, propsA, mockServicesContainer);
+
+    // No offer made — apply should be a no-op
+    monitor.applyPendingRecoveryContext();
+    assertSame(hostA, monitor.initialHostSpec, "Fields should remain unchanged");
+    assertSame(propsA, monitor.properties, "Properties should remain unchanged");
+  }
+
+  @Test
+  void testApplyPendingRecoveryContext_noOpIfMonitorBecomesHealthy() {
+    Properties propsA = new Properties();
+    ClusterTopologyMonitorImpl monitor = createMonitor(hostA, propsA, mockServicesContainer);
+
+    // Offer context while in panic mode
+    monitor.offerRecoveryContext(hostB, new Properties(), mockServicesContainer2);
+
+    // Simulate the monitor becoming healthy before apply
+    monitor.monitoringConnection.set(mockConnection);
+
+    monitor.applyPendingRecoveryContext();
+    // Fields should not be replaced because monitor is no longer in panic mode
+    assertSame(hostA, monitor.initialHostSpec, "Fields should remain unchanged when healthy");
+  }
+
+  @Test
+  void testApplyPendingRecoveryContext_closesOldConnectionHandler() {
+    Properties propsA = new Properties();
+    ClusterTopologyMonitorImpl monitor = createMonitor(hostA, propsA, mockServicesContainer);
+
+    // Force handler creation
+    MonitoringConnectionHandler handler = monitor.getConnectionHandler();
+    assertNotNull(handler);
+
+    // Offer and apply
+    monitor.offerRecoveryContext(hostB, new Properties(), mockServicesContainer2);
+    monitor.applyPendingRecoveryContext();
+
+    // The old handler should be nulled (will be lazily recreated)
+    // Access it again to get a new one
+    MonitoringConnectionHandler newHandler = monitor.getConnectionHandler();
+    assertNotNull(newHandler);
+    // They should be different instances
+    assertTrue(handler != newHandler, "Connection handler should be recreated after context replacement");
+  }
+
+  // ---- Concurrent offer safety ----
+
+  @Test
+  void testConcurrentOffers_doNotCorruptState() throws Exception {
+    Properties propsA = new Properties();
+    propsA.setProperty("user", "userA");
+    ClusterTopologyMonitorImpl monitor = createMonitor(hostA, propsA, mockServicesContainer);
+
+    final int threadCount = 8;
+    CyclicBarrier barrier = new CyclicBarrier(threadCount);
+    CountDownLatch done = new CountDownLatch(threadCount);
+    AtomicInteger acceptedCount = new AtomicInteger(0);
+    AtomicReference<Throwable> error = new AtomicReference<>(null);
+
+    for (int i = 0; i < threadCount; i++) {
+      final int idx = i;
+      final HostSpec host = new HostSpecBuilder(new SimpleHostAvailabilityStrategy())
+          .host("host-" + idx + ".cluster.us-east-1.rds.amazonaws.com").port(5432).build();
+      final Properties props = new Properties();
+      props.setProperty("user", "user" + idx);
+
+      new Thread(() -> {
+        try {
+          barrier.await(5, TimeUnit.SECONDS);
+          boolean accepted = monitor.offerRecoveryContext(host, props, mockServicesContainer2);
+          if (accepted) {
+            acceptedCount.incrementAndGet();
+          }
+        } catch (Throwable t) {
+          error.compareAndSet(null, t);
+        } finally {
+          done.countDown();
+        }
+      }).start();
+    }
+
+    assertTrue(done.await(10, TimeUnit.SECONDS), "All threads should complete");
+    assertNull(error.get(), "No errors should occur during concurrent offers");
+
+    // All should have been accepted since monitor stays in panic mode
+    assertEquals(threadCount, acceptedCount.get(), "All offers should be accepted in panic mode");
+
+    // The pending context should be one of the offered contexts (last-writer-wins)
+    ClusterTopologyMonitorImpl.RecoveryContext pending = monitor.pendingRecoveryContext.get();
+    assertNotNull(pending, "A pending context should exist");
+    assertNotNull(pending.initialHostSpec);
+    assertNotNull(pending.properties);
+
+    // Apply and verify no corruption
+    monitor.applyPendingRecoveryContext();
+    assertNotNull(monitor.initialHostSpec, "initialHostSpec should not be null after apply");
+    assertNotNull(monitor.properties, "properties should not be null after apply");
+    assertNotNull(monitor.monitoringProperties, "monitoringProperties should not be null after apply");
+  }
+
+  // ---- RdsHostListProvider integration ----
+
+  @Test
+  void testRdsHostListProvider_sharesMonitorByClusterId() throws SQLException {
+    // Two providers with same clusterId should get the same monitor
+    ClusterTopologyMonitorImpl sharedMonitor =
+        createMonitor(hostA, new Properties(), mockServicesContainer);
+
+    when(mockMonitorService.runIfAbsent(
+        eq(ClusterTopologyMonitorImpl.class),
+        anyString(),
+        any(FullServicesContainer.class),
+        any(Properties.class),
+        any(MonitorInitializer.class)))
+        .thenReturn(sharedMonitor);
+    when(mockServicesContainer.getHostListProviderService()).thenReturn(mockHostListProviderService);
+    when(mockPluginService.getHostSpecBuilder())
+        .thenReturn(new HostSpecBuilder(new SimpleHostAvailabilityStrategy()));
+
+    RdsHostListProvider provider1 = new RdsHostListProvider(
+        mockTopologyUtils, new Properties(), "jdbc:someprotocol://url1/", mockServicesContainer);
+    provider1.init();
+    ClusterTopologyMonitor m1 = provider1.getOrCreateMonitor();
+
+    RdsHostListProvider provider2 = new RdsHostListProvider(
+        mockTopologyUtils, new Properties(), "jdbc:someprotocol://url2/", mockServicesContainer);
+    provider2.init();
+    ClusterTopologyMonitor m2 = provider2.getOrCreateMonitor();
+
+    assertSame(m1, m2, "Both providers should get the same monitor instance");
+    verify(mockMonitorService, times(2)).runIfAbsent(
+        eq(ClusterTopologyMonitorImpl.class),
+        anyString(),
+        any(FullServicesContainer.class),
+        any(Properties.class),
+        any(MonitorInitializer.class));
+  }
+
+  @Test
+  void testRdsHostListProvider_offersContextToExistingMonitor() throws SQLException {
+    ClusterTopologyMonitorImpl sharedMonitor =
+        createMonitor(hostA, new Properties(), mockServicesContainer);
+    // Monitor is in panic mode by default (no monitoring connection)
+    assertTrue(sharedMonitor.isInPanicMode());
+
+    when(mockMonitorService.runIfAbsent(
+        eq(ClusterTopologyMonitorImpl.class),
+        anyString(),
+        any(FullServicesContainer.class),
+        any(Properties.class),
+        any(MonitorInitializer.class)))
+        .thenReturn(sharedMonitor);
+    when(mockServicesContainer.getHostListProviderService()).thenReturn(mockHostListProviderService);
+    when(mockPluginService.getHostSpecBuilder())
+        .thenReturn(new HostSpecBuilder(new SimpleHostAvailabilityStrategy()));
+
+    Properties providerProps = new Properties();
+    providerProps.setProperty("user", "provider2-user");
+
+    RdsHostListProvider provider = new RdsHostListProvider(
+        mockTopologyUtils, providerProps, "jdbc:someprotocol://url/", mockServicesContainer);
+    provider.init();
+    provider.getOrCreateMonitor();
+
+    // The provider should have offered its context
+    ClusterTopologyMonitorImpl.RecoveryContext pending = sharedMonitor.pendingRecoveryContext.get();
+    assertNotNull(pending, "Provider should offer recovery context to a monitor in panic mode");
+  }
+
+  @Test
+  void testRdsHostListProvider_doesNotOfferContextToHealthyMonitor() throws SQLException {
+    ClusterTopologyMonitorImpl sharedMonitor =
+        createMonitor(hostA, new Properties(), mockServicesContainer);
+    // Make monitor healthy
+    sharedMonitor.monitoringConnection.set(mockConnection);
+    assertFalse(sharedMonitor.isInPanicMode());
+
+    when(mockMonitorService.runIfAbsent(
+        eq(ClusterTopologyMonitorImpl.class),
+        anyString(),
+        any(FullServicesContainer.class),
+        any(Properties.class),
+        any(MonitorInitializer.class)))
+        .thenReturn(sharedMonitor);
+    when(mockServicesContainer.getHostListProviderService()).thenReturn(mockHostListProviderService);
+    when(mockPluginService.getHostSpecBuilder())
+        .thenReturn(new HostSpecBuilder(new SimpleHostAvailabilityStrategy()));
+
+    RdsHostListProvider provider = new RdsHostListProvider(
+        mockTopologyUtils, new Properties(), "jdbc:someprotocol://url/", mockServicesContainer);
+    provider.init();
+    provider.getOrCreateMonitor();
+
+    assertNull(sharedMonitor.pendingRecoveryContext.get(),
+        "No context should be offered to a healthy monitor");
+  }
+
+  // ---- buildMonitoringProperties tests ----
+
+  @Test
+  void testBuildMonitoringProperties_appliesPrefixOverrides() {
+    Properties source = new Properties();
+    source.setProperty("user", "testUser");
+    source.setProperty(MONITORING_PREFIX + "socketTimeout", "12345");
+    source.setProperty(MONITORING_PREFIX + "connectTimeout", "67890");
+
+    Properties result = ClusterTopologyMonitorImpl.buildMonitoringProperties(source, mockServicesContainer);
+
+    assertEquals("12345", result.getProperty("socketTimeout"));
+    assertEquals("67890", result.getProperty("connectTimeout"));
+    assertNull(result.getProperty(MONITORING_PREFIX + "socketTimeout"),
+        "Prefixed key should be removed");
+  }
+
+  @Test
+  void testBuildMonitoringProperties_stripsHostSelectionProperties() {
+    Properties source = new Properties();
+    source.setProperty("user", "testUser");
+
+    ClusterTopologyMonitorImpl.buildMonitoringProperties(source, mockServicesContainer);
+
+    verify(mockTargetDriverDialect).removeHostSelectionProperties(any(Properties.class));
+  }
+
+  @Test
+  void testBuildMonitoringProperties_setsDefaultTimeoutsWhenMissing() {
+    Properties source = new Properties();
+
+    Properties result = ClusterTopologyMonitorImpl.buildMonitoringProperties(source, mockServicesContainer);
+
+    assertEquals(String.valueOf(ClusterTopologyMonitorImpl.defaultSocketTimeoutMs),
+        PropertyDefinition.SOCKET_TIMEOUT.getString(result));
+    assertEquals(String.valueOf(ClusterTopologyMonitorImpl.defaultConnectionTimeoutMs),
+        PropertyDefinition.CONNECT_TIMEOUT.getString(result));
+  }
+
+  @Test
+  void testBuildMonitoringProperties_preservesExplicitTimeouts() {
+    Properties source = new Properties();
+    PropertyDefinition.SOCKET_TIMEOUT.set(source, "99999");
+    PropertyDefinition.CONNECT_TIMEOUT.set(source, "88888");
+
+    Properties result = ClusterTopologyMonitorImpl.buildMonitoringProperties(source, mockServicesContainer);
+
+    assertEquals("99999", PropertyDefinition.SOCKET_TIMEOUT.getString(result));
+    assertEquals("88888", PropertyDefinition.CONNECT_TIMEOUT.getString(result));
+  }
+
+  @Test
+  void testApplyPendingRecoveryContext_updatesLogUnclosedConnections() {
+    Properties propsA = new Properties();
+    ClusterTopologyMonitorImpl monitor = createMonitor(hostA, propsA, mockServicesContainer);
+    assertFalse(monitor.logUnclosedConnections);
+
+    Properties propsB = new Properties();
+    PropertyDefinition.LOG_UNCLOSED_CONNECTIONS.set(propsB, "true");
+    monitor.offerRecoveryContext(hostB, propsB, mockServicesContainer2);
+    monitor.applyPendingRecoveryContext();
+
+    assertTrue(monitor.logUnclosedConnections,
+        "logUnclosedConnections should be updated from new properties");
+  }
+
+  @Test
+  void testApplyPendingRecoveryContext_resetsNodeMonitorState() {
+    Properties propsA = new Properties();
+    ClusterTopologyMonitorImpl monitor = createMonitor(hostA, propsA, mockServicesContainer);
+
+    // Simulate some node monitor state
+    monitor.submittedNodes.put("host-1", true);
+    monitor.submittedNodes.put("host-2", true);
+    HostSpec reader = new HostSpecBuilder(new SimpleHostAvailabilityStrategy())
+        .host("reader").hostId("reader-1").build();
+    monitor.readerTopologiesById.put("reader-1",
+        Collections.singletonList(reader));
+    monitor.completedOneCycle.put("reader-1", true);
+    monitor.stableTopologiesStartNano = 12345L;
+
+    monitor.offerRecoveryContext(hostB, new Properties(), mockServicesContainer2);
+    monitor.applyPendingRecoveryContext();
+
+    assertTrue(monitor.submittedNodes.isEmpty(), "submittedNodes should be cleared");
+    assertTrue(monitor.readerTopologiesById.isEmpty(), "readerTopologiesById should be cleared");
+    assertTrue(monitor.completedOneCycle.isEmpty(), "completedOneCycle should be cleared");
+    assertEquals(0, monitor.stableTopologiesStartNano, "stableTopologiesStartNano should be reset");
+  }
+
+  // ---- Stale context race regression tests ----
+
+  /**
+   * Regression test: a recovery context offered during the panic→recovery transition
+   * must be discarded once the monitor becomes healthy, not carried forward to a future
+   * panic episode where it would apply stale credentials. The test calls the production
+   * {@link ClusterTopologyMonitorImpl#discardPendingRecoveryContext()} method rather than
+   * manipulating the {@code AtomicReference} directly so it will break if that method is
+   * removed or changed.
+   */
+  @Test
+  void testPendingContextDiscardedAfterRecovery() {
+    Properties propsA = new Properties();
+    ClusterTopologyMonitorImpl monitor = createMonitor(hostA, propsA, mockServicesContainer);
+    assertTrue(monitor.isInPanicMode(), "Monitor should start in panic mode");
+
+    // 1. Apply a valid recovery context (simulating first panic-mode iteration).
+    Properties propsB = new Properties();
+    propsB.setProperty("user", "userB");
+    monitor.offerRecoveryContext(hostB, propsB, mockServicesContainer2);
+    monitor.applyPendingRecoveryContext();
+    assertNull(monitor.pendingRecoveryContext.get(), "Pending context should be consumed");
+
+    // 2. While still in panic (no connection yet), a third provider offers context.
+    //    This simulates the race: offer arrives after apply but before recovery completes.
+    HostSpec hostC = new HostSpecBuilder(new SimpleHostAvailabilityStrategy())
+        .host("host-c.cluster.us-east-1.rds.amazonaws.com").port(5432).build();
+    Properties propsC = new Properties();
+    propsC.setProperty("user", "userC-stale");
+    monitor.offerRecoveryContext(hostC, propsC, mockServicesContainer2);
+    assertNotNull(monitor.pendingRecoveryContext.get(), "Late offer should be pending");
+
+    // 3. Monitor recovers (gets a connection).
+    monitor.monitoringConnection.set(mockConnection);
+    assertFalse(monitor.isInPanicMode(), "Monitor should be healthy now");
+
+    // 4. The production regular-mode branch calls discardPendingRecoveryContext().
+    monitor.discardPendingRecoveryContext();
+
+    // 5. Verify the stale context was discarded.
+    assertNull(monitor.pendingRecoveryContext.get(),
+        "Stale context must be discarded after recovery");
+
+    // 6. Simulate a new panic episode — fields should still reflect the last successful apply,
+    //    not the discarded stale context.
+    monitor.monitoringConnection.set(null);
+    assertTrue(monitor.isInPanicMode());
+    monitor.applyPendingRecoveryContext(); // no-op: nothing pending
+    assertSame(hostB, monitor.initialHostSpec,
+        "initialHostSpec should remain from last successful recovery, not stale offer");
+  }
+
+  // ---- Container lifecycle safety tests ----
+
+  @Test
+  void testApplyPendingRecoveryContext_createsMinimalContainer() throws SQLException {
+    Properties propsA = new Properties();
+    ClusterTopologyMonitorImpl monitor = createMonitor(hostA, propsA, mockServicesContainer);
+
+    Properties propsB = new Properties();
+    propsB.setProperty("user", "userB");
+    monitor.offerRecoveryContext(hostB, propsB, mockServicesContainer2);
+    monitor.applyPendingRecoveryContext();
+
+    // Verify createRecoveryServiceContainer was called with the provider's container (not the monitor's)
+    verify(monitor).createRecoveryServiceContainer(eq(mockServicesContainer2), eq(propsB));
+    // The monitor's container should now be the minimal one, not the provider's full container
+    assertSame(mockMinimalContainer, monitor.servicesContainer,
+        "Monitor should use the minimal container, not the provider's full container");
+  }
+
+  @Test
+  void testApplyPendingRecoveryContext_abortsOnContainerCreationFailure() throws SQLException {
+    Properties propsA = new Properties();
+    propsA.setProperty("user", "userA");
+    ClusterTopologyMonitorImpl monitor = createMonitor(hostA, propsA, mockServicesContainer);
+
+    // Simulate existing panic-mode node worker state that should survive the failed apply.
+    monitor.submittedNodes.put("node-1", true);
+    monitor.submittedNodes.put("node-2", true);
+    monitor.completedOneCycle.put("node-1", true);
+    monitor.stableTopologiesStartNano = 99999L;
+
+    // Override the spy to throw on container creation
+    doThrow(new SQLException("simulated container failure")).when(monitor)
+        .createRecoveryServiceContainer(any(FullServicesContainer.class), any(Properties.class));
+
+    Properties propsB = new Properties();
+    propsB.setProperty("user", "userB");
+    monitor.offerRecoveryContext(hostB, propsB, mockServicesContainer2);
+    monitor.applyPendingRecoveryContext();
+
+    // Context fields should remain unchanged because container creation failed.
+    assertSame(hostA, monitor.initialHostSpec,
+        "initialHostSpec should remain unchanged after container creation failure");
+    assertSame(propsA, monitor.properties,
+        "properties should remain unchanged after container creation failure");
+    assertSame(mockServicesContainer, monitor.servicesContainer,
+        "servicesContainer should remain unchanged after container creation failure");
+
+    // Node worker state should be untouched — the destructive reset must not have run.
+    assertEquals(2, monitor.submittedNodes.size(),
+        "submittedNodes should be untouched after container creation failure");
+    assertTrue(monitor.completedOneCycle.containsKey("node-1"),
+        "completedOneCycle should be untouched after container creation failure");
+    assertEquals(99999L, monitor.stableTopologiesStartNano,
+        "stableTopologiesStartNano should be untouched after container creation failure");
+
+    // Pending context should be consumed (not retried with potentially the same broken context)
+    assertNull(monitor.pendingRecoveryContext.get(),
+        "Pending context should be consumed even on failure");
+  }
+}


### PR DESCRIPTION
### Summary

Allows a shared Aurora topology monitor to recover with a current provider's connection context when the context that originally created the monitor can no longer connect.

Fixes #2110.

### Description

`RdsHostListProvider` shares topology monitors by `clusterId`. Before this change, the resulting `ClusterTopologyMonitorImpl` was permanently bound to the first provider's `initialHostSpec`, connection properties, and minimal services container. If that database or credential context became invalid, the shared monitor could remain in panic mode even while another provider for the same physical cluster had a valid connection context.

This change:

- lets `RdsHostListProvider` and `GlobalAuroraHostListProvider` offer their current context to an existing monitor;
- accepts replacement contexts only while the monitor has no active monitoring connection;
- applies the replacement on the monitor thread rather than a connection caller thread;
- builds an isolated minimal services container before changing monitor state;
- rebuilds monitoring properties, including host-selection removal, monitoring-prefix overrides, and timeout defaults;
- stops stale node workers and recreates the monitoring connection handler after a successful context replacement;
- discards offers that arrive during the final part of a successful recovery so they cannot be applied during a later panic episode;
- leaves healthy monitors and their current connection context unchanged.

Topology remains shared by physical cluster through the existing `clusterId`; this does not create a monitor per logical database or credential context.

The handoff is intentionally last-writer-wins when several providers offer contexts concurrently. A failed candidate leaves the monitor in panic mode, allowing a later provider interaction to offer another context. This draft requests maintainer feedback on whether a bounded multi-candidate strategy is preferable.

For Global Aurora, region topology and instance templates remain cluster-scoped and are not replaced with connection context.

### Tests

Added `ClusterTopologyMonitorRecoveryContextTest` with coverage for:

- accepting a context in panic mode and rejecting it while healthy;
- rebuilding and sanitizing monitoring properties;
- isolated minimal-container creation and failure handling;
- connection-handler recreation and node-worker state reset;
- stale offers during panic exit;
- concurrent context offers;
- provider integration while preserving shared monitor identity.

Local validation:

```text
./gradlew :aws-advanced-jdbc-wrapper:test \
  --tests software.amazon.jdbc.hostlistprovider.ClusterTopologyMonitorRecoveryContextTest \
  --tests software.amazon.jdbc.hostlistprovider.RdsHostListProviderTest \
  --tests software.amazon.jdbc.util.monitoring.MonitorServiceImplTest

34 tests passed, 0 failed

./gradlew :aws-advanced-jdbc-wrapper:checkstyleMain \
  :aws-advanced-jdbc-wrapper:checkstyleTest
```

### Additional Reviewers

None.

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
