### PR TITLE
chore: fix Java 17+ integration test classpath and CI IP cleanup

### DIFF
--- a/.github/workflows/run-bg-integration-tests-latest.yml
+++ b/.github/workflows/run-bg-integration-tests-latest.yml
@@ -75,11 +75,25 @@ jobs:
           name: html-summary-report-latest-${{ matrix.testTask }}
           path: ./wrapper/build/report
           retention-days: 5
+      # The test host records the address it whitelisted in the region's default security group (see
+      # TestEnvironment.authorizeIP). Prefer that over asking checkip.amazonaws.com again: a
+      # GitHub-hosted runner's egress address can change during a job, in which case a fresh lookup
+      # revokes a rule that never existed and leaves the real one behind, consuming the group's
+      # 60-rule quota. No recorded address means the test host either never authorized one or has
+      # already revoked it, so there is nothing to clean up.
       - name: Get Github Action IP
         if: always()
         id: ip
-        run: echo "ipv4=$(curl -s https://checkip.amazonaws.com)" >> $GITHUB_OUTPUT
+        run: |
+          ipFile=./wrapper/build/authorized-runner-ip.txt
+          if [ -s "$ipFile" ]; then
+            ipv4=$(tr -d '[:space:]' < "$ipFile")
+            echo "Authorized runner IP recorded by the test host: $ipv4"
+            echo "ipv4=$ipv4" >> $GITHUB_OUTPUT
+          else
+            echo "No authorized runner IP was recorded; nothing to revoke."
+          fi
       - name: Remove Github Action IP
-        if: always()
+        if: always() && steps.ip.outputs.ipv4 != ''
         run: |
           aws ec2 revoke-security-group-ingress --group-name default --protocol all --port 0-65535 --cidr ${{ steps.ip.outputs.ipv4 }}/32

--- a/.github/workflows/run-integration-tests-5-instance-default.yml
+++ b/.github/workflows/run-integration-tests-5-instance-default.yml
@@ -72,12 +72,26 @@ jobs:
           name: html-summary-report-default-5-instance-${{ matrix.dbEngine }}
           path: ./wrapper/build/report
           retention-days: 5
+      # The test host records the address it whitelisted in the region's default security group (see
+      # TestEnvironment.authorizeIP). Prefer that over asking checkip.amazonaws.com again: a
+      # GitHub-hosted runner's egress address can change during a job, in which case a fresh lookup
+      # revokes a rule that never existed and leaves the real one behind, consuming the group's
+      # 60-rule quota. No recorded address means the test host either never authorized one or has
+      # already revoked it, so there is nothing to clean up.
       - name: Get Github Action IP
         if: always()
         id: ip
-        run: echo "ipv4=$(curl -s https://checkip.amazonaws.com)" >> $GITHUB_OUTPUT
+        run: |
+          ipFile=./wrapper/build/authorized-runner-ip.txt
+          if [ -s "$ipFile" ]; then
+            ipv4=$(tr -d '[:space:]' < "$ipFile")
+            echo "Authorized runner IP recorded by the test host: $ipv4"
+            echo "ipv4=$ipv4" >> $GITHUB_OUTPUT
+          else
+            echo "No authorized runner IP was recorded; nothing to revoke."
+          fi
 
       - name: Remove Github Action IP
-        if: always()
+        if: always() && steps.ip.outputs.ipv4 != ''
         run: |
           aws ec2 revoke-security-group-ingress --group-name default --protocol all --port 0-65535 --cidr ${{ steps.ip.outputs.ipv4 }}/32

--- a/.github/workflows/run-integration-tests-5-instance-latest.yml
+++ b/.github/workflows/run-integration-tests-5-instance-latest.yml
@@ -72,12 +72,26 @@ jobs:
           name: html-summary-report-latest-5-instance-${{ matrix.dbEngine }}
           path: ./wrapper/build/report
           retention-days: 5
