### PR TITLE
fix: publish refreshed host measurements to load-aware selectors

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/PartialPluginService.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/PartialPluginService.java
@@ -463,8 +463,13 @@ public class PartialPluginService implements PluginService, CanReleaseResources,
       }
     }
 
+    // Always publish the new host list, even when no structural change was detected. Measured host
+    // details such as weight, CPU utilization and replication lag are carried by freshly created
+    // HostSpec objects and are not considered by compare(), so keeping the previous list would make
+    // getHosts() report those details indefinitely on a cluster with a stable membership.
+    this.allHosts = newHosts != null ? newHosts : new ArrayList<>();
+
     if (!changes.isEmpty()) {
-      this.allHosts = newHosts != null ? newHosts : new ArrayList<>();
       this.pluginManager.notifyNodeListChanged(changes);
     }
   }

--- a/wrapper/src/main/java/software/amazon/jdbc/PluginServiceImpl.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/PluginServiceImpl.java
@@ -628,8 +628,13 @@ public class PluginServiceImpl implements PluginService, CanReleaseResources,
       }
     }
 
+    // Always publish the new host list, even when no structural change was detected. Measured host
+    // details such as weight, CPU utilization and replication lag are carried by freshly created
+    // HostSpec objects and are not considered by compare(), so keeping the previous list would make
+    // getHosts() report those details indefinitely on a cluster with a stable membership.
+    this.allHosts = newHosts != null ? newHosts : new ArrayList<>();
+
     if (!changes.isEmpty()) {
-      this.allHosts = newHosts != null ? newHosts : new ArrayList<>();
       this.pluginManager.notifyNodeListChanged(changes);
     }
   }

--- a/wrapper/src/test/java/software/amazon/jdbc/PartialPluginServiceTests.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/PartialPluginServiceTests.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.jdbc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.SQLException;
+import java.util.Collections;
+import java.util.Properties;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import software.amazon.jdbc.dialect.Dialect;
+import software.amazon.jdbc.dialect.HostListProviderSupplier;
+import software.amazon.jdbc.exceptions.ExceptionManager;
+import software.amazon.jdbc.hostavailability.SimpleHostAvailabilityStrategy;
+import software.amazon.jdbc.hostlistprovider.HostListProvider;
+import software.amazon.jdbc.profile.ConfigurationProfile;
+import software.amazon.jdbc.profile.ConfigurationProfileBuilder;
+import software.amazon.jdbc.targetdriverdialect.TargetDriverDialect;
+import software.amazon.jdbc.util.FullServicesContainer;
+
+public class PartialPluginServiceTests {
+
+  private static final Properties PROPERTIES = new Properties();
+  private static final String URL = "url";
+  private static final String DRIVER_PROTOCOL = "driverProtocol";
+
+  private AutoCloseable closeable;
+
+  @Mock FullServicesContainer servicesContainer;
+  @Mock ConnectionPluginManager pluginManager;
+  @Mock HostListProvider hostListProvider;
+  @Mock Dialect mockDialect;
+  @Mock TargetDriverDialect mockTargetDriverDialect;
+
+  private final ConfigurationProfile configurationProfile =
+      ConfigurationProfileBuilder.get().withName("test").build();
+
+  @BeforeEach
+  void setUp() {
+    closeable = MockitoAnnotations.openMocks(this);
+    when(servicesContainer.getConnectionPluginManager()).thenReturn(pluginManager);
+    final HostListProviderSupplier supplier = (props, url, container) -> hostListProvider;
+    when(mockDialect.getHostListProviderSupplier()).thenReturn(supplier);
+    PartialPluginService.hostAvailabilityExpiringCache.clear();
+  }
+
+  @AfterEach
+  void cleanUp() throws Exception {
+    closeable.close();
+    PartialPluginService.hostAvailabilityExpiringCache.clear();
+  }
+
+  private PartialPluginService createTarget() throws SQLException {
+    return new PartialPluginService(
+        servicesContainer,
+        new ExceptionManager(),
+        PROPERTIES,
+        URL,
+        DRIVER_PROTOCOL,
+        mockTargetDriverDialect,
+        mockDialect,
+        configurationProfile);
+  }
+
+  @Test
+  public void testSetNodeListMeasuredDetailsChanged() throws SQLException {
+    doNothing().when(pluginManager).notifyNodeListChanged(any());
+
+    when(hostListProvider.refresh()).thenReturn(
+        Collections.singletonList(new HostSpecBuilder(new SimpleHostAvailabilityStrategy())
+            .host("hostA").port(HostSpec.NO_PORT).role(HostRole.READER)
+            .weight(200).cpuPercent(90.0F).lagMs(800.0F).build()));
+
+    final PartialPluginService target = createTarget();
+    target.allHosts = Collections.singletonList(new HostSpecBuilder(new SimpleHostAvailabilityStrategy())
+        .host("hostA").port(HostSpec.NO_PORT).role(HostRole.READER)
+        .weight(100).cpuPercent(10.0F).lagMs(5.0F).build());
+
+    target.refreshHostList();
+
+    assertEquals(1, target.getAllHosts().size());
+    final HostSpec updatedHost = target.getAllHosts().get(0);
+    assertEquals("hostA", updatedHost.getHost());
+    assertEquals(200, updatedHost.getWeight());
+    assertEquals(90.0F, updatedHost.getCpuPercent(), 0.0001F);
+    assertEquals(800.0F, updatedHost.getLagMs(), 0.0001F);
+    verify(pluginManager, times(0)).notifyNodeListChanged(any());
+  }
+
+  @Test
+  public void testSetNodeListNoChanges() throws SQLException {
+    doNothing().when(pluginManager).notifyNodeListChanged(any());
+
+    when(hostListProvider.refresh()).thenReturn(
+        Collections.singletonList(new HostSpecBuilder(new SimpleHostAvailabilityStrategy())
+            .host("hostA").port(HostSpec.NO_PORT).role(HostRole.READER)
+            .weight(100).cpuPercent(10.0F).lagMs(5.0F).build()));
+
+    final PartialPluginService target = createTarget();
+    target.allHosts = Collections.singletonList(new HostSpecBuilder(new SimpleHostAvailabilityStrategy())
+        .host("hostA").port(HostSpec.NO_PORT).role(HostRole.READER)
+        .weight(100).cpuPercent(10.0F).lagMs(5.0F).build());
+
+    target.refreshHostList();
+
+    assertEquals(1, target.getAllHosts().size());
+    assertEquals("hostA", target.getAllHosts().get(0).getHost());
+    verify(pluginManager, times(0)).notifyNodeListChanged(any());
+  }
+}

