### PR TITLE
fix: use driver properties for test topology connection

### DIFF
--- a/wrapper/src/test/java/integration/container/ConnectionStringHelper.java
+++ b/wrapper/src/test/java/integration/container/ConnectionStringHelper.java
@@ -237,4 +237,30 @@ public class ConnectionStringHelper {
     properties.setProperty(PropertyDefinition.PLUGINS.name, "");
     return properties;
   }
+
+  /**
+   * Returns the properties needed to open a connection with the target driver directly, i.e. without going through
+   * the wrapper. Only credentials and driver-specific settings are included; wrapper-specific properties are
+   * intentionally omitted since the target driver doesn't recognize them.
+   *
+   * @param userName the user name to connect with.
+   * @param password the password to connect with.
+   * @return the properties to use for a direct target driver connection.
+   */
+  public static Properties getTargetDriverProperties(final String userName, final String password) {
+    final Properties props = new Properties();
+    props.setProperty(PropertyDefinition.USER.name, userName);
+    props.setProperty(PropertyDefinition.PASSWORD.name, password);
+
+    if (TestEnvironment.getCurrent().getCurrentDriver() == TestDriver.MARIADB) {
+      // This property is required when using the mariadb driver against mysql version 8.4 or newer, or you will get
+      // the error "RSA public key is not available client side" when the driver has to run the full
+      // caching_sha2_password exchange, which happens when connecting to a server that hasn't cached the credentials
+      // yet. The mariadb driver may not fully support mysql 8.4's SSL mechanisms, which is why this property is only
+      // required for newer mysql versions.
+      props.setProperty("allowPublicKeyRetrieval", "true");
+    }
+
+    return props;
+  }
 }

--- a/wrapper/src/test/java/integration/util/AuroraTestUtility.java
+++ b/wrapper/src/test/java/integration/util/AuroraTestUtility.java
@@ -1628,7 +1628,13 @@ public class AuroraTestUtility {
 
     ArrayList<String> auroraInstances = new ArrayList<>();
 
-    try (final Connection conn = DriverManager.getConnection(connectionUrl, userName, password);
+    // The connection is opened with the target driver directly, so it needs the driver-specific properties rather
+    // than just the credentials. The mariadb driver in particular requires allowPublicKeyRetrieval when the server
+    // hasn't cached the credentials yet, which is the case for a freshly created instance such as a Blue/Green
+    // deployment's green cluster.
+    final Properties connProps = ConnectionStringHelper.getTargetDriverProperties(userName, password);
+
+    try (final Connection conn = DriverManager.getConnection(connectionUrl, connProps);
         final Statement stmt = conn.createStatement();
         final ResultSet resultSet = stmt.executeQuery(retrieveTopologySql)) {
       while (resultSet.next()) {


### PR DESCRIPTION
## Summary

Fixes the `mysql-aurora-mariadb-driver` job of the "Run Blue/Green Integration Tests Latest" workflow, which has been failing on every scheduled run with a single test failure:

```
BlueGreenDeploymentTests > testSwitchover(TestDriver) - [Driver: MARIADB] FAILED
java.sql.SQLException: RSA public key is not available client side (option serverRsaPublicKeyFile not set)
  at org.mariadb.jdbc.plugin.authentication.standard.CachingSha2PasswordPlugin.process(...)
  at integration.util.AuroraTestUtility.getAuroraInstanceIds(AuroraTestUtility.java:1631)
  at integration.container.tests.BlueGreenDeploymentTests.getBlueGreenEndpoints(BlueGreenDeploymentTests.java:1569)
  at integration.container.tests.BlueGreenDeploymentTests.testSwitchover(BlueGreenDeploymentTests.java:300)
```

Example failing runs: 33835622076, 33717799418, 33589594619, 33468646373, 33233006086. This is a test-infrastructure bug, not a driver bug.

## Root cause

`AuroraTestUtility.getAuroraInstanceIds` opened its topology query connection with the bare overload:

```java
DriverManager.getConnection(connectionUrl, userName, password);
```

That URL is a target driver URL, not a wrapper URL, so the connection is made by the MariaDB driver directly and receives nothing but the credentials. In particular it does not get `allowPublicKeyRetrieval=true`, which `ConnectionStringHelper.getDefaultProperties()` adds for the MariaDB driver.

Three conditions have to line up, which is why only this one job breaks:

- The "latest engine" workflow provisions `aurora-mysql 8.4.mysql_aurora.8.4.8`. MySQL 8.4 authenticates with `caching_sha2_password`.
- The MariaDB driver does not use TLS by default, so a full `caching_sha2_password` exchange needs the server's RSA public key, and the driver refuses to fetch it unless `allowPublicKeyRetrieval=true`. Connector/J defaults to `sslMode=PREFERRED`, so the `mysql-aurora-mysql-driver` job never reaches the RSA path.
- `getBlueGreenEndpoints` calls this against the **green** cluster endpoint. The green cluster is a freshly created server with a cold credential cache, so it requires full auth. The blue cluster survives the same bare call only because earlier wrapper connections (which do carry `allowPublicKeyRetrieval=true`) already warmed its cache, letting fast auth succeed.

Only the `AURORA` branch of `getBlueGreenEndpoints` calls `getAuroraInstanceIds`; the `RDS_MULTI_AZ_INSTANCE` branch returns earlier, which is why `mysql-rds-instance-mariadb-driver` passes.

This is the same class of bug already fixed in `XaFailoverTest`, which carries an explicit comment about switching to the default properties for exactly this reason. `getAuroraInstanceIds` was missed.

## Changes

- Add `ConnectionStringHelper.getTargetDriverProperties(userName, password)`, returning the credentials plus the driver-specific settings needed for a direct target driver connection. Wrapper-only properties are deliberately excluded, since the target driver does not recognize them.
- Use it for the topology connection in `AuroraTestUtility.getAuroraInstanceIds`.

The signature of `getAuroraInstanceIds` is unchanged, so all five call sites benefit. That includes `FailoverTest`, which uses the same overload and currently only passes because it targets an already warmed host.

## Behavior review

Only the connection properties change; the SQL, the topology parsing, the exception types, and the empty-result handling are untouched. For non-MariaDB drivers the resulting properties are equivalent to what `DriverManager.getConnection(url, user, password)` builds internally (`user` and `password`), so those jobs are unaffected. For the MariaDB driver the single added property is `allowPublicKeyRetrieval=true`, which `BasicConnectivityTests.testFailedProperties` already relies on being effective (it explicitly sets it to `false` so that a negative test keeps failing to connect). All call sites pass credentials sourced from the test environment config, so the switch to `Properties.setProperty` does not introduce a null path.

## Testing

- `./gradlew :aws-advanced-jdbc-wrapper:compileTestJava` - passes.
- `./gradlew :aws-advanced-jdbc-wrapper:checkstyleTest` - passes.
- The affected test is an integration test that needs live Aurora resources, so it could not be run locally. Verification requires a run of the Blue/Green latest engine workflow on this branch.