+      # The test host records the address it whitelisted in the region's default security group (see
+      # TestEnvironment.authorizeIP). Prefer that over asking checkip.amazonaws.com again: a
+      # GitHub-hosted runner's egress address can change during a job, in which case a fresh lookup
+      # revokes a rule that never existed and leaves the real one behind, consuming the group's
+      # 60-rule quota. No recorded address means the test host either never authorized one or has
+      # already revoked it, so there is nothing to clean up.
       - name: Get Github Action IP
         if: always()
         id: ip
-        run: echo "ipv4=$(curl -s https://checkip.amazonaws.com)" >> $GITHUB_OUTPUT
+        run: |
+          ipFile=./wrapper/build/authorized-runner-ip.txt
+          if [ -s "$ipFile" ]; then
+            ipv4=$(tr -d '[:space:]' < "$ipFile")
+            echo "Authorized runner IP recorded by the test host: $ipv4"
+            echo "ipv4=$ipv4" >> $GITHUB_OUTPUT
+          else
+            echo "No authorized runner IP was recorded; nothing to revoke."
+          fi
 
       - name: Remove Github Action IP
-        if: always()
+        if: always() && steps.ip.outputs.ipv4 != ''
         run: |
           aws ec2 revoke-security-group-ingress --group-name default --protocol all --port 0-65535 --cidr ${{ steps.ip.outputs.ipv4 }}/32

--- a/.github/workflows/run-integration-tests-default.yml
+++ b/.github/workflows/run-integration-tests-default.yml
@@ -113,12 +113,26 @@ jobs:
           name: html-summary-report-default-${{ matrix.name }}
           path: ./wrapper/build/report
           retention-days: 5
+      # The test host records the address it whitelisted in the region's default security group (see
+      # TestEnvironment.authorizeIP). Prefer that over asking checkip.amazonaws.com again: a
+      # GitHub-hosted runner's egress address can change during a job, in which case a fresh lookup
+      # revokes a rule that never existed and leaves the real one behind, consuming the group's
+      # 60-rule quota. No recorded address means the test host either never authorized one or has
+      # already revoked it, so there is nothing to clean up.
       - name: Get Github Action IP
         if: always()
         id: ip
-        run: echo "ipv4=$(curl -s https://checkip.amazonaws.com)" >> $GITHUB_OUTPUT
+        run: |
+          ipFile=./wrapper/build/authorized-runner-ip.txt
+          if [ -s "$ipFile" ]; then
+            ipv4=$(tr -d '[:space:]' < "$ipFile")
+            echo "Authorized runner IP recorded by the test host: $ipv4"
+            echo "ipv4=$ipv4" >> $GITHUB_OUTPUT
+          else
+            echo "No authorized runner IP was recorded; nothing to revoke."
+          fi
 
       - name: Remove Github Action IP
-        if: always()
+        if: always() && steps.ip.outputs.ipv4 != ''
         run: |
           aws ec2 revoke-security-group-ingress --group-name default --protocol all --port 0-65535 --cidr ${{ steps.ip.outputs.ipv4 }}/32

--- a/.github/workflows/run-integration-tests-full-matrix-weekly.yml
+++ b/.github/workflows/run-integration-tests-full-matrix-weekly.yml
@@ -92,12 +92,26 @@ jobs:
           name: html-summary-report-weekly-2inst-${{ matrix.dbEngine }}
           path: ./wrapper/build/report
           retention-days: 5
+      # The test host records the address it whitelisted in the region's default security group (see
+      # TestEnvironment.authorizeIP). Prefer that over asking checkip.amazonaws.com again: a
+      # GitHub-hosted runner's egress address can change during a job, in which case a fresh lookup
+      # revokes a rule that never existed and leaves the real one behind, consuming the group's
+      # 60-rule quota. No recorded address means the test host either never authorized one or has
+      # already revoked it, so there is nothing to clean up.
       - name: Get Github Action IP
         if: always()
         id: ip