--- a/wrapper/src/test/java/software/amazon/jdbc/PluginServiceImplTests.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/PluginServiceImplTests.java
@@ -587,6 +587,125 @@ public class PluginServiceImplTests {
   }
 
   @Test
+  public void testSetNodeListMeasuredDetailsChanged() throws SQLException {
+    doNothing().when(pluginManager).notifyNodeListChanged(any());
+
+    when(hostListProvider.refresh()).thenReturn(
+        Collections.singletonList(new HostSpecBuilder(new SimpleHostAvailabilityStrategy())
+            .host("hostA").port(HostSpec.NO_PORT).role(HostRole.READER)
+            .weight(200).cpuPercent(90.0F).lagMs(800.0F).build()));
+
+    PluginServiceImpl target = spy(
+        new PluginServiceImpl(
+            servicesContainer,
+            new ExceptionManager(),
+            PROPERTIES,
+            URL,
+            DRIVER_PROTOCOL,
+            dialectManager,
+            mockTargetDriverDialect,
+            configurationProfile,
+            sessionStateService));
+    target.allHosts = Collections.singletonList(new HostSpecBuilder(new SimpleHostAvailabilityStrategy())
+        .host("hostA").port(HostSpec.NO_PORT).role(HostRole.READER)
+        .weight(100).cpuPercent(10.0F).lagMs(5.0F).build());
+    target.hostListProvider = hostListProvider;
+
+    target.refreshHostList();
+
+    // The host list carries no structural change, but the refreshed measured details must still be published.
+    assertEquals(1, target.getAllHosts().size());
+    final HostSpec updatedHost = target.getAllHosts().get(0);
+    assertEquals("hostA", updatedHost.getHost());
+    assertEquals(200, updatedHost.getWeight());
+    assertEquals(90.0F, updatedHost.getCpuPercent(), 0.0001F);
+    assertEquals(800.0F, updatedHost.getLagMs(), 0.0001F);
+
+    // A measured detail change is not a node change, so no notification is expected.
+    verify(pluginManager, times(0)).notifyNodeListChanged(any());
+  }
+
+  @Test
+  public void testForceRefreshHostListMeasuredDetailsChanged() throws SQLException, TimeoutException {
+    doNothing().when(pluginManager).notifyNodeListChanged(any());
+
+    when(hostListProvider.forceRefresh(anyBoolean(), anyLong())).thenReturn(
+        Collections.singletonList(new HostSpecBuilder(new SimpleHostAvailabilityStrategy())
+            .host("hostA").port(HostSpec.NO_PORT).role(HostRole.READER)
+            .weight(200).cpuPercent(90.0F).lagMs(800.0F).build()));
+
+    PluginServiceImpl target = spy(
+        new PluginServiceImpl(
+            servicesContainer,
+            new ExceptionManager(),
+            PROPERTIES,
+            URL,
+            DRIVER_PROTOCOL,
+            dialectManager,
+            mockTargetDriverDialect,
+            configurationProfile,
+            sessionStateService));
+    target.allHosts = Collections.singletonList(new HostSpecBuilder(new SimpleHostAvailabilityStrategy())
+        .host("hostA").port(HostSpec.NO_PORT).role(HostRole.READER)
+        .weight(100).cpuPercent(10.0F).lagMs(5.0F).build());
+    target.hostListProvider = hostListProvider;
+
+    assertTrue(target.forceRefreshHostList(true, 5000));
+
+    assertEquals(1, target.getAllHosts().size());
+    final HostSpec updatedHost = target.getAllHosts().get(0);
+    assertEquals(200, updatedHost.getWeight());
+    assertEquals(90.0F, updatedHost.getCpuPercent(), 0.0001F);
+    assertEquals(800.0F, updatedHost.getLagMs(), 0.0001F);
+    verify(pluginManager, times(0)).notifyNodeListChanged(any());
+  }
+
+  @Test
+  public void testLoadAwareSelectionUsesRefreshedMeasuredDetails() throws SQLException {
+    doNothing().when(pluginManager).notifyNodeListChanged(any());
+
+    final HostSpec staleReaderB = new HostSpecBuilder(new SimpleHostAvailabilityStrategy())
+        .host("hostB").port(HostSpec.NO_PORT).role(HostRole.READER)
+        .availability(HostAvailability.AVAILABLE).cpuPercent(10.0F).lagMs(5.0F).build();
+    final HostSpec staleReaderC = new HostSpecBuilder(new SimpleHostAvailabilityStrategy())
+        .host("hostC").port(HostSpec.NO_PORT).role(HostRole.READER)
+        .availability(HostAvailability.AVAILABLE).cpuPercent(10.0F).lagMs(500.0F).build();
+
+    // hostB is now the lagging reader; membership, roles and availability are unchanged.
+    final HostSpec freshReaderB = new HostSpecBuilder(new SimpleHostAvailabilityStrategy())
+        .host("hostB").port(HostSpec.NO_PORT).role(HostRole.READER)
+        .availability(HostAvailability.AVAILABLE).cpuPercent(10.0F).lagMs(900.0F).build();
+    final HostSpec freshReaderC = new HostSpecBuilder(new SimpleHostAvailabilityStrategy())
+        .host("hostC").port(HostSpec.NO_PORT).role(HostRole.READER)
+        .availability(HostAvailability.AVAILABLE).cpuPercent(10.0F).lagMs(5.0F).build();
+
+    when(hostListProvider.refresh()).thenReturn(Arrays.asList(freshReaderB, freshReaderC));
+
+    PluginServiceImpl target = spy(
+        new PluginServiceImpl(
+            servicesContainer,
+            new ExceptionManager(),
+            PROPERTIES,
+            URL,
+            DRIVER_PROTOCOL,
+            dialectManager,
+            mockTargetDriverDialect,
+            configurationProfile,
+            sessionStateService));
+    target.allHosts = Arrays.asList(staleReaderB, staleReaderC);
+    target.hostListProvider = hostListProvider;
+
+    final HostSelector selector = LowestLoadHostSelector.byLag();
+    assertEquals("hostB",
+        Objects.requireNonNull(selector.getHost(target.getAllHosts(), HostRole.READER, PROPERTIES)).getHost());
+
+    target.refreshHostList();
+
+    assertEquals("hostC",
+        Objects.requireNonNull(selector.getHost(target.getAllHosts(), HostRole.READER, PROPERTIES)).getHost());
+  }
+
+  @Test
   public void testNodeAvailabilityNotChanged() throws SQLException {
     doNothing().when(pluginManager).notifyNodeListChanged(argumentChangesMap.capture());
 


### PR DESCRIPTION
## Summary

Fixes #2108.

`PluginService.getHosts()` kept reporting the `weight`, `cpuPercent` and `lagMs` values captured during the last *structural* topology change. On a cluster with stable membership, every load-aware host selector ranked hosts on measurements that never advanced.

### Root cause

`setNodeList()` coupled two independent decisions into one guard:

```java
if (!changes.isEmpty()) {
  this.allHosts = newHosts != null ? newHosts : new ArrayList<>();
  this.pluginManager.notifyNodeListChanged(changes);
}
```

`changes` comes from `compare(HostSpec, HostSpec)`, which inspects hostname, port, role and availability, but not the measured host details. A refresh carrying only new measurements produced an empty change set, so the freshly fetched `HostSpec` list was discarded.

The measured details can only reach `getHosts()` through list replacement: `cpuPercent` and `lagMs` have no setters and the topology utils build new `HostSpec` instances on every query. This is why availability tracked correctly (it is mutated in place) while the measurements did not.

The asymmetry with the caller is the clearest symptom. `refreshHostList()` pre-checks with `Objects.equals`, and `HostSpec.equals` *does* include `weight`, `cpuPercent` and `lagMs`, so a measurement-only delta was recognised as a change at one layer and denied at the next.

Affected selectors: `lowestLoad`, `lowestLoadByCpu`, `lowestLoadByLag`, `highestLoad`, `highestLoadByCpu`, `highestLoadByLag`, `weightedRandom`, and the deprecated `highestWeight`.

### Change

The new host list is now always published; `notifyNodeListChanged()` stays guarded by the change set, so a measurement-only refresh does not signal a node change to the plugins. This avoids sending `NODE_CHANGED` at the topology refresh rate, which would cause cache invalidation and connection churn in the plugins that react to notifications.

`PartialPluginService` carries a copy of `setNodeList()` and receives the same fix.

### Scope

This keeps `getHosts()` as fresh as the last `refreshHostList()` / `forceRefreshHostList()` call on that `PluginService`. It does not add a push from `ClusterTopologyMonitorImpl` to live `PluginService` instances, so a connection that never refreshes still observes the measurements from its last refresh. Read/write splitting refreshes on every switch, and the initial connection strategy refreshes per connection and on each retry, so both reported paths are covered.

## Testing

New unit tests, all of which fail against the unpatched code:

- `PluginServiceImplTests.testSetNodeListMeasuredDetailsChanged` - a measurement-only refresh updates `weight`, `cpuPercent` and `lagMs` and sends no notification.
- `PluginServiceImplTests.testForceRefreshHostListMeasuredDetailsChanged` - same via `forceRefreshHostList`.
- `PluginServiceImplTests.testLoadAwareSelectionUsesRefreshedMeasuredDetails` - `LowestLoadHostSelector.byLag()` stops selecting a reader once its observed lag rises, with membership, roles and availability unchanged.
- `PartialPluginServiceTests` - measurement-only refresh is published, and an identical refresh still sends no notification.

Existing coverage kept: `testSetNodeListAdded`, `testSetNodeListDeleted`, `testSetNodeListChanged` and `testSetNodeListNoChanges` continue to pass, so the notification behaviour is unchanged.

Verified locally: full `:aws-advanced-jdbc-wrapper:test` suite (1361 tests, 0 failures), `checkstyleMain` and `checkstyleTest`. No integration tests were run.
