### PR TITLE
fix: raise in-container test heap to avoid MariaDB Blue/Green OOM

### DIFF
--- a/wrapper/src/test/build.gradle.kts
+++ b/wrapper/src/test/build.gradle.kts
@@ -287,6 +287,16 @@ fun selectShard(classNames: List<String>, shardIndex: Int, shardCount: Int): Lis
 tasks.register<Test>("in-container") {
     filter.excludeTestsMatching("software.*") // exclude unit tests
 
+    // Give the forked test JVM an explicit, generous heap instead of relying on the container's
+    // default (~25% of container RAM under UseContainerSupport). The MariaDB driver rebuilds its
+    // TLS trust manager by re-parsing the full RDS CA bundle (org.mariadb.jdbc DefaultTlsSocketPlugin
+    // -> X509Factory.engineGenerateCertificates) on EVERY new SSL connection. The Blue/Green
+    // switchover test opens connections in tight loops across ~30 monitoring threads, so those
+    // per-connection certificate allocations pile up faster than GC reclaims them and the default
+    // heap is exhausted with OutOfMemoryError - which the MariaDB driver surfaces as a SQLException
+    // and the test then counts as an unsuccessful post-switchover execution. See CI run 34560981447.
+    maxHeapSize = "2g"
+
     val shardIndex = (System.getProperty("test-shard-index") ?: "1").toInt()
     val shardCount = (System.getProperty("test-shard-count") ?: "1").toInt()
 


### PR DESCRIPTION
## Summary

The scheduled "Run Blue/Green Integration Tests Latest" workflow
([run 34560981447](https://github.com/aws/aws-advanced-jdbc-wrapper/actions/runs/34560981447))
failed only on the two MariaDB-driver jobs (`mysql-rds-instance-mariadb-driver` and
`mysql-aurora-mariadb-driver`). Both failed in `BlueGreenDeploymentTests.testSwitchover` with:

```
org.opentest4j.AssertionFailedError: Found N unsuccessful wrapper executions after switchover completed. ==> expected: <0> but was: <N>
```

The mysql-connector-j and pgjdbc variants of the same test passed.

## Root cause

This is not a Blue/Green routing regression. Every "unsuccessful execution" the test counted was
logged as `java.lang.OutOfMemoryError: Java heap space`.

The OOM stack trace points at the MariaDB driver's TLS setup:

```
org.mariadb.jdbc.plugin.tls.main.DefaultTlsSocketPlugin.getTrustManager
  -> java.security.cert.CertificateFactory.generateCertificates
  -> sun.security.provider.X509Factory.engineGenerateCertificates  (OOM here)
at org.mariadb.jdbc.client.impl.StandardClient.<init>
```

The MariaDB driver rebuilds its trust manager by re-parsing the full RDS CA bundle on every new
SSL connection. `testSwitchover` opens connections in tight loops across ~30 background monitoring
threads, so those per-connection certificate allocations pile up faster than GC reclaims them and
the forked test JVM's default heap is exhausted. The driver surfaces the OOM as a `SQLException`,
which the test's post-switchover execution monitor records as a failed execution, tripping the
assertion. The other drivers do not re-parse a trust manager per connection, so they stay under
the same default heap ceiling.

## Change

Set an explicit `maxHeapSize = "2g"` on the `in-container` Gradle test task
(`wrapper/src/test/build.gradle.kts`). The in-container test worker previously ran on the
container default (roughly 25% of container RAM under `UseContainerSupport`), which is not enough
headroom for the MariaDB connection churn in this test. The heap bump applies to all in-container
integration runs and is harmless for the drivers that already passed.

## Testing

- Verified the failure signature in the CI logs for both failing jobs: all counted unsuccessful
  executions were `OutOfMemoryError`, and the OOM originates in the MariaDB driver's per-connection
  X.509 trust-manager construction.
- Build-config-only change; no product code touched. Requires a Blue/Green integration run on the
  MariaDB driver to confirm the OOM no longer occurs.