-        run: echo "ipv4=$(curl -s https://checkip.amazonaws.com)" >> $GITHUB_OUTPUT
+        run: |
+          ipFile=./wrapper/build/authorized-runner-ip.txt
+          if [ -s "$ipFile" ]; then
+            ipv4=$(tr -d '[:space:]' < "$ipFile")
+            echo "Authorized runner IP recorded by the test host: $ipv4"
+            echo "ipv4=$ipv4" >> $GITHUB_OUTPUT
+          else
+            echo "No authorized runner IP was recorded; nothing to revoke."
+          fi
 
       - name: Remove Github Action IP
-        if: always()
+        if: always() && steps.ip.outputs.ipv4 != ''
         run: |
           aws ec2 revoke-security-group-ingress --group-name default --protocol all --port 0-65535 --cidr ${{ steps.ip.outputs.ipv4 }}/32

--- a/.github/workflows/run-integration-tests-latest.yml
+++ b/.github/workflows/run-integration-tests-latest.yml
@@ -124,12 +124,26 @@ jobs:
           name: html-summary-report-latest-${{ matrix.name }}
           path: ./wrapper/build/report
           retention-days: 5
+      # The test host records the address it whitelisted in the region's default security group (see
+      # TestEnvironment.authorizeIP). Prefer that over asking checkip.amazonaws.com again: a
+      # GitHub-hosted runner's egress address can change during a job, in which case a fresh lookup
+      # revokes a rule that never existed and leaves the real one behind, consuming the group's
+      # 60-rule quota. No recorded address means the test host either never authorized one or has
+      # already revoked it, so there is nothing to clean up.
       - name: Get Github Action IP
         if: always()
         id: ip
-        run: echo "ipv4=$(curl -s https://checkip.amazonaws.com)" >> $GITHUB_OUTPUT
+        run: |
+          ipFile=./wrapper/build/authorized-runner-ip.txt
+          if [ -s "$ipFile" ]; then
+            ipv4=$(tr -d '[:space:]' < "$ipFile")
+            echo "Authorized runner IP recorded by the test host: $ipv4"
+            echo "ipv4=$ipv4" >> $GITHUB_OUTPUT
+          else
+            echo "No authorized runner IP was recorded; nothing to revoke."
+          fi
 
       - name: Remove Github Action IP
-        if: always()
+        if: always() && steps.ip.outputs.ipv4 != ''
         run: |
           aws ec2 revoke-security-group-ingress --group-name default --protocol all --port 0-65535 --cidr ${{ steps.ip.outputs.ipv4 }}/32

--- a/.github/workflows/run-integration-tests-mysql-aurora-java-lts.yml
+++ b/.github/workflows/run-integration-tests-mysql-aurora-java-lts.yml
@@ -22,12 +22,34 @@ concurrency:
 
 jobs:
   all-mysql-integration-tests-java-lts:
-    name: Run integration tests with MySQL Aurora latest version
+    name: 'Java ${{ matrix.javaVersion }} / ${{ matrix.group.name }}'
     runs-on: ubuntu-latest
+    # A GitHub-hosted job is hard-killed at 6 hours and the assumed role below expires at the same
+    # point, so a job that gets anywhere near that limit starts failing with "The security token
+    # included in the request is expired" mid-test instead of reporting real results. That is what
+    # happened to the unsplit Java 24 job in run 33759811109 (13:13 -> 19:13). Each matrix entry
+    # below covers a subset of the environments and is expected to finish in about 2-2.5 hours; the
+    # timeout fails a stuck job cleanly while the credentials are still valid.
+    timeout-minutes: 330
     strategy:
       fail-fast: false
       matrix:
         javaVersion: [ "8", "11", "17", "21", "24" ]
+        # Each entry pins itself to a subset of the environments that test-all-mysql-aurora-java*
+        # would otherwise run one after another in a single job. None of these `test-no-*`
+        # properties are set by the gradle task itself, so the command line wins.
+        #
+        # The split is by environment rather than by test class shard because the environments
+        # themselves are the expensive part: in run 33759811109 the two 3-instance Aurora
+        # environments took ~105 min each while all four RDS Multi-AZ environments together took
+        # ~2 hours. Splitting Aurora MySQL from Aurora PG keeps the three entries roughly even.
+        group:
+          - name: aurora-mysql
+            envArgs: '-Dtest-no-multi-az-cluster=true -Dtest-no-multi-az-instance=true -Dtest-no-pg-driver=true -Dtest-no-pg-engine=true'
+          - name: aurora-pg
+            envArgs: '-Dtest-no-multi-az-cluster=true -Dtest-no-multi-az-instance=true -Dtest-no-mysql-driver=true -Dtest-no-mysql-engine=true'
+          - name: multi-az
+            envArgs: '-Dtest-no-aurora=true'
     steps:
       - name: 'Clone repository'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -49,7 +71,8 @@ jobs:
           output-credentials: true
       - name: Run MySQL Aurora integration tests
         run: |
-          ./gradlew --no-parallel --no-daemon test-all-mysql-aurora-java${{ matrix.javaVersion }}
+          ./gradlew --no-parallel --no-daemon test-all-mysql-aurora-java${{ matrix.javaVersion }} \
+            ${{ matrix.group.envArgs }}
         env:
           AURORA_CLUSTER_DOMAIN: ${{ secrets.DB_CONN_SUFFIX }}
           RDS_DB_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
@@ -65,21 +88,35 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: junit-report-java${{ matrix.javaVersion }}-latest
+          name: junit-report-java${{ matrix.javaVersion }}-${{ matrix.group.name }}-latest
           path: ./wrapper/build/test-results
           retention-days: 5
       - name: Archive html summary report for Java${{ matrix.javaVersion }} latest
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: html-summary-report-java${{ matrix.javaVersion }}-latest
+          name: html-summary-report-java${{ matrix.javaVersion }}-${{ matrix.group.name }}-latest
           path: ./wrapper/build/report
           retention-days: 5
+      # The test host records the address it whitelisted in the region's default security group (see
+      # TestEnvironment.authorizeIP). Prefer that over asking checkip.amazonaws.com again: a
+      # GitHub-hosted runner's egress address can change during a job, in which case a fresh lookup
+      # revokes a rule that never existed and leaves the real one behind, consuming the group's
+      # 60-rule quota. No recorded address means the test host either never authorized one or has
+      # already revoked it, so there is nothing to clean up.
       - name: Get Github Action IP
         if: always()
         id: ip
-        run: echo "ipv4=$(curl -s https://checkip.amazonaws.com)" >> $GITHUB_OUTPUT
+        run: |
+          ipFile=./wrapper/build/authorized-runner-ip.txt
+          if [ -s "$ipFile" ]; then
+            ipv4=$(tr -d '[:space:]' < "$ipFile")
+            echo "Authorized runner IP recorded by the test host: $ipv4"
+            echo "ipv4=$ipv4" >> $GITHUB_OUTPUT
+          else
+            echo "No authorized runner IP was recorded; nothing to revoke."
+          fi
       - name: Remove Github Action IP
-        if: always()
+        if: always() && steps.ip.outputs.ipv4 != ''
         run: |
           aws ec2 revoke-security-group-ingress --group-name default --protocol all --port 0-65535 --cidr ${{ steps.ip.outputs.ipv4 }}/32

--- a/.github/workflows/run-integration-tests-mysql-aurora-java-lts.yml
+++ b/.github/workflows/run-integration-tests-mysql-aurora-java-lts.yml
@@ -3,8 +3,13 @@ name: Run Integration Tests Latest against Java LTS versions
 on:
   workflow_dispatch:
   schedule:
-    # Every working day (Mon-Fri) at 5:00 AM PST (13:00 UTC), ~4.5 hours after "latest"
-    - cron: '0 13 * * 2-6'
+    # Every working day (Mon-Fri) at 8:00 PM PST (4:00 AM UTC next day).
+    #
+    # This used to start at 5:00 AM PST, which meant it held the shared rds-integration-tests
+    # concurrency group through the morning and queued anything dispatched for a PR behind it.
+    # Starting in the evening keeps the run overnight. Note that "default" and "bg-latest" are
+    # scheduled at the same minute, so the three take the group in turn rather than in parallel.
+    - cron: '0 4 * * 2-6'
 
 permissions:
   id-token: write   # This is required for requesting the JWT

--- a/.github/workflows/test-encryption-e2e.yml
+++ b/.github/workflows/test-encryption-e2e.yml
@@ -185,13 +185,26 @@ jobs:
             wrapper/build/test-results/
           retention-days: 7
 
+      # The test host records the address it whitelisted in the region's default security group (see
+      # TestEnvironment.authorizeIP). Prefer that over asking checkip.amazonaws.com again: a
+      # GitHub-hosted runner's egress address can change during a job, in which case a fresh lookup
+      # revokes a rule that never existed and leaves the real one behind, consuming the group's
+      # 60-rule quota. No recorded address means the test host either never authorized one or has
+      # already revoked it, so there is nothing to clean up.
       - name: Get Github Action IP
         if: always()
         id: ip
         run: |
-          echo "ipv4=$(curl -s https://checkip.amazonaws.com)" >> $GITHUB_OUTPUT
+          ipFile=./wrapper/build/authorized-runner-ip.txt
+          if [ -s "$ipFile" ]; then
+            ipv4=$(tr -d '[:space:]' < "$ipFile")
+            echo "Authorized runner IP recorded by the test host: $ipv4"
+            echo "ipv4=$ipv4" >> $GITHUB_OUTPUT
+          else
+            echo "No authorized runner IP was recorded; nothing to revoke."
+          fi
 
       - name: Remove Github Action IP
-        if: always()
+        if: always() && steps.ip.outputs.ipv4 != ''
         run: |
           aws ec2 revoke-security-group-ingress --group-name default --protocol all --port 0-65535 --cidr ${{ steps.ip.outputs.ipv4 }}/32

--- a/wrapper/src/test/build.gradle.kts
+++ b/wrapper/src/test/build.gradle.kts
@@ -56,6 +56,14 @@ dependencies {
     testImplementation("org.apache.poi:poi-ooxml:5.3.0")
     testImplementation("org.slf4j:slf4j-simple:2.0.13")
     testImplementation("com.fasterxml.jackson.core:jackson-databind:2.17.1")
+    // Required by the java17 multi-release classes in the wrapper jar (for example the Jackson 3
+    // based AwsSecretsManagerConnectionPlugin under META-INF/versions/17). A Java 17+ container
+    // loads those classes instead of the Jackson 2 ones from the base directory, so without this
+    // entry any test touching them fails with
+    // NoClassDefFoundError: tools/jackson/core/JacksonException.
+    // Must match the host build file (wrapper/build.gradle.kts). Harmless on the Java 8 container:
+    // that JVM ignores META-INF/versions, so the jar is only an unused classpath entry there.
+    testImplementation("tools.jackson.core:jackson-databind:3.2.2")
     testImplementation("com.amazonaws:aws-xray-recorder-sdk-core:2.18.2")
     testImplementation("io.opentelemetry:opentelemetry-sdk:1.42.1")
     testImplementation("io.opentelemetry:opentelemetry-sdk-metrics:1.43.0")

--- a/wrapper/src/test/java/integration/host/TestEnvironment.java
+++ b/wrapper/src/test/java/integration/host/TestEnvironment.java
@@ -34,8 +34,11 @@ import integration.TestTelemetryInfo;
 import integration.host.TestEnvironmentProvider.EnvPreCreateInfo;
 import integration.util.AuroraTestUtility;
 import integration.util.ContainerHelper;
+import java.io.File;
 import java.io.IOException;
 import java.net.UnknownHostException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -83,6 +86,15 @@ public class TestEnvironment implements AutoCloseable {
   private static final boolean USE_OTLP_CONTAINER_FOR_TRACES = true;
 
   private static final AtomicInteger ipAddressUsageRefCount = new AtomicInteger(0);
+
+  // Where the IP address that has been whitelisted in the default security group is recorded, so
+  // that an external cleanup step (the "Remove Github Action IP" step in the CI workflows) can
+  // revoke exactly that rule when this process is killed before it de-authorizes the IP itself.
+  // Resolving the address again later is not reliable: a GitHub-hosted runner's egress address can
+  // change during a job, which leaves the real rule behind and revokes one that never existed.
+  // The path is relative to the host test task's working directory, i.e. it resolves to
+  // wrapper/build/authorized-runner-ip.txt.
+  private static final String AUTHORIZED_IP_FILE = "./build/authorized-runner-ip.txt";
 
   private final TestEnvironmentInfo info =
       new TestEnvironmentInfo(); // only this info is passed to test container
@@ -1020,6 +1032,10 @@ public class TestEnvironment implements AutoCloseable {
     } catch (UnknownHostException e) {
       throw new RuntimeException(e);
     }
+    // Recorded before the rule is created rather than after, so that being killed in between can
+    // never leave a rule that nothing knows how to clean up. The opposite order is harmless: the
+    // cleanup step then revokes a rule that does not exist, which EC2 reports and ignores.
+    recordAuthorizedIp(env.runnerIP);
     env.auroraUtil.ec2AuthorizeIP(env.runnerIP);
     LOGGER.finest(String.format("Test runner IP %s authorized. Usage count: %d",
         env.runnerIP, ipAddressUsageRefCount.get()));
@@ -1027,6 +1043,12 @@ public class TestEnvironment implements AutoCloseable {
 
   private static void deAuthorizeIP(TestEnvironment env) {
     if (ipAddressUsageRefCount.decrementAndGet() == 0) {
+      if (env.runnerIP == null) {
+        // Only the environment that performed the authorization holds the address, so prefer the
+        // recorded one over asking checkip.amazonaws.com again: a second lookup can return a
+        // different address and would then revoke a rule that was never created.
+        env.runnerIP = readAuthorizedIp();
+      }
       if (env.runnerIP == null) {
         try {
           env.runnerIP = env.auroraUtil.getPublicIPAddress();
@@ -1043,8 +1065,66 @@ public class TestEnvironment implements AutoCloseable {
         LOGGER.finest("The IP address usage count hit 0, but the REUSE_RDS_DB was set to true, so IP "
             + "de-authorization was skipped.");
       }
+
+      // The ingress rule is no longer the external cleanup step's responsibility: it has either
+      // just been revoked, or REUSE_RDS_DB asked for it to be kept on purpose.
+      discardAuthorizedIpRecord();
     } else {
       LOGGER.finest("IP usage count: " + ipAddressUsageRefCount.get());
+    }
+  }
+
+  /**
+   * Stores the whitelisted IP address where an external cleanup step can find it. A failure to
+   * store it must not fail the test run: the rule is still de-authorized by {@link #deAuthorizeIP}
+   * on a clean shutdown, and {@code AuroraTestUtility.securityGroupRulesCleanUp} sweeps rules that
+   * outlive their run.
+   *
+   * @param ipAddress the IP address that has been added to the default security group
+   */
+  private static void recordAuthorizedIp(String ipAddress) {
+    try {
+      final File file = new File(AUTHORIZED_IP_FILE);
+      final File parentDir = file.getParentFile();
+      if (parentDir != null) {
+        parentDir.mkdirs();
+      }
+      Files.write(file.toPath(), (ipAddress + "\n").getBytes(StandardCharsets.UTF_8));
+    } catch (Exception ex) {
+      LOGGER.warning(
+          "Unable to record the authorized test runner IP in " + AUTHORIZED_IP_FILE + ": " + ex.getMessage());
+    }
+  }
+
+  /**
+   * Reads back the address stored by {@link #recordAuthorizedIp}.
+   *
+   * @return the recorded IP address, or null if nothing was recorded or it could not be read
+   */
+  private static String readAuthorizedIp() {
+    try {
+      final File file = new File(AUTHORIZED_IP_FILE);
+      if (!file.exists()) {
+        return null;
+      }
+      final String recordedIp =
+          new String(Files.readAllBytes(file.toPath()), StandardCharsets.UTF_8).trim();
+      return StringUtils.isNullOrEmpty(recordedIp) ? null : recordedIp;
+    } catch (Exception ex) {
+      LOGGER.warning("Unable to read " + AUTHORIZED_IP_FILE + ": " + ex.getMessage());
+      return null;
+    }
+  }
+
+  /**
+   * Discards the record written by {@link #recordAuthorizedIp} so that the external cleanup step
+   * does not try to revoke a rule that is already gone, or one that is deliberately being kept.
+   */
+  private static void discardAuthorizedIpRecord() {
+    try {
+      Files.deleteIfExists(new File(AUTHORIZED_IP_FILE).toPath());
+    } catch (Exception ex) {
+      LOGGER.warning("Unable to delete " + AUTHORIZED_IP_FILE + ": " + ex.getMessage());
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes three independent CI problems found while investigating [run 33759811109](https://github.com/aws/aws-advanced-jdbc-wrapper/actions/runs/33759811109) of "Run Integration Tests Latest against Java LTS versions" (Java 8 passed, Java 11/17/21 failed, Java 24 was cancelled at the 6h mark).

### 1. Jackson 3 was missing from the in-container test classpath

Every `AwsSecretsManager2IntegrationTest` case failed on Java 17, 21 and 24 with:

```
java.lang.NoClassDefFoundError: tools/jackson/core/JacksonException
	at integration.container.tests.AwsSecretsManager2IntegrationTest.beforeEach(AwsSecretsManager2IntegrationTest.java:136)
```

That is 40 failures per job, 120 for the run, and it has been happening on every run of this workflow since `AwsSecretsManager2IntegrationTest` was added (confirmed in the Sep 2 run as well). Java 8 stayed green.

`beforeEach` calls the static `AwsSecretsManagerConnectionPlugin2.clearCache()`, which forces the superclass to load. The wrapper jar is a multi-release jar, so on Java 17+ that resolves to `META-INF/versions/17`, the Jackson 3 variant in `wrapper/src/main/java17`. Its static `ObjectMapper` field and the `catch (SecretsManagerException | JacksonException)` multi-catch need `tools.jackson.*`, and the in-container gradle project (`wrapper/src/test/build.gradle.kts`) declared Jackson 2 only. Java 8 ignores `META-INF/versions` and loaded the Jackson 2 base class, which is why the gap stayed invisible there.

The host build got the matching `testImplementation` entry when Jackson 3 support landed; the container build file did not. This adds it. It resolves on the Java 8 container too (`jackson-databind-3.2.2.module` publishes no `org.gradle.jvm.version` attribute) and is simply an unused classpath entry there, since nothing loads `tools.jackson.*` under Java 8.

### 2. The workflow cleanup step revoked the wrong security group rule

`Get Github Action IP` re-queried `checkip.amazonaws.com` after the tests, but a GitHub-hosted runner's egress address can change during a job. In the Java 11 job:

```
13:15:58  TestEnvironment authorizeIP : Test runner IP: 145.132.102.177 ... authorized
14:31:08  aws ec2 revoke-security-group-ingress ... --cidr 145.132.102.178/32
14:31:12      "UnknownIpPermissions": [
```

Two consequences: the `.177` rule leaked into the region's `default` security group (60 inbound rules per group, and this workflow family already budgets 20), and no connection from the runner was permitted, so all eight environments failed to provision with `SocketTimeoutException: connect timed out`. No test ran in that job at all.

`TestEnvironment` now records the address it whitelisted in `wrapper/build/authorized-runner-ip.txt`, and deletes the record once the rule has been revoked or deliberately retained (`REUSE_RDS_DB`). The eight workflows that clean up the rule read that file and skip the revoke when nothing is recorded.

`deAuthorizeIP` also prefers the recorded address over a second `checkip` lookup. That fixes the same wrong-address problem inside the test host: only the environment that performed the authorization holds `runnerIP`, so the environment that closes last usually had to re-resolve it and could revoke an address that was never authorized.

Recording happens *before* the AWS call so an interrupted run can never leave a rule that nothing knows about. The opposite order is harmless: the cleanup step then revokes a rule that does not exist, which is exactly what the step already did on every non-RDS run.

### 3. The Java LTS job ran into the 6 hour ceiling

A GitHub-hosted job is hard-killed at 6 hours and `role-duration-seconds: 21600` expires at the same point. The Java 24 job ran 13:13 to 19:13 and started failing with `The security token included in the request is expired` (3 XA and IAM tests) before being cancelled; its final cleanup step failed too.

Each Java version now splits into three jobs by environment group (`aurora-mysql`, `aurora-pg`, `multi-az`) instead of running all eight environments back to back, and gets a `timeout-minutes` ceiling that fails a stuck job while its credentials are still valid.

The split is by environment rather than by test-class shard because provisioning dominates the runtime. Measured in this run's Java 24 log:

| Environment | Elapsed |
| --- | --- |
| RDS Multi-AZ cluster, MySQL | 49 min |
| RDS Multi-AZ cluster, PG | 52 min |
| RDS Multi-AZ instance (both engines) | ~22 min |
| Aurora MySQL, 3 instances | 105 min |
| Aurora PG, 3 instances | 107 min |

Sharding test classes would have duplicated all eight provisioning cycles per shard; splitting Aurora MySQL from Aurora PG keeps the three groups at roughly 2 to 2.5 hours each. Concurrency goes from 5 to 15 jobs, which raises peak usage to about 15 inbound security group rules and roughly 30 clusters, within the observed quotas (60 rules, 60 clusters, 300 instances) and still serialized against the other workflows by the shared `rds-integration-tests` concurrency group.

The schedule also moves from 5:00 AM PST to 8:00 PM PST (13:00 UTC to 4:00 AM UTC next day). Starting in the morning meant the suite held the shared `rds-integration-tests` concurrency group through the working day, so anything dispatched for a PR queued behind it. This puts it in the same slot as the `default` and `bg-latest` suites, which already share that minute; they take the group in turn, which is what `queue: max` is there for.

## Not addressed here

- Two `XaFailoverTest` cases failed on Java 24 / RDS Multi-AZ cluster PG with `Expected XaFailoverNotSupportedSQLException to be thrown, but nothing was thrown`. The same two tests on the same environment passed on Java 8, 17 and 21 in this run, so the induced toxiproxy outage most likely did not land. Left as a flake to monitor.
- The `AwsSecretsManagerConnectionPlugin.jacksonDatabindNotInClasspath` guard is a `Class.forName` check inside the constructor, so class verification and static initialization always fail first and users on Java 17+ without Jackson 3 get a raw `NoClassDefFoundError` instead of the intended message. Fixing that means restructuring the java17 plugin to keep `JacksonException` out of verified signatures, which is a separate change.

## Testing

- `./gradlew :aws-advanced-jdbc-wrapper:compileTestJava :aws-advanced-jdbc-wrapper:checkstyleTest` passes.
- All workflow files parse as YAML.
- The new `Get Github Action IP` shell step was exercised against a missing record file, an empty one, one holding an address, and one padded with whitespace and CRLF; it only sets the output when a non-empty address is present.
- The integration suites themselves have to run in CI to confirm the Jackson fix, since they need real RDS clusters.

## Regression review

- `deAuthorizeIP`: the `refCount == 0` guard is unchanged, and the new record cleanup sits inside it. The `getPublicIPAddress` fallback and its `UnknownHostException` to `RuntimeException` wrapping are preserved for the case where no address was recorded; they simply run less often.
- Both existing `LOGGER.finest` calls still fire on the same paths, once each. The new helpers swallow all exceptions and only log warnings, so they add no failure modes to the test run.
- The `REUSE_RDS_DB` branch still skips de-authorization; the record is dropped there too so the workflow does not revoke a rule that is being kept on purpose.
- Workflow behavior when nothing was authorized changes from "revoke a bogus rule and log `UnknownIpPermissions`" to "skip", which is the same net effect.
